### PR TITLE
Dramatically decrease the startup locking/halt time when the overlay is enabled

### DIFF
--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -216,6 +216,7 @@ private:
 
 public:
     constexpr const static int INVALID_IMAGE_HANDLE = 0;
+    constexpr const static int UNLOADED_IMAGE_HANDLE = -1;
 
     //Depots
     std::vector<DepotId_t> depots{};
@@ -258,8 +259,12 @@ public:
     // the stat itself is always saved regardless of that flag, only affects the achievement progress
     bool save_only_higher_stat_achievement_progress = true;
     // the emulator loads the achievements icons is memory mainly for `ISteamUserStats::GetAchievementIcon()`
-    // true means load icons lazily when they are requested, otherwise load icons as soon as the interface ISteamUserStats is initialized
-    bool lazy_load_achievements_icons = true;
+    // this defines how many icons to load each iteration when the periodic callback in `Steam_User_Stats` is triggered
+    // or when the app calls `SteamAPI_RunCallbacks()`
+    // -1 == functionality disabled
+    // 0  == load icons only when they're requested
+    // >0 == load icons in the background as mentioned above
+    int paginated_achievements_icons = 10;
 
     // bypass to make SetAchievement() always return true, prevent some games from breaking
     bool achievement_bypass = false;
@@ -314,6 +319,8 @@ public:
     bool overlay_warn_local_save = false;
     //disable overlay warning for local save
     bool disable_overlay_warning_local_save = false;
+    // should the overlay upload icons to the GPU and display them
+    bool overlay_upload_achs_icons_to_gpu = true;
     //disable overlay warning for bad app ID (= 0)
     bool disable_overlay_warning_bad_appid = false;
     // disable all overlay warnings

