### PR TITLE
Allow saving stats from `ISteamGameStats` to .csv files

### DIFF
--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -295,6 +295,9 @@ public:
     // synchronize user stats/achievements with game servers as soon as possible instead of caching them.
     bool immediate_gameserver_stats = false;
 
+    // steam_game_stats
+    std::string steam_game_stats_reports_dir{};
+
     //overlay
     bool disable_overlay = true;
     int overlay_hook_delay_sec = 0; // "Saints Row (2022)" needs a lot of time to initialize, otherwise detection will fail

--- a/dll/dll/steam_gamestats.h
+++ b/dll/dll/steam_gamestats.h
@@ -64,11 +64,14 @@ private:
 
   struct Session_t
   {
+    bool ended = false;
+    bool saved_to_disk = false;
+    uint64 account_id{};
+
     EGameStatsAccountType nAccountType{};
     RTime32 rtTimeStarted{};
     RTime32 rtTimeEnded{};
     int nReasonCode{};
-    bool ended = false;
     std::map<std::string, Attribute_t> attributes{};
 
     std::vector<std::pair<std::string, Table_t>> tables{};
@@ -90,6 +93,8 @@ private:
   Attribute_t *get_or_create_row_att(uint64 ulRowID, const char *att_name, Table_t &table, AttributeType_t type_if_create);
   Session_t* get_last_active_session();
 
+  std::string sanitize_csv_value(std::string_view value);
+  void save_session_to_disk(Steam_GameStats::Session_t &session, uint64 session_id);
   void steam_run_callback();
 
   // user connect/disconnect

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -1345,6 +1345,20 @@ static void parse_overlay_general_config(class Settings *settings_client, class 
 
 }
 
+// main::general::steam_game_stats_reports_dir
+static void parse_steam_game_stats_reports_dir(class Settings *settings_client, class Settings *settings_server)
+{
+    std::string line(common_helpers::string_strip(ini.GetValue("main::general", "steam_game_stats_reports_dir", "")));
+    if (line.size()) {
+        auto folder = common_helpers::to_absolute(line, get_full_program_path());
+        if (folder.size()) {
+            PRINT_DEBUG("ISteamGameStats reports will be saved to '%s'", folder.c_str());
+            settings_client->steam_game_stats_reports_dir = folder;
+            settings_server->steam_game_stats_reports_dir = folder;
+        }
+    }
+}
+
 // mainly enable/disable features
 static void parse_simple_features(class Settings *settings_client, class Settings *settings_server)
 {
@@ -1697,6 +1711,7 @@ uint32 create_localstorage_settings(Settings **settings_client_out, Settings **s
 
     parse_overlay_general_config(settings_client, settings_server);
     load_overlay_appearance(settings_client, settings_server, local_storage);
+    parse_steam_game_stats_reports_dir(settings_client, settings_server);
 
     *settings_client_out = settings_client;
     *settings_server_out = settings_server;

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -1345,10 +1345,10 @@ static void parse_overlay_general_config(class Settings *settings_client, class 
 
 }
 
-// main::general::steam_game_stats_reports_dir
+// main::misc::steam_game_stats_reports_dir
 static void parse_steam_game_stats_reports_dir(class Settings *settings_client, class Settings *settings_server)
 {
-    std::string line(common_helpers::string_strip(ini.GetValue("main::general", "steam_game_stats_reports_dir", "")));
+    std::string line(common_helpers::string_strip(ini.GetValue("main::misc", "steam_game_stats_reports_dir", "")));
     if (line.size()) {
         auto folder = common_helpers::to_absolute(line, get_full_program_path());
         if (folder.size()) {

--- a/dll/steam_gamestats.cpp
+++ b/dll/steam_gamestats.cpp
@@ -521,7 +521,7 @@ void Steam_GameStats::save_session_to_disk(Steam_GameStats::Session_t &session, 
             ss << "\"" << name_str << "\",\"" << val_str << "\"\n";
         }
         auto ss_str = ss.str();
-        Local_Storage::store_file_data(folder_u8_str, "session_attributes.csv", ss_str.c_str(), ss_str.size());
+        Local_Storage::store_file_data(folder_u8_str, "session_attributes.csv", ss_str.c_str(), (unsigned int)ss_str.size());
     }
 
     // save each table
@@ -588,7 +588,7 @@ void Steam_GameStats::save_session_to_disk(Steam_GameStats::Session_t &session, 
         }
         ss_table << "\n";
         auto ss_str = ss_table.str();
-        Local_Storage::store_file_data(folder_u8_str, table_name.c_str(), ss_str.c_str(), ss_str.size());
+        Local_Storage::store_file_data(folder_u8_str, table_name.c_str(), ss_str.c_str(), (unsigned int)ss_str.size());
 
     }
 }

--- a/dll/steam_matchmaking.cpp
+++ b/dll/steam_matchmaking.cpp
@@ -362,7 +362,7 @@ int Steam_Matchmaking::AddFavoriteGame( AppId_t nAppID, uint32 nIP, uint16 nConn
                 directory_path = file_path.substr(0, file_directory);
                 file_name = file_path.substr(file_directory);
             }
-            Local_Storage::store_file_data(directory_path, file_name, (char *)list.data(), list.size());
+            Local_Storage::store_file_data(directory_path, file_name, (char *)list.data(), (unsigned int)list.size());
 
             ++list_lines;
             return static_cast<int>(list_lines);
@@ -379,7 +379,7 @@ int Steam_Matchmaking::AddFavoriteGame( AppId_t nAppID, uint32 nIP, uint16 nConn
             directory_path = file_path.substr(0, file_directory);
             file_name = file_path.substr(file_directory);
         }
-        Local_Storage::store_file_data(directory_path, file_name, (char *)newip_string.data(), newip_string.size());
+        Local_Storage::store_file_data(directory_path, file_name, (char *)newip_string.data(), (unsigned int)newip_string.size());
 
         return 1;
     }
@@ -429,7 +429,7 @@ bool Steam_Matchmaking::RemoveFavoriteGame( AppId_t nAppID, uint32 nIP, uint16 n
                 directory_path = file_path.substr(0, file_directory);
                 file_name = file_path.substr(file_directory);
             }
-            Local_Storage::store_file_data(directory_path, file_name, (char *)list.data(), list.size());
+            Local_Storage::store_file_data(directory_path, file_name, (char *)list.data(), (unsigned int)list.size());
 
             return true;
         }

--- a/helpers/common_helpers.cpp
+++ b/helpers/common_helpers.cpp
@@ -499,3 +499,31 @@ std::string common_helpers::to_str(std::wstring_view wstr)
 
     return {};
 }
