### PR TITLE
Random fixes/changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,17 @@ You can also find instructions here in [README.release.md](./post_build/README.r
   ```
 * Python 3.10 or above
    ```shell
+   sudo apt update -y
+   sudo apt install -y software-properties-common
    sudo add-apt-repository ppa:deadsnakes/ppa -y
    sudo apt update -y
-   sudo apt install python3.10 -y
+   sudo apt install -y "python3.12"
+   sudo apt install -y "python3.12-dev"
+   sudo apt install -y "python3.12-venv"
+   sudo apt install -y python3-dev
    
    # make sure it works
-   python3.10 --version
+   python3.12 --version
    ```
 
 ### **Building dependencies**
@@ -291,7 +296,7 @@ Open bash terminal then:
    You might need to edit this script to use a different python version.  
    Find this line and change it:
    ```shell
-   python_package="python3.10"
+   python_package="python3.12"
    ``` 
 2. Build the tool using `pyinstaller`  
    ```shell

--- a/build_linux_premake.sh
+++ b/build_linux_premake.sh
@@ -35,7 +35,7 @@ chmod 777 "$premake_exe"
 # build deps
 if [[ $BUILD_DEPS = 1 ]]; then
   export CMAKE_GENERATOR="Unix Makefiles"
-  "$premake_exe" --file="premake5-deps.lua" --all-ext --all-build --64-build --32-build --verbose --clean --os=linux gmake2 || {
+  "$premake_exe" --file="premake5-deps.lua" --all-ext --all-build --64-build --32-build --verbose --clean --j=$build_threads --os=linux gmake2 || {
     exit 1;
   }
 fi

--- a/tools/steamclient_loader/win/ColdClientLoader.cpp
+++ b/tools/steamclient_loader/win/ColdClientLoader.cpp
@@ -91,7 +91,7 @@ static std::vector<std::string> collect_dlls_to_inject(const bool is_exe_32, std
     const auto load_order_file = std::filesystem::u8path(DllsToInjectFolder) / "load_order.txt";
     std::vector<std::string> dlls_to_inject{};
     for (const auto &dir_entry :
-        std::filesystem::recursive_directory_iterator(DllsToInjectFolder, std::filesystem::directory_options::follow_directory_symlink)
+        std::filesystem::recursive_directory_iterator(std::filesystem::u8path(DllsToInjectFolder), std::filesystem::directory_options::follow_directory_symlink)
     ) {
         if (std::filesystem::is_directory(dir_entry.path())) continue;
 
@@ -582,15 +582,19 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
         return 1;
     }
 
-    if (!patch_registry_hklm()) {
-        cleanup_registry_hkcu();
-        MessageBoxA(NULL, "Unable to patch Registry (HKLM).", "ColdClientLoader", MB_ICONERROR);
-        return 1;
-    }
+    // this fails due to admin rights when Steam isn't installed, not a big deal
+    // ----------------------------------------------
+    patch_registry_hklm();
+    // if (!patch_registry_hklm()) {
+    //     cleanup_registry_hkcu();
+    //     cleanup_registry_hklm();
+    //     MessageBoxA(NULL, "Unable to patch Registry (HKLM).", "ColdClientLoader", MB_ICONERROR);
+    //     return 1;
+    // }
 
-    patch_registry_hkcs();
     // this fails due to admin rights, not a big deal
     // ----------------------------------------------
+    patch_registry_hkcs();
     // if (!patch_registry_hkcs()) {
     //     cleanup_registry_hkcu();
     //     cleanup_registry_hklm();


### PR DESCRIPTION
* ColdClientLoader for Windows: don't fail and close the loader if patching the registery key `HKLM` failed, this key exists only if Steam was installed
* ColdClientLoader for Windows: fix another utf-8 path handling when searching for dlls to inject
* build deps with limited thread count, fixes WSL compilation
* update readme for python