--- a/dll/dll/steam_user_stats.h
+++ b/dll/dll/steam_user_stats.h
@@ -70,8 +70,7 @@ public ISteamUserStats011,
 public ISteamUserStats
 {
 public:
-    static constexpr auto achievements_user_file = "achievements.json";
-    static constexpr int UNLOADED_ACH_ICON = -1;
+    static constexpr const auto achievements_user_file = "achievements.json";
 
 private:
     template<typename T>
@@ -95,7 +94,7 @@ private:
     nlohmann::json defined_achievements{};
     nlohmann::json user_achievements{};
     std::vector<std::string> sorted_achievement_names{};
-    bool achievements_icons_loaded = false;
+    size_t last_loaded_ach_icon{};
 
     std::map<std::string, int32> stats_cache_int{};
     std::map<std::string, float> stats_cache_float{};
@@ -213,7 +212,7 @@ public:
     // specified achievement.
     int GetAchievementIcon( const char *pchName );
 
-    int get_achievement_icon_handle( const std::string &ach_name, bool pbAchieved );
+    int get_achievement_icon_handle( const std::string &ach_name, bool pbAchieved, bool force_load = false );
 
     std::string get_achievement_icon_name( const char *pchName, bool achieved );
 

--- a/dll/settings.cpp
+++ b/dll/settings.cpp
@@ -375,7 +375,7 @@ int Settings::add_image(const std::string &data, uint32 width, uint32 height)
 
 Image_Data* Settings::get_image(int handle)
 {
-    if (INVALID_IMAGE_HANDLE == handle) {
+    if (INVALID_IMAGE_HANDLE == handle || UNLOADED_IMAGE_HANDLE == handle) {
         return nullptr;
     }
     

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -1343,6 +1343,9 @@ static void parse_overlay_general_config(class Settings *settings_client, class 
     settings_client->disable_overlay_warning_local_save = ini.GetBoolValue("overlay::general", "disable_warning_local_save", settings_client->disable_overlay_warning_local_save);
     settings_server->disable_overlay_warning_local_save = ini.GetBoolValue("overlay::general", "disable_warning_local_save", settings_server->disable_overlay_warning_local_save);
 
+    settings_client->overlay_upload_achs_icons_to_gpu = ini.GetBoolValue("overlay::general", "upload_achievements_icons_to_gpu", settings_client->overlay_upload_achs_icons_to_gpu);
+    settings_server->overlay_upload_achs_icons_to_gpu = ini.GetBoolValue("overlay::general", "upload_achievements_icons_to_gpu", settings_server->overlay_upload_achs_icons_to_gpu);
+
 }
 
 // main::misc::steam_game_stats_reports_dir
@@ -1437,8 +1440,13 @@ static void parse_stats_features(class Settings *settings_client, class Settings
     settings_client->save_only_higher_stat_achievement_progress = ini.GetBoolValue("main::stats", "save_only_higher_stat_achievement_progress", settings_client->save_only_higher_stat_achievement_progress);
     settings_server->save_only_higher_stat_achievement_progress = ini.GetBoolValue("main::stats", "save_only_higher_stat_achievement_progress", settings_server->save_only_higher_stat_achievement_progress);
 
-    settings_client->lazy_load_achievements_icons = ini.GetBoolValue("main::stats", "lazy_load_achievements_icons", settings_client->lazy_load_achievements_icons);
-    settings_server->lazy_load_achievements_icons = ini.GetBoolValue("main::stats", "lazy_load_achievements_icons", settings_server->lazy_load_achievements_icons);
+    {
+        long val_client = ini.GetLongValue("main::stats", "paginated_achievements_icons", settings_client->paginated_achievements_icons);
+        settings_client->paginated_achievements_icons = static_cast<int>(val_client);
+
+        long val_server = ini.GetLongValue("main::stats", "paginated_achievements_icons", settings_server->paginated_achievements_icons);
+        settings_server->paginated_achievements_icons = static_cast<int>(val_server);
+    }
 }
 
 

--- a/dll/steam_user_stats.cpp
+++ b/dll/steam_user_stats.cpp
@@ -96,8 +96,8 @@ Steam_User_Stats::Steam_User_Stats(Settings *settings, class Networking *network
         it["displayName"] = get_value_for_language(it, "displayName", settings->get_language());
         it["description"] = get_value_for_language(it, "description", settings->get_language());
 
-        it["icon_handle"] = UNLOADED_ACH_ICON;
-        it["icon_gray_handle"] = UNLOADED_ACH_ICON;
+        it["icon_handle"] = Settings::UNLOADED_IMAGE_HANDLE;
+        it["icon_gray_handle"] = Settings::UNLOADED_IMAGE_HANDLE;
     }
 
     //TODO: not sure if the sort is actually case insensitive, ach names seem to be treated by steam as case insensitive so I assume they are.

--- a/post_build/steam_settings.EXAMPLE/configs.main.EXAMPLE.ini
+++ b/post_build/steam_settings.EXAMPLE/configs.main.EXAMPLE.ini
@@ -59,13 +59,16 @@ stat_achievement_progress_functionality=1
 # also has no impact on the functions which directly change stats, achievements, or achievements progress
 # default=1
 save_only_higher_stat_achievement_progress=1
-# the emulator loads the achievements icons is memory
-# this is needed for APIs like `ISteamUserStats::GetAchievementIcon()`
-# the loaded icon size is controlled by [overlay::appearance] -> Icon_Size, in configs.overlay.ini
-# 1=load icons lazily when they are requested
-# 0=load icons as soon as the interface ISteamUserStats is initialized
-# default=1
-lazy_load_achievements_icons=1
+# the emulator loads the achievements icons is memory, this is needed for APIs like `ISteamUserStats::GetAchievementIcon()` and the overlay
+# the loaded icon size is controlled by [overlay::appearance] -> Icon_Size, in the file configs.overlay.ini
+# this value controls how many icons to load each iteration when the periodic callback of the emu is triggered
+# or when the app/game calls `SteamAPI_RunCallbacks()`
+# each achievement has 2 icons, one when it's locked and another when it's unlocked, so a value of 10 means loading 20 icons
+# increasing this value will cause a huge startup delay
+# -1=disable this functionality (`ISteamUserStats::GetAchievementIcon()` and the overlay won't be able to use icons)
+#  0=load the icon in memory only when it's requested
+# default=10
+paginated_achievements_icons=10
 
 [main::connectivity]
 # 1=prevent hooking OS networking APIs and allow any external requests

--- a/post_build/steam_settings.EXAMPLE/configs.overlay.EXAMPLE.ini
+++ b/post_build/steam_settings.EXAMPLE/configs.overlay.EXAMPLE.ini
@@ -38,6 +38,12 @@ disable_warning_bad_appid=0
 # 1=disable the local_save warning in the overlay
 # default=0
 disable_warning_local_save=0
+# by default the overlay will attempt to upload the achievements icons to the GPU
+# so that they are displayed, in rare cases this might keep failing and cause FPS drop
+# 0=prevent the overlay from attempting to upload the icons periodically,
+#   in that case achievements icons win't be displayed
+# default=1
+upload_achievements_icons_to_gpu=1
 
 [overlay::appearance]
 # load custom TrueType font from a path, it could be absolute, or relative


### PR DESCRIPTION
* deprecate `lazy_load_achievements_icons` in favor of `paginated_achievements_icons` in `configs.main.ini`, which controls how many icons to load each iteration
* new option `upload_achievements_icons_to_gpu` in `configs.overlay.ini` which controls whether the overlay should upload the achievements icons to the GPU and display them or not
* synchronize overlay proc with the periodic steam callback in a better way to avoid FPS drop
* fix overlay flickering regression
* upload achievements icons to the GPU in the overlay proc periodically, this dramatically decreased the startup locking/halt time
* fix a potential deadlock scenario in the overlay as a result of synchronizing with 2 mutex objects

The way this works now is as follows:

### Steam_User_Stats class
In the periodic callback of the `Steam_User_Stats` class, the achievements icons will be loaded from disk into memory via `stb` lib, this is done in batches each time the callback is run and the amount of images to load is controlled by `paginated_achievements_icons`.

Too much loading operations from disk will make the callback consume more time, and all steam callbacks will be impacted, but will happen once or twice at startup only.
This can cause timeout in some games.

Too few loading operations from disk will make the callback consume way less time, and all steam callbacks will run just fine, but will keep recurring during startup until all icons are loaded.
This can cause an overall slow down in the steam callback system.

With some testing it seemed 20 images is a moderate amount, it takes ~20-30 ms.
This doesn't impact the original startup delay problem which happens when the overlay is enabled, but this is a much better way to load icons without impacting performance or causing timeout.

### overlay class
This 2 biggest problems are
- Uploading an image resource to the GPU takes almost **~30 ms per image** especially on DirectX 12, DirectX 11 takes way less time per image

- The overlay procedure/function is called each frame of the game and it locks the overlay mutex, and the periodic callback of the overlay, which already owns the emu's global mutex, also locks the same mutex

The second point caused 2 problems:
* Deadlock scenario which happens like this:
  1. The steam callback is triggered one way or another, either the game itself called RunCallbacks() or the emu's background thread was now running, in both cases the emu's global mutex is locked
  2. DirectX, which runs on its own thread, decided to invoke the Present() function, which is called each frame of the game, and the overlay proc locked the overlay mutex
  3. Now back to the steam callback, it attempted to call a function in the overlay which locks the overlay mutex, it won't succeed and now the steam callback thread is halted
  4. Back to the overlay proc, it tries to call some steam API which locks the global emu's mutex, but because the steam callback has already locked it, the overlay proc thread is now also halted

* Frame drops when the overlay was active, this can happen when the steam callback is run too many times, which locks the overlay mutex, and the overlay proc, which also locks the overlay mutex, gets fewer chances to run uninterrupted. The time consumed by the steam callback is a dead time for the overlay proc, or a dead time for DirectX's rendering thread.

To fix the problem of icon uploading, the overlay proc now will attempt to upload **1 image at a time**, since that takes ~30 ms on DirectX 12, the game FPS will be low at startup but will eventually rise again, and in case it keeps failing over and over forever, the user now has the option `upload_achievements_icons_to_gpu`.

To fix the 2 mutexes sync problem, the steam callback will *try to lock* the overlay mutex instead of forcefully doing it, if it failed to lock the mutex, it won't block the steam thread and instead bail out immediately, leaving the global mutex available. After all this callback is run periodically, so it should be fine to skip a few iterations.
The other way around, which is making the overlay proc attempt to lock the global emu mutex and bailing out immediately if it failed, made the overlay skip a few frames as expected, but that obviously means it will be hidden in some frames and visible in others very rapidly, hence the flickering regression.

