### PR TITLE
Fixes for `Steam_Http` class

### DIFF
--- a/dll/dll/steam_http.h
+++ b/dll/dll/steam_http.h
@@ -30,12 +30,15 @@ struct Steam_Http_Request {
 	bool requires_valid_ssl = false;
 
 	constexpr const static char STEAM_DEFAULT_USER_AGENT[] = "Valve/Steam HTTP Client 1.0";
-	// GET or POST parameter value on the request
+	// check Steam_HTTP::SetHTTPRequestHeaderValue() and make sure to bypass the ones that should be reserved
 	std::map<std::string, std::string> headers{
-		{"User-Agent", STEAM_DEFAULT_USER_AGENT},
+		{ "User-Agent", STEAM_DEFAULT_USER_AGENT },
+		{ "Cache-Control", "max-age=0" },
+		{ "Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7" },
+		{ "Upgrade-Insecure-Requests", "1" },
 	};
 
-	// GET or POST parameter value on the request
+	// GET or POST parameter value of the request
 	std::map<std::string, std::string> get_or_post_params{};
 	std::string post_raw{};
 

--- a/dll/dll/steam_http.h
+++ b/dll/dll/steam_http.h
@@ -67,7 +67,7 @@ public ISteamHTTP
 	std::vector<Steam_Http_Request> requests{};
 
 	Steam_Http_Request *get_request(HTTPRequestHandle hRequest);
-	void online_http_request(Steam_Http_Request *request, SteamAPICall_t *pCallHandle);
+	void online_http_request(Steam_Http_Request *request, SteamAPICall_t call_res_id);
 
 public:
 	Steam_HTTP(class Settings *settings, class Networking *network, class SteamCallResults *callback_results, class SteamCallBacks *callbacks);

--- a/dll/network.cpp
+++ b/dll/network.cpp
@@ -249,7 +249,7 @@ static void run_at_startup()
         return;
     }
 #if defined(STEAM_WIN32)
