### PR TITLE
Allow disabling the internal functionality which reports an achievement progress for stats that are tied to achievements

### DIFF
--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -247,6 +247,9 @@ public:
     // allow stats not defined by the user?
     bool allow_unknown_stats = false;
 
+    // whether to enable the functionality which reports an achievement progress for stats that are tied to achievements
+    // only used internally for a stat that's tied to an achievement, the normal achievement progress requests made by the game are not impacted
+    bool stat_achievement_progress_functionality = true;
     // when a stat that's tied to an achievement gets a new value, should the emu save that progress only if it's higher?
     // the stat itself is always saved regardless of that flag, only affects the achievement progress
     bool save_only_higher_stat_achievement_progress = true;

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -1370,6 +1370,9 @@ static void parse_simple_features(class Settings *settings_client, class Setting
     settings_client->allow_unknown_stats = ini.GetBoolValue("main::general", "allow_unknown_stats", settings_client->allow_unknown_stats);
     settings_server->allow_unknown_stats = ini.GetBoolValue("main::general", "allow_unknown_stats", settings_server->allow_unknown_stats);
 
+    settings_client->stat_achievement_progress_functionality = ini.GetBoolValue("main::general", "stat_achievement_progress_functionality", settings_client->stat_achievement_progress_functionality);
+    settings_server->stat_achievement_progress_functionality = ini.GetBoolValue("main::general", "stat_achievement_progress_functionality", settings_server->stat_achievement_progress_functionality);
+
     settings_client->save_only_higher_stat_achievement_progress = ini.GetBoolValue("main::general", "save_only_higher_stat_achievement_progress", settings_client->save_only_higher_stat_achievement_progress);
     settings_server->save_only_higher_stat_achievement_progress = ini.GetBoolValue("main::general", "save_only_higher_stat_achievement_progress", settings_server->save_only_higher_stat_achievement_progress);
 

--- a/dll/steam_user_stats.cpp
+++ b/dll/steam_user_stats.cpp
@@ -465,7 +465,7 @@ Steam_User_Stats::InternalSetResult<int32> Steam_User_Stats::set_stat_internal( 
             if (t.should_unlock_ach(nData)) {
                 set_achievement_internal(t.name.c_str());
             }
-            if (t.should_indicate_progress(nData)) {
+            if (settings->stat_achievement_progress_functionality && t.should_indicate_progress(nData)) {
                 bool indicate_progress = true;
                 // appid 1482380 needs that otherwise it will spam progress indications while driving
                 if (settings->save_only_higher_stat_achievement_progress) {
@@ -539,7 +539,7 @@ Steam_User_Stats::InternalSetResult<std::pair<GameServerStats_Messages::StatInfo
             if (t.should_unlock_ach(fData)) {
                 set_achievement_internal(t.name.c_str());
             }
-            if (t.should_indicate_progress(fData)) {
+            if (settings->stat_achievement_progress_functionality && t.should_indicate_progress(fData)) {
                 bool indicate_progress = true;
                 // appid 1482380 needs that otherwise it will spam progress indications while driving
                 if (settings->save_only_higher_stat_achievement_progress) {

--- a/post_build/steam_settings.EXAMPLE/configs.main.EXAMPLE.ini
+++ b/post_build/steam_settings.EXAMPLE/configs.main.EXAMPLE.ini
@@ -18,6 +18,14 @@ disable_leaderboards_create_unknown=0
 # set this to 1 to allow unknown stats
 # default=0
 allow_unknown_stats=0
+# the emu has an internal extra functionality which reports an achievement progress when a stat that's tied to an ahcievement is updated
+# also the progress is saved to disk (usual local storage folder for the current appid) so that external applications can watch these updates
+# 1=enable this functionality
+# only used internally for a stat that's tied to an achievement, the normal achievement progress requests made by the game are not impacted
+# some applications tie many stats to achievements, and update these stats very frequently, causing a spam of disk writes and overlay popups
+# in that case you can disable this functionality (set the value to 0), but the stat progress won't be saved or displayed in the overlay
+# default=1
+stat_achievement_progress_functionality=1
 # whenever a game updates a stat which is tied to an achievement progress, the emu will save that progress immediately
 # but some games will update the stat very frequently (with lower & higher values) resulting in a spam of disk writes or overlay notifications
 # set this to 0 to save any stat achievement progress value (higher or lower) 


### PR DESCRIPTION
Many Source-based games spam updates for stats values, which happen to be tied to an achievement.
While the progress notification in the overlay itself can be disabled, the useless disk write operations are still happening, moreover external applications like Achievement Watcher will also spam toast notifications since they watch for folder/files updates.

This adds an option to allow disabling this functionality from the ini.