### PR TITLE
Correct undocumented api in `ISteamNetworkingSockets010` and `ISteamNetworkingSockets011`

### DIFF
--- a/dll/dll/steam_networking_sockets.h
+++ b/dll/dll/steam_networking_sockets.h
@@ -490,9 +490,6 @@ public:
     /// - k_EResultInvalidParam - nLanes is bad
     EResult GetConnectionRealTimeStatus( HSteamNetConnection hConn, SteamNetConnectionRealTimeStatus_t *pStatus, int nLanes, SteamNetConnectionRealTimeLaneStatus_t *pLanes );
 
-    // based on reversing the vftable returned from original steamclient64.dll
-    bool GetConnectionRealTimeStatus_old( HSteamNetConnection hConn, SteamNetConnectionRealTimeStatus_t *pStatus );
-
     /// Fetch the next available message(s) from the socket, if any.
     /// Returns the number of messages returned into your array, up to nMaxMessages.
     /// If the connection handle is invalid, -1 is returned.

--- a/dll/steam_networking_sockets.cpp
+++ b/dll/steam_networking_sockets.cpp
@@ -950,24 +950,6 @@ EResult Steam_Networking_Sockets::GetConnectionRealTimeStatus( HSteamNetConnecti
     return k_EResultOK;
 }
 
-// based on reversing the vftable returned from original steamclient64.dll
-bool Steam_Networking_Sockets::GetConnectionRealTimeStatus_old( HSteamNetConnection hConn, SteamNetConnectionRealTimeStatus_t *pStatus )
-{
-    PRINT_DEBUG("undocumented API, interface v10-11");
-    /*
-    ...
-    xor     r9d, r9d                                 // int nLanes = 0
-    mov     qword ptr ss:[rsp+0x20], 0x0             // SteamNetConnectionRealTimeLaneStatus_t *pLanes = nullptr
-    ...
-    call    qword ptr ds:[rax+0x80]                  // call GetConnectionRealTimeStatus(hConn, pStatus, nLanes, pLanes)
-    test    eax, eax
-    setne   al                                       if (eax !=0) { al=1 } else { al=0 }
-    ...
-    ret     
-    */
-    return GetConnectionRealTimeStatus(hConn, pStatus, 0, nullptr) != EResult::k_EResultNone;
-}
-
 /// Fetch the next available message(s) from the socket, if any.
 /// Returns the number of messages returned into your array, up to nMaxMessages.
 /// If the connection handle is invalid, -1 is returned.
@@ -1022,10 +1004,19 @@ bool Steam_Networking_Sockets::GetConnectionInfo( HSteamNetConnection hConn, Ste
 bool Steam_Networking_Sockets::GetQuickConnectionStatus( HSteamNetConnection hConn, SteamNetworkingQuickConnectionStatus *pStats )
 {
     PRINT_DEBUG_ENTRY();
-    if (!pStats)
-        return false;
-
-    return GetConnectionRealTimeStatus(hConn, pStats, 0, NULL) == k_EResultOK;
+    // based on reversing the vftable returned from original steamclient64.dll
+    /*
+    ...
+    xor     r9d, r9d                                 // int nLanes = 0
+    mov     qword ptr ss:[rsp+0x20], 0x0             // SteamNetConnectionRealTimeLaneStatus_t *pLanes = nullptr
+    ...
+    call    qword ptr ds:[rax+0x80]                  // call GetConnectionRealTimeStatus(hConn, pStatus, nLanes, pLanes)
+    test    eax, eax
+    setne   al                                       if (eax !=0) { al=1 } else { al=0 }
+    ...
+    ret     
+    */
+    return GetConnectionRealTimeStatus(hConn, pStats, 0, NULL) != k_EResultNone;
 }
 
 

--- a/sdk/steam/isteamnetworkingsockets010.h
+++ b/sdk/steam/isteamnetworkingsockets010.h
@@ -301,8 +301,9 @@ public:
 	/// Returns basic information about the high-level state of the connection.
 	virtual bool GetConnectionInfo( HSteamNetConnection hConn, SteamNetConnectionInfo_t *pInfo ) = 0;
 
-	// based on reversing the vftable returned from original steamclient64.dll
-	virtual bool GetConnectionRealTimeStatus_old( HSteamNetConnection hConn, SteamNetConnectionRealTimeStatus_t *pStatus ) = 0;
+	/// Returns a small set of information about the real-time state of the connection
+	/// Returns false if the connection handle is invalid, or the connection has ended.
+	virtual bool GetQuickConnectionStatus( HSteamNetConnection hConn, SteamNetworkingQuickConnectionStatus *pStats ) = 0;
 
 	/// Returns detailed connection stats in text format.  Useful
 	/// for dumping to a log, etc.

--- a/sdk/steam/isteamnetworkingsockets011.h
+++ b/sdk/steam/isteamnetworkingsockets011.h
@@ -301,8 +301,9 @@ public:
 	/// Returns basic information about the high-level state of the connection.
 	virtual bool GetConnectionInfo( HSteamNetConnection hConn, SteamNetConnectionInfo_t *pInfo ) = 0;
 
-	// based on reversing the vftable returned from original steamclient64.dll
-	virtual bool GetConnectionRealTimeStatus_old( HSteamNetConnection hConn, SteamNetConnectionRealTimeStatus_t *pStatus ) = 0;
+	/// Returns a small set of information about the real-time state of the connection
+	/// Returns false if the connection handle is invalid, or the connection has ended.
+	virtual bool GetQuickConnectionStatus( HSteamNetConnection hConn, SteamNetworkingQuickConnectionStatus *pStats ) = 0;
 
 	/// Returns detailed connection stats in text format.  Useful
 	/// for dumping to a log, etc.


### PR DESCRIPTION
At first, great thanks to the reversed interfaces. However one function in `ISteamNetworkingSockets010` and `ISteamNetworkingSockets011` was mistakenly analyzed. According to my own reversing, the "undocumented `GetConnectionRealTimeStatus_old`" seems to be just previous `GetQuickConnectionStatus`, and judging by the result, original code there was simply wrong. So fix is here.