-    WSADATA wsaData;
+    WSADATA wsaData{};
     if (WSAStartup(MAKEWORD(2, 2), &wsaData) != NO_ERROR) {
         PRINT_DEBUG("Networking WSAStartup error");
         return;
@@ -257,8 +257,13 @@ static void run_at_startup()
 
     for (int i = 0; i < 10; ++i) {
         //hack: the game Full Mojo Rampage calls WSACleanup on startup so we call WSAStartup a few times so it doesn't get deallocated.
-        WSAStartup(MAKEWORD(2, 2), &wsaData);
+        WSADATA wsaData{};
+        if (WSAStartup(MAKEWORD(2, 2), &wsaData) != NO_ERROR) {
+            PRINT_DEBUG("Networking WSAStartup error");
+            return;
+        }
     }
+    PRINT_DEBUG("Networking WSAStartup success!");
 #else
 
 #endif

--- a/dll/steam_http.cpp
+++ b/dll/steam_http.cpp
@@ -347,7 +347,8 @@ void Steam_HTTP::online_http_request(Steam_Http_Request *request, SteamAPICall_t
     
     unsigned int file_size = file_size_(request->target_filepath);
     if (file_size) {
-        long long read = Local_Storage::get_file_data(request->target_filepath, (char *)&request->response[0], file_size, 0);
+        request->response.resize(static_cast<size_t>(file_size));
+        long long read = Local_Storage::get_file_data(request->target_filepath, (char *)&request->response[0], file_size);
         if (read < 0) read = 0;
         request->response.resize(static_cast<size_t>(read));
     }

--- a/dll/steam_http.cpp
+++ b/dll/steam_http.cpp
@@ -308,6 +308,7 @@ void Steam_HTTP::online_http_request(Steam_Http_Request *request, SteamAPICall_t
     curl_easy_setopt(chttp, CURLOPT_TIMEOUT, request->timeout_sec);
     curl_easy_setopt(chttp, CURLOPT_NOSIGNAL, 1L);
     curl_easy_setopt(chttp, CURLOPT_USE_SSL, request->requires_valid_ssl ? CURLUSESSL_TRY : CURLUSESSL_NONE);
+    curl_easy_setopt(chttp, CURLOPT_SSL_VERIFYPEER, 0L);
 
     // post data, or get params
     std::string post_data{};

--- a/premake5-deps.lua
+++ b/premake5-deps.lua
@@ -535,8 +535,9 @@ local wild_zlib_64 = {
 if _OPTIONS["build-curl"] or _OPTIONS["all-build"] then
     local curl_common_defs = {
         "BUILD_CURL_EXE=OFF",
-        "BUILD_SHARED_LIBS=OFF",
         "BUILD_STATIC_CURL=OFF", -- "Build curl executable with static libcurl"
+
+        "BUILD_SHARED_LIBS=OFF",
         "BUILD_STATIC_LIBS=ON",
         "BUILD_MISC_DOCS=OFF",
         "BUILD_TESTING=OFF",
@@ -544,6 +545,8 @@ if _OPTIONS["build-curl"] or _OPTIONS["all-build"] then
         "ENABLE_CURL_MANUAL=OFF",
         "CURL_USE_OPENSSL=OFF",
         "CURL_ZLIB=ON",
+
+        -- fix building on Arch Linux
         "CURL_USE_LIBSSH2=OFF",
         "CURL_USE_LIBPSL=OFF",
         "USE_LIBIDN2=OFF",

--- a/premake5-deps.lua
+++ b/premake5-deps.lua
@@ -564,12 +564,15 @@ if _OPTIONS["build-mbedtls"] or _OPTIONS["all-build"] then
         table.insert(mbedtls_common_defs, "LINK_WITH_PTHREAD=ON")
     end
 
+    local mbedtls_32_bit_fixes = {}
+    if _OPTIONS["32-build"] and string.match(_ACTION, 'gmake.*') then
+        table.insert(mbedtls_32_bit_fixes, '-mpclmul')
+        table.insert(mbedtls_32_bit_fixes, '-msse2')
+        table.insert(mbedtls_32_bit_fixes, '-maes')
+    end
+
     if _OPTIONS["32-build"] then
-        cmake_build('mbedtls', true, mbedtls_common_defs, {
-            '-mpclmul',
-            '-msse2',
-            '-maes',
-        })
+        cmake_build('mbedtls', true, mbedtls_common_defs, mbedtls_32_bit_fixes)
     end
     if _OPTIONS["64-build"] then
         cmake_build('mbedtls', false, mbedtls_common_defs)

--- a/premake5-deps.lua
+++ b/premake5-deps.lua
@@ -498,23 +498,41 @@ end
 -- https://github.com/Kitware/CMake/blob/a6853135f569f0b040a34374a15a8361bb73901b/Modules/FindZLIB.cmake#L98C4-L98C13
 
 local zlib_name = ''
+local mbedtls_name = ''
+local mbedcrypto_name = ''
+local mbedx509_name = ''
 -- name
 if _ACTION and os.target() == 'windows' then
     if string.match(_ACTION, 'vs.+') then
         zlib_name = 'zlibstatic'
+        mbedtls_name = 'mbedtls'
+        mbedcrypto_name = 'mbedcrypto'
+        mbedx509_name = 'mbedx509'
     elseif string.match(_ACTION, 'gmake.*') then
         zlib_name = 'libzlibstatic'
+        mbedtls_name = 'libmbedtls'
+        mbedcrypto_name = 'libmbedcrypto'
+        mbedx509_name = 'libmbedx509'
     else
         error('unsupported os/action: ' .. os.target() .. ' / ' .. _ACTION)
     end
 else -- linux or macos
     zlib_name = 'libz'
+    mbedtls_name = 'libmbedtls'
+    mbedcrypto_name = 'libmbedcrypto'
+    mbedx509_name = 'mbedx509'
 end
 -- extension
 if _ACTION and string.match(_ACTION, 'vs.+') then
     zlib_name = zlib_name .. '.lib'
+    mbedtls_name = mbedtls_name .. '.lib'
+    mbedcrypto_name = mbedcrypto_name .. '.lib'
+    mbedx509_name = mbedx509_name .. '.lib'
 else
     zlib_name = zlib_name .. '.a'
+    mbedtls_name = mbedtls_name .. '.a'
+    mbedcrypto_name = mbedcrypto_name .. '.a'
+    mbedx509_name = mbedx509_name .. '.a'
 end
 
 local wild_zlib_path_32 = path.join(deps_dir, 'zlib', 'install32', 'lib', zlib_name)
@@ -532,6 +550,32 @@ local wild_zlib_64 = {
     'ZLIB_LIBRARY="' .. wild_zlib_path_64 .. '"',
 }
 
+if _OPTIONS["build-mbedtls"] or _OPTIONS["all-build"] then
+    local mbedtls_common_defs = {
+        "USE_STATIC_MBEDTLS_LIBRARY=ON",
+        "USE_SHARED_MBEDTLS_LIBRARY=OFF",
+        "ENABLE_TESTING=OFF",
+        "ENABLE_PROGRAMS=OFF",
+        "MBEDTLS_FATAL_WARNINGS=OFF",
+    }
+    if os.target() == 'windows' and string.match(_ACTION, 'vs.+') then
+        table.insert(mbedtls_common_defs, "MSVC_STATIC_RUNTIME=ON")
+    else -- linux or macos or MinGW on Windows
+        table.insert(mbedtls_common_defs, "LINK_WITH_PTHREAD=ON")
+    end
+
+    if _OPTIONS["32-build"] then
+        cmake_build('mbedtls', true, mbedtls_common_defs, {
+            '-mpclmul',
+            '-msse2',
+            '-maes',
+        })
+    end
+    if _OPTIONS["64-build"] then
+        cmake_build('mbedtls', false, mbedtls_common_defs)
+    end
+end
+
 if _OPTIONS["build-curl"] or _OPTIONS["all-build"] then
     local curl_common_defs = {
         "BUILD_CURL_EXE=OFF",
@@ -543,8 +587,13 @@ if _OPTIONS["build-curl"] or _OPTIONS["all-build"] then
         "BUILD_TESTING=OFF",
         "BUILD_LIBCURL_DOCS=OFF",
         "ENABLE_CURL_MANUAL=OFF",
+
         "CURL_USE_OPENSSL=OFF",
         "CURL_ZLIB=ON",
+        
+        "CURL_USE_MBEDTLS=ON",
+        -- "CURL_USE_SCHANNEL=ON",
+        "CURL_CA_FALLBACK=ON",
 
         -- fix building on Arch Linux
         "CURL_USE_LIBSSH2=OFF",
@@ -558,10 +607,20 @@ if _OPTIONS["build-curl"] or _OPTIONS["all-build"] then
     end
 
     if _OPTIONS["32-build"] then
-        cmake_build('curl', true, merge_list(curl_common_defs, wild_zlib_32))
+        cmake_build('curl', true, merge_list(curl_common_defs, merge_list(wild_zlib_32, {
+            'MBEDTLS_INCLUDE_DIRS="' .. path.join(deps_dir, 'mbedtls', 'install32', 'include') .. '"',
+            'MBEDTLS_LIBRARY="' .. path.join(deps_dir, 'mbedtls', 'install32', 'lib', mbedtls_name) .. '"',
+            'MBEDCRYPTO_LIBRARY="' .. path.join(deps_dir, 'mbedtls', 'install32', 'lib', mbedcrypto_name) .. '"',
+            'MBEDX509_LIBRARY="' .. path.join(deps_dir, 'mbedtls', 'install32', 'lib', mbedx509_name) .. '"',
+        })))
     end
     if _OPTIONS["64-build"] then
-        cmake_build('curl', false, merge_list(curl_common_defs, wild_zlib_64))
+        cmake_build('curl', false, merge_list(curl_common_defs, merge_list(wild_zlib_64, {
+            'MBEDTLS_INCLUDE_DIRS="' .. path.join(deps_dir, 'mbedtls', 'install64', 'include') .. '"',
+            'MBEDTLS_LIBRARY="' .. path.join(deps_dir, 'mbedtls', 'install64', 'lib', mbedtls_name) .. '"',
+            'MBEDCRYPTO_LIBRARY="' .. path.join(deps_dir, 'mbedtls', 'install64', 'lib', mbedcrypto_name) .. '"',
+            'MBEDX509_LIBRARY="' .. path.join(deps_dir, 'mbedtls', 'install64', 'lib', mbedx509_name) .. '"',
+        })))
     end
 end
 
@@ -588,32 +647,6 @@ if _OPTIONS["build-protobuf"] or _OPTIONS["all-build"] then
     end
     if _OPTIONS["64-build"] then
         cmake_build('protobuf', false, merge_list(proto_common_defs, wild_zlib_64))
-    end
-end
-
-if _OPTIONS["build-mbedtls"] or _OPTIONS["all-build"] then
-    local mbedtls_common_defs = {
-        "USE_STATIC_MBEDTLS_LIBRARY=ON",
-        "USE_SHARED_MBEDTLS_LIBRARY=OFF",
-        "ENABLE_TESTING=OFF",
-        "ENABLE_PROGRAMS=OFF",
-        "MBEDTLS_FATAL_WARNINGS=OFF",
-    }
-    if os.target() == 'windows' and string.match(_ACTION, 'vs.+') then
-        table.insert(mbedtls_common_defs, "MSVC_STATIC_RUNTIME=ON")
-    else -- linux or macos or MinGW on Windows
-        table.insert(mbedtls_common_defs, "LINK_WITH_PTHREAD=ON")
-    end
-
-    if _OPTIONS["32-build"] then
-        cmake_build('mbedtls', true, mbedtls_common_defs, {
-            '-mpclmul',
-            '-msse2',
-            '-maes',
-        })
-    end
-    if _OPTIONS["64-build"] then
-        cmake_build('mbedtls', false, mbedtls_common_defs)
     end
 end
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -273,6 +273,8 @@ local deps_link = {
     zlib_archive_name    .. static_postfix,
     lib_prefix .. "curl" .. static_postfix,
     "mbedcrypto"         .. static_postfix,
+    "mbedtls"            .. static_postfix,
+    "mbedx509"           .. static_postfix,
 }
 -- add protobuf libs
 table_append(deps_link, {


### PR DESCRIPTION
* Fix a bug in `Steam_HTTP::SendHTTPRequest()` where the ID of the triggered call-result from online requests was completely unrelated to the original request, resulting in timeout
* Workaround a problem in `Steam_HTTP::SetHTTPRequestHeaderValue()` where some games (like appid 1902490) set a cache-control policy which allows only responses from previous requests, otherwise the server will respond with error 504
* Verbose Curl lib logging in debug builds, to inspect problems easier
* Build Curl with mbedtls as SSL backend to allow using https protocol, previously this was not possible, making the option to download requests made by the game through `ISteamHttp` useless
* Add newly required mbedtls linking to all emu builds + fix compilation warning for mbedtls on Visual Studio
* Fix a buffer overrun bug in `steam_http` where the buffer size wasn't set correctly resulting in a crash
* Bypass SSL verification in `steam_http` when downloading requests, this sounds scary, but otherwise the user has to load a local list of trusted certificates since mbedtls doesn't use the Trusted Authority list from Windows, also the option to download requests made by a game is disabled by default

As far as I can remember, this won't work with Github
1. The deps cache you currently have is built without mbedtls
2. If you invalidated the cache (deleting it), you'll have to first integrate the PR otherwise you'll build again with the old stuff
3. If you delete the cache and trigger the checks on the PR again, Github will create a separate cache for this PR, but it will invalid once it is integrated, but at least it will be valid
4. In any case if this PR is integrated, the current cache has to be deleted and rebuilt again

I assume there might be a better way to handle this scenario but I just don't know how.
If you decided to integrate this PR, and it broke, you can ping me here and I'll see what broke and how to fix it.

You can test this with appid 1902490 (free game) since it downloads its own app schema via https protocol.

Feel free to close/reject this PR if it's too much trouble.