### PR TITLE
upgrade to c++20/23

### DIFF
--- a/crash_printer/linux.cpp
+++ b/crash_printer/linux.cpp
@@ -50,7 +50,7 @@ static void exception_handler(int signal, siginfo_t *info, void *context, struct
         return;
     }
     
-    std::ofstream file(std::filesystem::u8path(logs_filepath), std::ios::app);
+    std::ofstream file(common_helpers::open_fwrite(logs_filepath, std::ios::out | std::ios::app));
 
     std::string time(common_helpers::get_utc_time());
     common_helpers::write(file, "[" + time + "]");

--- a/crash_printer/tests/test_linux_sa_handler.cpp
+++ b/crash_printer/tests/test_linux_sa_handler.cpp
@@ -15,7 +15,7 @@ std::string logs_filepath = "./crash_test/asd.txt";
 // sa_sigaction handler for illegal instruction (SIGILL)
 void exception_handler_SIGILL(int signal)
 {
-    std::ifstream file(std::filesystem::u8path(logs_filepath));
+    std::ifstream file(common_helpers::open_fread(logs_filepath));
     if (file.is_open()) {
         std::string line{};
         std::getline(file, line);

--- a/crash_printer/tests/test_linux_sa_sigaction.cpp
+++ b/crash_printer/tests/test_linux_sa_sigaction.cpp
@@ -15,7 +15,7 @@ std::string logs_filepath = "./crash_test/asd.txt";
 // sa_handler handler for illegal instruction (SIGILL)
 void exception_handler_SIGILL(int signal, siginfo_t *info, void *context)
 {
-    std::ifstream file(std::filesystem::u8path(logs_filepath));
+    std::ifstream file(common_helpers::open_fread(logs_filepath));
     if (file.is_open()) {
         std::string line{};
         std::getline(file, line);

--- a/crash_printer/tests/test_win.cpp
+++ b/crash_printer/tests/test_win.cpp
@@ -13,7 +13,7 @@ std::string logs_filepath = "./crash_test/zxc.txt";
 
 static LONG WINAPI exception_handler(LPEXCEPTION_POINTERS ex_pointers)
 {
-    std::ifstream file(std::filesystem::u8path(logs_filepath));
+    std::ifstream file(common_helpers::open_fread(logs_filepath));
     if (file.is_open()) {
         std::string line{};
         std::getline(file, line);

--- a/crash_printer/win.cpp
+++ b/crash_printer/win.cpp
@@ -104,7 +104,7 @@ static void log_exception(LPEXCEPTION_POINTERS ex_pointers)
         return;
     }
     
-    std::ofstream file(std::filesystem::u8path(logs_filepath), std::ios::out | std::ios::app);
+    std::ofstream file(common_helpers::open_fwrite(logs_filepath, std::ios::out | std::ios::app));
 
     std::string time(common_helpers::get_utc_time());
     common_helpers::write(file, "[" + time + "]");

--- a/dll/dll/common_includes.h
+++ b/dll/dll/common_includes.h
@@ -55,7 +55,6 @@
 
 #include <string.h>
 #include <stdio.h>
-#include <filesystem>
 #include <optional>
 #include <numeric>
 

--- a/dll/local_storage.cpp
+++ b/dll/local_storage.cpp
@@ -34,6 +34,9 @@
 #define STB_IMAGE_RESIZE_IMPLEMENTATION
 #include "stb/stb_image_resize2.h"
 
+#include <filesystem>
+
+
 struct File_Data {
     std::string name{};
 };
@@ -574,8 +577,7 @@ int Local_Storage::store_file_data(std::string folder, std::string file, const c
     }
 
     create_directory(folder + file_folder);
-    std::ofstream myfile;
-    myfile.open(std::filesystem::u8path(folder + file), std::ios::binary | std::ios::out);
+    std::ofstream myfile(common_helpers::open_fwrite(folder + file, std::ios::out | std::ios::binary));
     if (!myfile.is_open()) return -1;
     myfile.write(data, length);
     int position = static_cast<int>(myfile.tellp());
@@ -618,13 +620,14 @@ std::vector<std::string> Local_Storage::get_folders_path(std::string path)
     std::vector<std::string> output{};
     try
     {
-        const auto path_p(std::filesystem::u8path(path));
+        const auto path_p(common_helpers::std_fs_path(path));
         if (!common_helpers::dir_exist(path_p)) return output;
 
         for (const auto &dir_entry :
             std::filesystem::directory_iterator(path_p, std::filesystem::directory_options::follow_directory_symlink)) {
-            if (std::filesystem::is_directory(dir_entry)) {
-                output.push_back(dir_entry.path().filename().u8string());
+            if (common_helpers::dir_exist(dir_entry.path())) {
+                auto filename = common_helpers::u8str_to_str( dir_entry.path().filename().u8string() );
+                output.emplace_back(filename);
             }
         }
     } catch(...) { }
@@ -658,8 +661,7 @@ int Local_Storage::store_data_settings(std::string file, const char *data, unsig
 
 int Local_Storage::get_file_data(const std::string &full_path, char *data, unsigned int max_length, unsigned int offset)
 {
-    std::ifstream myfile{};
-    myfile.open(std::filesystem::u8path(full_path), std::ios::binary | std::ios::in);
+    std::ifstream myfile( common_helpers::open_fread(full_path, std::ios::in | std::ios::binary) );
     if (!myfile.is_open()) return -1;
 
     myfile.seekg (offset, std::ios::beg);
@@ -805,12 +807,14 @@ bool Local_Storage::update_save_filenames(std::string folder)
 
 bool Local_Storage::load_json(const std::string &full_path, nlohmann::json& json)
 {
-    std::ifstream inventory_file(std::filesystem::u8path(full_path), std::ios::in | std::ios::binary);
+    std::ifstream inventory_file(common_helpers::open_fread(full_path, std::ios::in | std::ios::binary));
     // If there is a file and we opened it
     if (inventory_file) {
         try {
             json = nlohmann::json::parse(inventory_file);
             PRINT_DEBUG("Loaded json '%s' (%zu items)", full_path.c_str(), json.size());
+            
+            reset_LastError();
             return true;
         } catch (const std::exception& e) {
             PRINT_DEBUG("Error while parsing '%s' json error: %s", full_path.c_str(), e.what());
@@ -844,9 +848,11 @@ bool Local_Storage::write_json_file(std::string folder, std::string const&file, 
 
     create_directory(inv_path);
 
-    std::ofstream inventory_file(std::filesystem::u8path(full_path), std::ios::trunc | std::ios::out | std::ios::binary);
+    std::ofstream inventory_file(common_helpers::open_fwrite(full_path, std::ios::out | std::ios::binary | std::ios::trunc));
     if (inventory_file) {
         inventory_file << std::setw(2) << json;
+        
+        reset_LastError();
         return true;
     }
 

--- a/dll/settings.cpp
+++ b/dll/settings.cpp
@@ -346,7 +346,7 @@ const std::map<std::string, Stat_config>& Settings::getStats() const
 
 std::map<std::string, Stat_config>::const_iterator Settings::setStatDefiniton(const std::string &name, const struct Stat_config &stat_config)
 {
-    auto ins_it = stats.insert_or_assign(common_helpers::ascii_to_lowercase(name), stat_config);
+    auto ins_it = stats.insert_or_assign(common_helpers::to_lower(name), stat_config);
     return ins_it.first;
 }
 

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -139,7 +139,7 @@ Overlay_Appearance::NotificationPosition Overlay_Appearance::translate_notificat
 static void load_custom_broadcasts(const std::string &base_path, std::set<IP_PORT> &custom_broadcasts)
 {
     const std::string broadcasts_filepath(base_path + "custom_broadcasts.txt");
-    std::ifstream broadcasts_file(std::filesystem::u8path(broadcasts_filepath));
+    std::ifstream broadcasts_file(common_helpers::open_fread(broadcasts_filepath));
     if (broadcasts_file.is_open()) {
         common_helpers::consume_bom(broadcasts_file);
         PRINT_DEBUG("loading broadcasts file '%s'", broadcasts_filepath.c_str());
@@ -158,7 +158,7 @@ static void load_custom_broadcasts(const std::string &base_path, std::set<IP_POR
 static void load_subscribed_groups_clans(const std::string &base_path, Settings *settings_client, Settings *settings_server)
 {
     const std::string clans_filepath(base_path + "subscribed_groups_clans.txt");
-    std::ifstream clans_file(std::filesystem::u8path(clans_filepath));
+    std::ifstream clans_file(common_helpers::open_fread(clans_filepath));
     if (clans_file.is_open()) {
         common_helpers::consume_bom(clans_file);
         PRINT_DEBUG("loading group clans file '%s'", clans_filepath.c_str());
@@ -412,7 +412,7 @@ static void load_gamecontroller_settings(Settings *settings)
         std::transform(action_set_name.begin(), action_set_name.end(), action_set_name.begin(),[](unsigned char c){ return std::toupper(c); });
 
         std::string controller_config_path = path + PATH_SEPARATOR + p;
-        std::ifstream input( std::filesystem::u8path(controller_config_path) );
+        std::ifstream input( common_helpers::open_fread(controller_config_path) );
         if (input.is_open()) {
             common_helpers::consume_bom(input);
             std::map<std::string, std::pair<std::set<std::string>, std::string>> button_pairs;
@@ -552,7 +552,10 @@ static bool parse_local_save(std::string &save_path)
     auto ptr = ini.GetValue("user::saves", "local_save_path");
     if (!ptr || !ptr[0]) return false;
     
-    save_path = common_helpers::to_absolute(common_helpers::string_strip(ptr), Local_Storage::get_program_path());
+    save_path = common_helpers::to_absolute(
+        common_helpers::string_strip(std::string_view(ptr)),
+        Local_Storage::get_program_path()
+    );
     if (save_path.size() && save_path.back() != *PATH_SEPARATOR) {
         save_path.push_back(*PATH_SEPARATOR);
     }
@@ -627,7 +630,7 @@ static std::string parse_current_language(class Local_Storage *local_storage)
         );
     }
 
-    return common_helpers::to_lower(std::string(lang));
+    return common_helpers::to_lower(lang);
 }
 
 // supported_languages.txt
@@ -637,7 +640,7 @@ static std::set<std::string> parse_supported_languages(class Local_Storage *loca
     std::set<std::string> supported_languages{};
 
     std::string lang_config_path = Local_Storage::get_game_settings_path() + "supported_languages.txt";
-    std::ifstream input( std::filesystem::u8path(lang_config_path) );
+    std::ifstream input( common_helpers::open_fread(lang_config_path) );
 
     std::string first_language{};
     if (input.is_open()) {
@@ -739,7 +742,7 @@ static void parse_app_paths(class Settings *settings_client, Settings *settings_
 static void parse_leaderboards(class Settings *settings_client, class Settings *settings_server)
 {
     std::string dlc_config_path = Local_Storage::get_game_settings_path() + "leaderboards.txt";
-    std::ifstream input( std::filesystem::u8path(dlc_config_path) );
+    std::ifstream input( common_helpers::open_fread(dlc_config_path) );
     if (input.is_open()) {
         common_helpers::consume_bom(input);
 
@@ -782,7 +785,7 @@ static void parse_leaderboards(class Settings *settings_client, class Settings *
 static void parse_stats(class Settings *settings_client, class Settings *settings_server)
 {
     std::string stats_config_path = Local_Storage::get_game_settings_path() + "stats.txt";
-    std::ifstream input( std::filesystem::u8path(stats_config_path) );
+    std::ifstream input( common_helpers::open_fread(stats_config_path) );
     if (input.is_open()) {
         common_helpers::consume_bom(input);
         for( std::string line; getline( input, line ); ) {
@@ -850,7 +853,7 @@ static void parse_stats(class Settings *settings_client, class Settings *setting
 static void parse_depots(class Settings *settings_client, class Settings *settings_server)
 {
     std::string depots_config_path = Local_Storage::get_game_settings_path() + "depots.txt";
-    std::ifstream input( std::filesystem::u8path(depots_config_path) );
+    std::ifstream input( common_helpers::open_fread(depots_config_path) );
     if (input.is_open()) {
         common_helpers::consume_bom(input);
         for( std::string line; getline( input, line ); ) {
@@ -877,7 +880,7 @@ static void parse_depots(class Settings *settings_client, class Settings *settin
 static void parse_subscribed_groups(class Settings *settings_client, class Settings *settings_server)
 {
     std::string depots_config_path = Local_Storage::get_game_settings_path() + "subscribed_groups.txt";
-    std::ifstream input( std::filesystem::u8path(depots_config_path) );
+    std::ifstream input( common_helpers::open_fread(depots_config_path) );
     if (input.is_open()) {
         common_helpers::consume_bom(input);
         for( std::string line; getline( input, line ); ) {
@@ -904,7 +907,7 @@ static void parse_subscribed_groups(class Settings *settings_client, class Setti
 static void parse_installed_app_Ids(class Settings *settings_client, class Settings *settings_server)
 {
     std::string installed_apps_list_path = Local_Storage::get_game_settings_path() + "installed_app_ids.txt";
-    std::ifstream input( std::filesystem::u8path(installed_apps_list_path) );
+    std::ifstream input( common_helpers::open_fread(installed_apps_list_path) );
     if (input.is_open()) {
         settings_client->assumeAnyAppInstalled(false);
         settings_server->assumeAnyAppInstalled(false);
@@ -1161,7 +1164,7 @@ static void parse_crash_printer_location()
 static void parse_auto_accept_invite(class Settings *settings_client, class Settings *settings_server)
 {
     std::string auto_accept_list_path = Local_Storage::get_game_settings_path() + "auto_accept_invite.txt";
-    std::ifstream input( std::filesystem::u8path(auto_accept_list_path) );
+    std::ifstream input( common_helpers::open_fread(auto_accept_list_path) );
     if (input.is_open()) {
         bool accept_any_invite = true;
         common_helpers::consume_bom(input);
@@ -1455,7 +1458,7 @@ static std::map<SettingsItf, std::string> old_itfs_map{};
 
 static bool try_parse_old_steam_interfaces_file(std::string interfaces_path)
 {
-    std::ifstream input( std::filesystem::u8path(interfaces_path) );
+    std::ifstream input( common_helpers::open_fread(interfaces_path) );
     if (!input.is_open()) return false;
 
     PRINT_DEBUG("Trying to parse old steam interfaces from '%s'", interfaces_path.c_str());
@@ -1547,7 +1550,7 @@ static void load_all_config_settings()
         local_ini.SetUnicode();
 
         for (const auto &config_file : config_files) {
-            std::ifstream local_ini_file( std::filesystem::u8path(Local_Storage::get_game_settings_path() + config_file), std::ios::binary | std::ios::in);
+            std::ifstream local_ini_file( common_helpers::open_fread(Local_Storage::get_game_settings_path() + config_file, std::ios::in | std::ios::binary) );
             if (!local_ini_file.is_open()) continue;
 
             auto err = local_ini.LoadData(local_ini_file);
@@ -1571,7 +1574,9 @@ static void load_all_config_settings()
         local_ini.SetUnicode();
 
         for (const auto &config_file : config_files) {
-            std::ifstream local_ini_file( std::filesystem::u8path(local_save_folder + Local_Storage::settings_storage_folder + PATH_SEPARATOR + config_file), std::ios::binary | std::ios::in);
+            std::ifstream local_ini_file(
+                common_helpers::open_fread(local_save_folder + Local_Storage::settings_storage_folder + PATH_SEPARATOR + config_file, std::ios::in | std::ios::binary)
+            );
             if (!local_ini_file.is_open()) continue;
 
             auto err = local_ini.LoadData(local_ini_file);
@@ -1596,7 +1601,9 @@ static void load_all_config_settings()
         
         // now we can access get_user_appdata_path() which might have been changed by the above code
         for (const auto &config_file : config_files) {
-            std::ifstream ini_file( std::filesystem::u8path(Local_Storage::get_user_appdata_path() + Local_Storage::settings_storage_folder + PATH_SEPARATOR + config_file), std::ios::binary | std::ios::in);
+            std::ifstream ini_file(
+                common_helpers::open_fread(Local_Storage::get_user_appdata_path() + Local_Storage::settings_storage_folder + PATH_SEPARATOR + config_file, std::ios::in | std::ios::binary)
+            );
             if (!ini_file.is_open()) continue;
             
             auto err = global_ini.LoadData(ini_file);

--- a/dll/steam_apps.cpp
+++ b/dll/steam_apps.cpp
@@ -418,8 +418,8 @@ SteamAPICall_t Steam_Apps::GetFileDetails( const char* pszFileName )
     //TODO? this function should only return found if file is actually part of the steam depots
     if (file_exists_(pszFileName)) {
         data.m_eResult = k_EResultOK; //
-        std::ifstream stream(std::filesystem::u8path(pszFileName), std::ios::binary);
-        SHA1 checksum;
+        std::ifstream stream( common_helpers::open_fread(pszFileName, std::ios::in | std::ios::binary) );
+        SHA1 checksum{};
         checksum.update(stream);
         checksum.final().copy((char *)data.m_FileSHA, sizeof(data.m_FileSHA));
         data.m_ulFileSize = file_size_(pszFileName);

--- a/dll/steam_client_interface_getter.cpp
+++ b/dll/steam_client_interface_getter.cpp
@@ -968,7 +968,7 @@ void Steam_Client::report_missing_impl(std::string_view itf, std::string_view ca
     catch(...) { }
 
     try {
-        std::ofstream report(std::filesystem::u8path(get_full_program_path() + "EMU_MISSING_INTERFACE.txt"), std::ios::out | std::ios::app);
+        std::ofstream report( common_helpers::open_fwrite(get_full_program_path() + "EMU_MISSING_INTERFACE.txt", std::ios::out | std::ios::app) );
         if (report.is_open()) {
             report << ss.str();
         }

--- a/dll/steam_controller.cpp
+++ b/dll/steam_controller.cpp
@@ -573,7 +573,7 @@ int Steam_Controller::GetDigitalActionOrigins( ControllerHandle_t controllerHand
     EInputActionOrigin origins[STEAM_CONTROLLER_MAX_ORIGINS];
     int ret = GetDigitalActionOrigins(controllerHandle, actionSetHandle, digitalActionHandle, origins );
     for (int i = 0; i < ret; ++i) {
-        originsOut[i] = (EControllerActionOrigin)(origins[i] - (k_EInputActionOrigin_XBox360_A - k_EControllerActionOrigin_XBox360_A));
+        originsOut[i] = (EControllerActionOrigin)(origins[i] - ((long)k_EInputActionOrigin_XBox360_A - (long)k_EControllerActionOrigin_XBox360_A));
     }
 
     return ret;
@@ -767,7 +767,7 @@ int Steam_Controller::GetAnalogActionOrigins( ControllerHandle_t controllerHandl
     EInputActionOrigin origins[STEAM_CONTROLLER_MAX_ORIGINS];
     int ret = GetAnalogActionOrigins(controllerHandle, actionSetHandle, analogActionHandle, origins );
     for (int i = 0; i < ret; ++i) {
-        originsOut[i] = (EControllerActionOrigin)(origins[i] - (k_EInputActionOrigin_XBox360_A - k_EControllerActionOrigin_XBox360_A));
+        originsOut[i] = (EControllerActionOrigin)(origins[i] - ((long)k_EInputActionOrigin_XBox360_A - (long)k_EControllerActionOrigin_XBox360_A));
     }
 
     return ret;

--- a/dll/steam_gamestats.cpp
+++ b/dll/steam_gamestats.cpp
@@ -500,8 +500,8 @@ std::string Steam_GameStats::sanitize_csv_value(std::string_view value)
 void Steam_GameStats::save_session_to_disk(Steam_GameStats::Session_t &session, uint64 session_id)
 {
     auto folder = std::to_string(session.account_id) + "_" + std::to_string(session.rtTimeStarted) + "_" + std::to_string(session_id);
-    auto folder_p = std::filesystem::u8path(settings->steam_game_stats_reports_dir) / std::filesystem::u8path(folder);
-    auto folder_u8_str = folder_p.u8string();
+    auto folder_p = common_helpers::std_fs_path(settings->steam_game_stats_reports_dir) / common_helpers::std_fs_path(folder);
+    auto folder_u8_str = common_helpers::u8str_to_str( folder_p.u8string() );
 
     // save session attributes
     if (session.attributes.size()) {

--- a/dll/steam_http.cpp
+++ b/dll/steam_http.cpp
@@ -194,7 +194,7 @@ void Steam_HTTP::online_http_request(Steam_Http_Request *request, SteamAPICall_t
     PRINT_DEBUG("attempting to download from url: '%s', target filepath: '%s'",
         request->url.c_str(), request->target_filepath.c_str());
 
-    const auto send_callresult = [=]() -> void {
+    const auto send_callresult = [=, this]() -> void {
         struct HTTPRequestCompleted_t data{};
         data.m_hRequest = request->handle;
         data.m_ulContextValue = request->context_value;

--- a/dll/steam_remote_storage.cpp
+++ b/dll/steam_remote_storage.cpp
@@ -16,6 +16,7 @@
    <http://www.gnu.org/licenses/>.  */
 
 #include "dll/steam_remote_storage.h"
+#include <filesystem>
 
 
 Downloaded_File::Downloaded_File(DownloadSource src)
@@ -32,13 +33,13 @@ static void copy_file(const std::string &src_filepath, const std::string &dst_fi
     try
     {
         PRINT_DEBUG("copying file '%s' to '%s'", src_filepath.c_str(), dst_filepath.c_str());
-        const auto src_p(std::filesystem::u8path(src_filepath));
+        const auto src_p = common_helpers::std_fs_path(src_filepath);
         
         if (!common_helpers::file_exist(src_p)) return;
         
-        const auto dst_p(std::filesystem::u8path(dst_filepath));
-        std::filesystem::create_directories(dst_p.parent_path()); // make the folder tree if needed
-        std::filesystem::copy_file(src_p, dst_p, std::filesystem::copy_options::overwrite_existing);
+        const auto dst_p = common_helpers::std_fs_path(dst_filepath);
+        common_helpers::create_dir(dst_p.parent_path()); // make the folder tree if needed
+        std::filesystem::copy_file(src_p, dst_p, std::filesystem::copy_options::overwrite_existing | std::filesystem::copy_options::copy_symlinks);
     } catch(...) {}
 }
 

--- a/dll/steam_user_stats.cpp
+++ b/dll/steam_user_stats.cpp
@@ -69,7 +69,7 @@ Steam_User_Stats::Steam_User_Stats(Settings *settings, class Networking *network
             try {
                 trig.name = name;
                 trig.value_operation = static_cast<std::string const&>(it["progress"]["value"]["operation"]);
-                std::string stat_name = common_helpers::ascii_to_lowercase(static_cast<std::string const&>(it["progress"]["value"]["operand1"]));
+                std::string stat_name = common_helpers::to_lower(static_cast<std::string const&>(it["progress"]["value"]["operand1"]));
                 trig.min_value = static_cast<std::string const&>(it["progress"]["min_val"]);
                 trig.max_value = static_cast<std::string const&>(it["progress"]["max_val"]);
                 achievement_stat_trigger[stat_name].push_back(trig);

--- a/dll/steam_user_stats_leaderboard.cpp
+++ b/dll/steam_user_stats_leaderboard.cpp
@@ -81,7 +81,7 @@ std::vector<Steam_Leaderboard_Entry> Steam_User_Stats::load_leaderboard_entries(
 
     std::vector<Steam_Leaderboard_Entry> out{};
 
-    std::string leaderboard_name(common_helpers::ascii_to_lowercase(name));
+    std::string leaderboard_name(common_helpers::to_lower(name));
     unsigned read_bytes = local_storage->file_size(Local_Storage::leaderboard_storage_folder, leaderboard_name);
     if ((read_bytes == 0) ||
         (read_bytes < (ELEMENT_SIZE * MAIN_HEADER_ELEMENTS_COUNT)) ||
@@ -138,7 +138,7 @@ void Steam_User_Stats::save_my_leaderboard_entry(const Steam_Leaderboard &leader
         output.push_back(detail);
     }
 
-    std::string leaderboard_name(common_helpers::ascii_to_lowercase(leaderboard.name));
+    std::string leaderboard_name(common_helpers::to_lower(leaderboard.name));
     unsigned int buffer_size = static_cast<unsigned int>(output.size() * sizeof(output[0])); // in bytes
     local_storage->store_data(Local_Storage::leaderboard_storage_folder, leaderboard_name, (char* )&output[0], buffer_size);
 }
@@ -186,7 +186,7 @@ unsigned int Steam_User_Stats::cache_leaderboard_ifneeded(const std::string &nam
 
     // create a new entry in-memory and try reading the entries from disk
     struct Steam_Leaderboard new_board{};
-    new_board.name = common_helpers::ascii_to_lowercase(name);
+    new_board.name = common_helpers::to_lower(name);
     new_board.sort_method = eLeaderboardSortMethod;
     new_board.display_type = eLeaderboardDisplayType;
     new_board.entries = load_leaderboard_entries(name);
@@ -318,7 +318,7 @@ SteamAPICall_t Steam_User_Stats::FindLeaderboard( const char *pchLeaderboardName
         return ret;
     }
 
-    std::string name_lower(common_helpers::ascii_to_lowercase(pchLeaderboardName));
+    std::string name_lower(common_helpers::to_lower(pchLeaderboardName));
     const auto &settings_Leaderboards = settings->getLeaderboards();
     auto it = settings_Leaderboards.begin();
     for (;  settings_Leaderboards.end() != it; ++it) {

--- a/dll/steam_user_stats_stats.cpp
+++ b/dll/steam_user_stats_stats.cpp
@@ -28,7 +28,7 @@ bool Steam_User_Stats::clear_stats_internal()
     bool notify_server = false;
     
     for (const auto &stat : settings->getStats()) {
-        std::string stat_name(common_helpers::ascii_to_lowercase(stat.first));
+        std::string stat_name(common_helpers::to_lower(stat.first));
 
         switch (stat.second.type)
         {
@@ -79,7 +79,7 @@ Steam_User_Stats::InternalSetResult<int32> Steam_User_Stats::set_stat_internal( 
     Steam_User_Stats::InternalSetResult<int32> result{};
 
     if (!pchName) return result;
-    std::string stat_name(common_helpers::ascii_to_lowercase(pchName));
+    std::string stat_name(common_helpers::to_lower(pchName));
 
     const auto &stats_config = settings->getStats();
     auto stats_data = stats_config.find(stat_name);
@@ -152,7 +152,7 @@ Steam_User_Stats::InternalSetResult<std::pair<GameServerStats_Messages::StatInfo
     Steam_User_Stats::InternalSetResult<std::pair<GameServerStats_Messages::StatInfo::Stat_Type, float>> result{};
 
     if (!pchName) return result;
-    std::string stat_name(common_helpers::ascii_to_lowercase(pchName));
+    std::string stat_name(common_helpers::to_lower(pchName));
 
     const auto &stats_config = settings->getStats();
     auto stats_data = stats_config.find(stat_name);
@@ -226,7 +226,7 @@ Steam_User_Stats::InternalSetResult<std::pair<GameServerStats_Messages::StatInfo
     Steam_User_Stats::InternalSetResult<std::pair<GameServerStats_Messages::StatInfo::Stat_Type, float>> result{};
 
     if (!pchName) return result;
-    std::string stat_name(common_helpers::ascii_to_lowercase(pchName));
+    std::string stat_name(common_helpers::to_lower(pchName));
 
     const auto &stats_config = settings->getStats();
     auto stats_data = stats_config.find(stat_name);
@@ -305,7 +305,7 @@ bool Steam_User_Stats::GetStat( const char *pchName, int32 *pData )
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
     if (!pchName) return false;
-    std::string stat_name = common_helpers::ascii_to_lowercase(pchName);
+    std::string stat_name = common_helpers::to_lower(pchName);
 
     const auto &stats_config = settings->getStats();
     auto stats_data = stats_config.find(stat_name);
@@ -344,7 +344,7 @@ bool Steam_User_Stats::GetStat( const char *pchName, float *pData )
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
     if (!pchName) return false;
-    std::string stat_name = common_helpers::ascii_to_lowercase(pchName);
+    std::string stat_name = common_helpers::to_lower(pchName);
 
     const auto &stats_config = settings->getStats();
     auto stats_data = stats_config.find(stat_name);
@@ -531,7 +531,7 @@ bool Steam_User_Stats::ResetAllStats( bool bAchievementsToo )
     clear_stats_internal(); // this will save stats to disk if necessary
     if (!settings->disable_sharing_stats_with_gameserver) {
         for (const auto &stat : settings->getStats()) {
-            std::string stat_name(common_helpers::ascii_to_lowercase(stat.first));
+            std::string stat_name(common_helpers::to_lower(stat.first));
 
             auto &new_stat = (*pending_server_updates.mutable_user_stats())[stat_name];
             new_stat.set_stat_type(stat.second.type);

--- a/helpers/common_helpers.cpp
+++ b/helpers/common_helpers.cpp
@@ -109,7 +109,12 @@ std::u8string common_helpers::filesystem_str(const std::string &str)
     return std::u8string(reinterpret_cast<const char8_t* const>(str.data()), str.size());
 }
 
-std::string_view common_helpers::u8str_to_str(std::u8string_view u8str) noexcept
+const char* common_helpers::u8str_to_str(const char8_t *u8str)
+{
+    return reinterpret_cast<const char*>(u8str);
+}
+
+std::string_view common_helpers::u8str_to_str(std::u8string_view u8str)
 {
     return std::string_view(reinterpret_cast<const char* const>(u8str.data()), u8str.size());
 }

--- a/helpers/common_helpers/common_helpers.hpp
+++ b/helpers/common_helpers/common_helpers.hpp
@@ -11,7 +11,13 @@
 #include <thread>
 #include <mutex>
 #include <condition_variable>
+#include <cctype>
+#include <algorithm>
+#include <concepts>
+#include <type_traits>
 
+
+// class KillableWorker
 namespace common_helpers {
 
 class KillableWorker
@@ -50,57 +56,255 @@ public:
     void kill();
 };
 
-bool create_dir(std::string_view dir);
-bool create_dir(std::wstring_view dir);
+}
+
+
+// helper c++ concepts for templates
+namespace common_helpers {
+
+template<typename T>
+using remove_cvrefptr = std::remove_cvref< std::remove_pointer_t<T> >;
+template<typename T>
+using remove_cvrefptr_t = remove_cvrefptr<T>::type;
+
+template <typename TString>
+concept BsicStringable = requires {
+    typename TString::value_type;
+} && (
+    std::is_same_v< std::basic_string<typename TString::value_type>, TString > ||
+    std::is_same_v< std::basic_string_view<typename TString::value_type>, TString >
+);
+
+// (const char*)"str"
+template <typename TString>
+concept StaticPtrStringable =
+    std::is_pointer_v<TString> &&
+    !std::is_null_pointer_v<TString> &&
+    std::is_integral_v< remove_cvrefptr_t<TString> >;
+
+// (const char[4])"str"
+template <typename TString>
+concept StaticArrayStringable =
+    std::is_array_v< std::remove_cvref_t<TString> > &&
+    std::is_integral_v< std::remove_extent_t< std::remove_cvref_t<TString> > >;
+
+template <typename TString>
+concept StaticStringable = StaticPtrStringable<TString> || StaticArrayStringable<TString>;
+
+template <typename TString>
+concept StringViewable = BsicStringable<TString> || StaticStringable<TString>;
+
+template<typename T>
+struct str_info;
+
+template<BsicStringable TString>
+struct str_info<TString>
+{
+    using char_type = TString::value_type;
+};
+
+template<StaticStringable TString>
+struct str_info<TString>
+{
+    using char_type = std::remove_extent_t< remove_cvrefptr_t<TString> >;
+};
+
+template <typename TString>
+using str_info_t = str_info<TString>::char_type;
+
+}
+
+
+namespace common_helpers {
+
+std::u8string_view filesystem_str(std::string_view str) noexcept;
+std::u8string filesystem_str(const std::string &str);
+template<typename TChar>
+    requires (!std::is_same_v<TChar, char>)
+constexpr std::basic_string_view<TChar> filesystem_str(std::basic_string_view<TChar> str)
+{
+    // all other types are fine, only char has to be casted to char8_t
+    return str;
+}
+template<typename TChar>
+    requires (!std::is_same_v<TChar, char>)
+constexpr std::basic_string<TChar> filesystem_str(const std::basic_string<TChar> &str)
+{
+    // all other types are fine, only char has to be casted to char8_t
+    return std::basic_string<TChar>(str);
+}
+
+std::string_view u8str_to_str(std::u8string_view u8str) noexcept;
+std::string u8str_to_str(const std::u8string &u8str);
+
+template<StringViewable TString, typename TChar = str_info_t<TString>>
+constexpr std::filesystem::path std_fs_path(const TString &tpath)
+{
+    std::basic_string_view<TChar> path(tpath);
+    return std::filesystem::path(filesystem_str(path));
+}
+
+bool create_dir(const std::filesystem::path &dirpath);
+template<StringViewable TString, typename TChar = str_info_t<TString>>
+constexpr bool create_dir(const TString &tfilepath)
+{
+    std::basic_string_view<TChar> filepath(tfilepath);
+    const auto parent(std_fs_path(filepath).parent_path());
+    return create_dir(parent);
+}
 
 void write(std::ofstream &file, std::string_view data);
 
-std::wstring str_to_w(std::string_view str);
-std::string wstr_to_a(std::wstring_view wstr);
+template<StringViewable TString1, StringViewable TString2, typename TChar = str_info_t<TString1>>
+    requires std::is_same_v<TChar, str_info_t<TString2>>
+bool str_cmp_insensitive(const TString1 &tstr1, const TString2 &tstr2)
+{
+    std::basic_string_view<TChar> str1(tstr1);
+    std::basic_string_view<TChar> str2(tstr2);
+    if (str1.size() != str2.size()) return false;
 
-bool starts_with_i(std::string_view target, std::string_view query);
-bool starts_with_i(std::wstring_view target, std::wstring_view query);
+    return std::equal(str1.begin(), str1.end(), str2.begin(), [](const TChar c1, const TChar c2){
+        return std::toupper(c1) == std::toupper(c2);
+    });
+}
 
-bool ends_with_i(std::string_view target, std::string_view query);
-bool ends_with_i(std::wstring_view target, std::wstring_view query);
+template<StringViewable TStringT, StringViewable TStringQ, typename TChar = str_info_t<TStringT>>
+    requires std::is_same_v<TChar, str_info_t<TStringQ>>
+bool starts_with_i(const TStringT &ttarget, const TStringQ &tquery)
+{
+    std::basic_string_view<TChar> target(ttarget);
+    std::basic_string_view<TChar> query(tquery);
+    if (target.size() < query.size()) {
+        return false;
+    }
 
-std::string string_strip(std::string_view str);
+    return str_cmp_insensitive(target.substr(0, query.size()), query);
+}
+
+template<StringViewable TStringT, StringViewable TStringQ, typename TChar = str_info_t<TStringT>>
+    requires std::is_same_v<TChar, str_info_t<TStringQ>>
+bool ends_with_i(const TStringT &ttarget, const TStringQ &tquery)
+{
+    std::basic_string_view<TChar> target(ttarget);
+    std::basic_string_view<TChar> query(tquery);
+    if (target.size() < query.size()) {
+        return false;
+    }
+
+    const auto target_offset = target.length() - query.length();
+    return str_cmp_insensitive(target.substr(target_offset), query);
+}
+
+template<StringViewable TString, typename TChar = str_info_t<TString>>
+std::basic_string<TChar> string_strip(const TString &tstr)
+{
+    std::basic_string_view<TChar> str(tstr);
+    if (str.empty()) return {};
+
+    static constexpr const char whitespaces[] = " \t\r\n";
+    
+    const auto start = str.find_first_not_of(whitespaces);
+    const auto end = str.find_last_not_of(whitespaces);
+    
+    if (std::basic_string<TChar>::npos == start) return {};
+
+    if (start == end) { // happens when string is 1 char
+        auto c = str[start];
+        for (auto c_white = whitespaces; *c_white; ++c_white) {
+            if (c == *c_white) return {};
+        }
+    }
+
+    return std::basic_string<TChar>(str.substr(start, end - start + 1));
+}
 
 std::string uint8_vector_to_hex_string(const std::vector<uint8_t> &v);
-
-bool str_cmp_insensitive(std::string_view str1, std::string_view str2);
-bool str_cmp_insensitive(std::wstring_view str1, std::wstring_view str2);
-
-std::string ascii_to_lowercase(std::string data);
 
 void thisThreadYieldFor(std::chrono::microseconds u);
 
 void consume_bom(std::ifstream &input);
 
-std::string to_lower(std::string_view str);
-std::wstring to_lower(std::wstring_view wstr);
+template<StringViewable TString, typename TChar = str_info_t<TString>>
+std::basic_string<TChar> to_lower(const TString &tstr)
+{
+    std::basic_string_view<TChar> str(tstr);
+    if (str.empty()) return {};
 
-std::string to_upper(std::string_view str);
-std::wstring to_upper(std::wstring_view wstr);
+    std::basic_string<TChar> _str(str.size(), 0);
+    std::transform(str.begin(), str.end(), _str.begin(), [](TChar c) { return std::tolower(c); });
+    return _str;
+}
 
-std::string to_absolute(std::string_view path, std::string_view base = std::string_view());
-std::wstring to_absolute(std::wstring_view path, std::wstring_view base = std::wstring_view());
+template<StringViewable TString, typename TChar = str_info_t<TString>>
+std::basic_string<TChar> to_upper(const TString &tstr)
+{
+    std::basic_string_view<TChar> str(tstr);
+    if (str.empty()) return {};
+
+    std::basic_string<TChar> _str(str.size(), 0);
+    std::transform(str.begin(), str.end(), _str.begin(), [](TChar c) { return std::toupper(c); });
+    return _str;
+}
+
+std::filesystem::path to_absolute(const std::filesystem::path &path, const std::filesystem::path &base);
+template<StringViewable TStringP, StringViewable TStringB, typename TChar = str_info_t<TStringP>>
+    requires std::is_same_v<TChar, str_info_t<TStringB>>
+std::basic_string<TChar> to_absolute(const TStringP &tpath, const TStringB &tbase = "")
+{
+    std::basic_string_view<TChar> path(tpath);
+    std::basic_string_view<TChar> base(tbase);
+    if (path.empty()) return {};
+    std::filesystem::path path_abs = to_absolute(
+        std_fs_path(path),
+        base.empty() ? std::filesystem::current_path() : std_fs_path(base)
+    );
+    return u8str_to_str(path_abs.u8string());
+}
+
+std::filesystem::path to_canonical(const std::filesystem::path &path);
+template<StringViewable TString, typename TChar = str_info_t<TString>>
+std::basic_string<TChar> to_canonical(const TString &tpath)
+{
+    std::basic_string_view<TChar> path(tpath);
+    std::filesystem::path path_canon = to_canonical(std_fs_path(path));
+    return u8str_to_str( path_canon.u8string() );
+}
 
 bool file_exist(const std::filesystem::path &filepath);
-bool file_exist(const std::string &filepath);
-bool file_exist(const std::wstring &filepath);
+template<StringViewable TString, typename TChar = str_info_t<TString>>
+bool file_exist(const TString &tfilepath)
+{
+    std::basic_string_view<TChar> filepath(tfilepath);
+    if (filepath.empty()) return false;
+    return file_exist(std_fs_path(filepath));
+}
 
 bool file_size(const std::filesystem::path &filepath, size_t &size);
-bool file_size(const std::string &filepath, size_t &size);
-bool file_size(const std::wstring &filepath, size_t &size);
+template<StringViewable TString, typename TChar = str_info_t<TString>>
+bool file_size(const TString &tfilepath, size_t &size)
+{
+    std::basic_string_view<TChar> filepath(tfilepath);
+    return file_size(std_fs_path(filepath), size);
+}
 
 bool dir_exist(const std::filesystem::path &dirpath);
-bool dir_exist(const std::string &dirpath);
-bool dir_exist(const std::wstring &dirpath);
+template<StringViewable TString, typename TChar = str_info_t<TString>>
+bool dir_exist(const TString &tdirpath)
+{
+    std::basic_string_view<TChar> dirpath(tdirpath);
+    if (dirpath.empty()) return false;
+    return dir_exist(std_fs_path(dirpath));
+}
 
 bool remove_file(const std::filesystem::path &filepath);
-bool remove_file(const std::string &filepath);
-bool remove_file(const std::wstring &filepath);
+template<StringViewable TString, typename TChar = str_info_t<TString>>
+bool remove_file(const TString &tfilepath)
+{
+    std::basic_string_view<TChar> filepath(tfilepath);
+    return remove_file(std_fs_path(filepath));
+}
+
+std::string get_current_dir();
 
 // between 0 and max, 0 and max are included
 size_t rand_number(size_t max);
@@ -110,6 +314,58 @@ std::string get_utc_time();
 std::wstring to_wstr(std::string_view str);
 std::string to_str(std::wstring_view wstr);
 
-std::string str_replace_all(std::string_view source, std::string_view substr, std::string_view replace);
+template<StringViewable TStringSrc, StringViewable TStringSub, StringViewable TStringRep, typename TChar = str_info_t<TStringSrc>>
+    requires std::is_same_v<TChar, str_info_t<TStringSub>> && std::is_same_v<TChar, str_info_t<TStringRep>>
+std::basic_string<TChar> str_replace_all(const TStringSrc &tsource, const TStringSub &tsubstr, const TStringRep &treplace)
+{
+    std::basic_string_view<TChar> source(tsource);
+    std::basic_string_view<TChar> substr(tsubstr);
+    std::basic_string_view<TChar> replace(treplace);
+    if (source.empty() || substr.empty()) return std::basic_string<TChar>(source);
+
+    std::basic_string<TChar> out{};
+    out.reserve(source.size() / 4); // out could be bigger or smaller than source, start small
+
+    size_t start_offset = 0;
+    auto f_idx = source.find(substr);
+    while (std::basic_string<TChar>::npos != f_idx) {
+        // copy the chars before the match
+        auto chars_count_until_match = f_idx - start_offset;
+        out.append(source, start_offset, chars_count_until_match);
+        // copy the replace str
+        out.append(replace);
+
+        // adjust the start offset to point at the char after this match
+        start_offset = f_idx + substr.size();
+        // search for next match
+        f_idx = source.find(substr, start_offset);
+    }
+
+    // copy last remaining part
+    out.append(source, start_offset, std::basic_string<TChar>::npos);
+
+    return out;
+}
+
+std::fstream open_fstream(const std::filesystem::path &filepath, std::ios_base::openmode mode);
+template<StringViewable TString, typename TChar = str_info_t<TString>>
+std::fstream open_fstream(const TString &tfilepath, std::ios_base::openmode mode)
+{
+    return open_fstream( std_fs_path(tfilepath), mode );
+}
+
+std::ifstream open_fread(const std::filesystem::path &filepath, std::ios_base::openmode mode = std::ios_base::in);
+template<StringViewable TString, typename TChar = str_info_t<TString>>
+std::ifstream open_fread(const TString &tfilepath, std::ios_base::openmode mode = std::ios_base::in)
+{
+    return open_fread( std_fs_path(tfilepath), mode );
+}
+
+std::ofstream open_fwrite(const std::filesystem::path &filepath, std::ios_base::openmode mode = std::ios_base::out);
+template<StringViewable TString, typename TChar = str_info_t<TString>>
+std::ofstream open_fwrite(const TString &tfilepath, std::ios_base::openmode mode = std::ios_base::out)
+{
+    return open_fwrite( std_fs_path(tfilepath), mode );
+}
 
 }

--- a/helpers/common_helpers/common_helpers.hpp
+++ b/helpers/common_helpers/common_helpers.hpp
@@ -134,7 +134,8 @@ constexpr std::basic_string<TChar> filesystem_str(const std::basic_string<TChar>
     return std::basic_string<TChar>(str);
 }
 
-std::string_view u8str_to_str(std::u8string_view u8str) noexcept;
+const char* u8str_to_str(const char8_t *u8str);
+std::string_view u8str_to_str(std::u8string_view u8str);
 std::string u8str_to_str(const std::u8string &u8str);
 
 template<StringViewable TString, typename TChar = str_info_t<TString>>

--- a/helpers/dbg_log.cpp
+++ b/helpers/dbg_log.cpp
@@ -1,16 +1,14 @@
 #include "dbg_log/dbg_log.hpp"
 #include "common_helpers/common_helpers.hpp"
 #include "utfcpp/utf8.h"
+#include "common_helpers/os_detector.h"
 
 #include <iterator>
 #include <cwchar>
 #include <cstdarg>
-#include <filesystem>
 #include <sstream>
 #include <string>
 #include <stdio.h>
-
-#include "common_helpers/os_detector.h"
 
 
 void dbg_log::open()
@@ -19,7 +17,7 @@ void dbg_log::open()
 	if (!out_file && filepath.size()) {
 
 		// https://en.cppreference.com/w/cpp/filesystem/path/u8path
-		const auto fsp = std::filesystem::u8path(filepath);
+		const auto fsp = common_helpers::std_fs_path(filepath);
 #if defined(__WINDOWS__)
 		out_file = _wfopen(fsp.c_str(), L"at");
 #else

--- a/premake5.lua
+++ b/premake5.lua
@@ -183,7 +183,7 @@ end
 -- common defines
 ---------
 local common_emu_defines = { -- added to all filters, later defines will be appended
-    "UTF_CPP_CPLUSPLUS=201703L", "CURL_STATICLIB", "CONTROLLER_SUPPORT", "EMU_BUILD_STRING=" .. _OPTIONS["emubuild"],
+    "CURL_STATICLIB", "CONTROLLER_SUPPORT", "EMU_BUILD_STRING=" .. _OPTIONS["emubuild"],
 }
 
 -- include dirs
@@ -479,7 +479,7 @@ filter {} -- reset the filter and remove all active keywords
 configurations { "debug", "release", }
 platforms { "x64", "x32", }
 language "C++"
-cppdialect "C++17"
+cppdialect "C++20"
 cdialect "C17"
 filter { "system:not windows", "action:gmake*" , }
     cdialect("gnu17") -- gamepad.c relies on some linux-specific functions like strdup() and MAX_PATH
@@ -546,7 +546,11 @@ filter { "configurations:*release", }
 filter { "action:vs*", }
     buildoptions  {
         "/permissive-", "/DYNAMICBASE", "/bigobj",
-        "/utf-8", "/Zc:char8_t-", "/EHsc", "/GL-"
+        "/utf-8", "/EHsc", "/GL-",
+        -- fix __cplusplus version on Visual Studio
+        -- https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
+        -- https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus
+        "/Zc:__cplusplus",
     }
     linkoptions  {
         -- source of emittoolversioninfo: https://developercommunity.visualstudio.com/t/add-linker-option-to-strip-rich-stamp-from-exe-hea/740443
@@ -560,11 +564,6 @@ filter { "action:gmake*", }
     }
     linkoptions {
         "-Wl,--exclude-libs,ALL",
-    }
--- this is made separate because GCC complains but not CLANG
-filter { "action:gmake*" , "files:*.cpp or *.cxx or *.cc or *.hpp or *.hxx", }
-    buildoptions  {
-        "-fno-char8_t", -- GCC gives a warning when a .c file is compiled with this
     }
 filter {} -- reset the filter and remove all active keywords
 
@@ -1146,7 +1145,9 @@ project "tool_generate_interfaces"
     -- common source & header files
     ---------
     files {
-        "tools/generate_interfaces/generate_interfaces.cpp"
+        "tools/generate_interfaces/generate_interfaces.cpp",
+        'helpers/common_helpers.cpp', 'helpers/common_helpers/**',
+        'libs/utfcpp/**',
     }
 -- End tool_generate_interfaces
 
@@ -1165,6 +1166,7 @@ project "lib_steamnetworkingsockets"
         "networking_sockets_lib/**",
         "helpers/dbg_log.cpp", "helpers/dbg_log/**",
         'helpers/common_helpers.cpp', 'helpers/common_helpers/**',
+        'libs/utfcpp/**',
     }
 
 
@@ -1299,6 +1301,7 @@ project "steamclient_experimental_extra"
         "tools/steamclient_loader/win/extra_protection/**",
         "helpers/pe_helpers.cpp", "helpers/pe_helpers/**",
         "helpers/common_helpers.cpp", "helpers/common_helpers/**",
+        'libs/utfcpp/**',
         -- detours
         detours_files,
     }
@@ -1342,9 +1345,10 @@ project "steamclient_experimental_loader"
     filter {} -- reset the filter and remove all active keywords
     files {
         "tools/steamclient_loader/win/*", -- we want the .ini too
+        "helpers/dbg_log.cpp", "helpers/dbg_log/**",
         "helpers/pe_helpers.cpp", "helpers/pe_helpers/**",
         "helpers/common_helpers.cpp", "helpers/common_helpers/**",
-        "helpers/dbg_log.cpp", "helpers/dbg_log/**",
+        'libs/utfcpp/**',
         "libs/simpleini/**",
     }
     -- x32 common source files
@@ -1384,6 +1388,7 @@ project "tool_file_dos_stub_changer"
         "resources/win/file_dos_stub/file_dos_stub.cpp",
         "helpers/pe_helpers.cpp", "helpers/pe_helpers/**",
         "helpers/common_helpers.cpp", "helpers/common_helpers/**",
+        'libs/utfcpp/**',
     }
 -- End tool_file_dos_stub_changer
 
@@ -1404,6 +1409,7 @@ project "test_crash_printer"
         'crash_printer/' .. os_iden .. '.cpp', 'crash_printer/crash_printer/' .. os_iden .. '.hpp',
         -- helpers
         'helpers/common_helpers.cpp', 'helpers/common_helpers/**',
+        'libs/utfcpp/**',
         -- test files
         'crash_printer/tests/test_win.cpp',
     }
@@ -1518,6 +1524,7 @@ project "test_crash_printer_sa_handler"
         'crash_printer/' .. os_iden .. '.cpp', 'crash_printer/crash_printer/' .. os_iden .. '.hpp',
         -- helpers
         'helpers/common_helpers.cpp', 'helpers/common_helpers/**',
+        'libs/utfcpp/**',
         -- test files
         'crash_printer/tests/test_linux_sa_handler.cpp',
     }
@@ -1553,6 +1560,7 @@ project "test_crash_printer_sa_sigaction"
         'crash_printer/' .. os_iden .. '.cpp', 'crash_printer/crash_printer/' .. os_iden .. '.hpp',
         -- helpers
         'helpers/common_helpers.cpp', 'helpers/common_helpers/**',
+        'libs/utfcpp/**',
         -- test files
         'crash_printer/tests/test_linux_sa_sigaction.cpp',
     }

--- a/resources/win/file_dos_stub/file_dos_stub.cpp
+++ b/resources/win/file_dos_stub/file_dos_stub.cpp
@@ -1,9 +1,9 @@
 #include <fstream>
 #include <iostream>
 #include <vector>
-#include <filesystem>
 
 #include "pe_helpers/pe_helpers.hpp"
+#include "common_helpers/common_helpers.hpp"
 
 static size_t get_file_size(std::fstream &file)
 {
@@ -58,7 +58,7 @@ int main(int argc, char* *argv)
 
     for (size_t i = 1; i < (size_t)argc; ++i) {
         auto arg = argv[i];
-        std::fstream file(std::filesystem::u8path(arg), std::ios::in | std::ios::out | std::ios::binary);
+        std::fstream file( common_helpers::open_fstream(arg, std::ios::in | std::ios::out | std::ios::binary ) );
         if (!file.is_open()) {
             std::cerr << "Failed to open file: '" << arg << "'" << std::endl;
             return 1;

--- a/tools/generate_interfaces/generate_interfaces.cpp
+++ b/tools/generate_interfaces/generate_interfaces.cpp
@@ -2,7 +2,9 @@
 #include <string>
 #include <fstream>
 #include <iostream>
-#include <filesystem>
+
+#include "common_helpers/common_helpers.hpp"
+
 
 // these are defined in dll.cpp at the top like this:
 // static char old_xxx[128] = ...
@@ -68,7 +70,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    std::ifstream steam_api_file(std::filesystem::u8path(argv[1]), std::ios::binary);
+    std::ifstream steam_api_file( common_helpers::open_fread(argv[1], std::ios::in | std::ios::binary) );
     if (!steam_api_file)
     {
         std::cerr << "Error opening file: " << argv[1] << std::endl;
@@ -85,7 +87,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    std::ofstream out_file("steam_interfaces.txt");
+    std::ofstream out_file(common_helpers::open_fwrite("steam_interfaces.txt"));
     if (!out_file)
     {
         std::cerr << "Error opening output file" << std::endl;

--- a/tools/lobby_connect/lobby_connect.cpp
+++ b/tools/lobby_connect/lobby_connect.cpp
@@ -109,19 +109,19 @@ top:
 
     auto readLobbyFile = [&lobbyFile]() {
         std::string data;
-        std::ifstream ifs(std::filesystem::u8path(lobbyFile));
+        std::ifstream ifs(common_helpers::open_fread(lobbyFile));
         if (ifs.is_open())
             std::getline(ifs, data);
         return data;
     };
 
     auto writeLobbyFile = [&lobbyFile](const std::string& data) {
-        std::ofstream ofs(std::filesystem::u8path(lobbyFile));
+        std::ofstream ofs(common_helpers::open_fwrite(lobbyFile));
         ofs << data << std::endl;
     };
 
     auto fileExists = [](const std::string& filename) {
-        std::ifstream ifs(std::filesystem::u8path(filename));
+        std::ifstream ifs(common_helpers::open_fread(filename));
         return ifs.is_open();
     };
     


### PR DESCRIPTION
not because it is needed, but because `C++17` is getting older by now

* update language version in main premake script to `C++23`
* allow `char8_t` type
* fix `__cplusplus` version setting on Visual Studio
* avoid manually specifying lang version for `utfcpp` lib
* add missing files include for `utfcpp` lib in many projects
* rewrite common helpers to use templates + some of the `C++20` templated concepts
* fix the problematic utf-8 path handling when opening files via helper functions

I would suggest not merging this immediately, you have to test paths handling, I can't test every scenario unfortunately.
if this was ever merged, please always encourage opening files via one of these:
- `common_helpers::open_fread()` -> `std::ifstream`
- `common_helpers::open_fwrite()` -> `std::ofstream`
- `common_helpers::open_fstream()` -> `std::fstream`
- `common_helpers::std_fs_path()` -> `std::filesystem::path`

`common_helpers::filesystem_str()` isn't related to files, but does the appropriate conversion to the useless new types `std::u8string`/`std::u8string_view`/`char8_t*` for later usage by `std::filesystem::path` when needed.

`common_helpers::u8str_to_str()` isn't also related to files, but changes the same useless new types back to `std::string`

no need to build deps again