+
+std::string common_helpers::str_replace_all(std::string_view source, std::string_view substr, std::string_view replace)
+{
+    if (source.empty() || substr.empty()) return std::string(source);
+
+    std::string out{};
+    out.reserve(source.size() / 4); // out could be bigger or smaller than source, start small
+
+    size_t start_offset = 0;
+    auto f_idx = source.find(substr);
+    while (std::string::npos != f_idx) {
+        // copy the chars before the match
+        auto chars_count_until_match = f_idx - start_offset;
+        out.append(source, start_offset, chars_count_until_match);
+        // copy the replace str
+        out.append(replace);
+
+        // adjust the start offset to point at the char after this match
+        start_offset = f_idx + substr.size();
+        // search for next match
+        f_idx = source.find(substr, start_offset);
+    }
+
+    // copy last remaining part
+    out.append(source, start_offset, std::string::npos);
+
+    return out;
+}

--- a/helpers/common_helpers/common_helpers.hpp
+++ b/helpers/common_helpers/common_helpers.hpp
@@ -110,4 +110,6 @@ std::string get_utc_time();
 std::wstring to_wstr(std::string_view str);
 std::string to_str(std::wstring_view wstr);
 
+std::string str_replace_all(std::string_view source, std::string_view substr, std::string_view replace);
+
 }

--- a/post_build/steam_settings.EXAMPLE/configs.main.EXAMPLE.ini
+++ b/post_build/steam_settings.EXAMPLE/configs.main.EXAMPLE.ini
@@ -57,6 +57,10 @@ matchmaking_server_details_via_source_query=0
 # this is intended to debug some annoying scenarios, and best used with the debug build of the emu
 # default=
 crash_printer_location=./path/relative/to/dll/crashes.txt
+# some Source-based games use the interface ISteamGameStats to report some stats
+# you can make the emu save this data to a folder
+# empty value = don't save anything (default), otherwise the path specified must be writable
+steam_game_stats_reports_dir=./path/relative/to/dll/
 
 [main::connectivity]
 # 1=prevent hooking OS networking APIs and allow any external requests

--- a/post_build/steam_settings.EXAMPLE/configs.main.EXAMPLE.ini
+++ b/post_build/steam_settings.EXAMPLE/configs.main.EXAMPLE.ini
@@ -57,10 +57,6 @@ matchmaking_server_details_via_source_query=0
 # this is intended to debug some annoying scenarios, and best used with the debug build of the emu
 # default=
 crash_printer_location=./path/relative/to/dll/crashes.txt
-# some Source-based games use the interface ISteamGameStats to report some stats
-# you can make the emu save this data to a folder
-# empty value = don't save anything (default), otherwise the path specified must be writable
-steam_game_stats_reports_dir=./path/relative/to/dll/
 
 [main::connectivity]
 # 1=prevent hooking OS networking APIs and allow any external requests
@@ -119,3 +115,9 @@ disable_steamoverlaygameid_env_var=0
 # https://developer.valvesoftware.com/wiki/Dedicated_Servers_List
 # default=0
 enable_steam_preowned_ids=0
+# some Source-based games use the interface `ISteamGameStats` to report some stats
+# you can make the emu save this data to a folder
+# empty value = don't save anything (default)
+# the emu will create the folders if they are missing but the path specified must be writable
+# default=
+steam_game_stats_reports_dir=./path/relative/to/dll/


### PR DESCRIPTION
New ini option `steam_game_stats_reports_dir` in `configs.main.ini` which allows specifying a folder where statistics from `ISteamGameStats` will be saved to, in .csv files.

Only works with Valve games.

This is currently useless, but hopefully someone can figure out something useful out of them later.
Feel free to close/reject this PR, it doesn't add anything of value honestly.
