### PR TITLE
implement ISteamMasterServerUpdater as a proxy for ISteamGameServer

### DIFF
--- a/dll/dll/steam_masterserver_updater.h
+++ b/dll/dll/steam_masterserver_updater.h
@@ -18,7 +18,10 @@
 #ifndef __INCLUDED_STEAM_MASTERSERVER_UPDATER_H__
 #define __INCLUDED_STEAM_MASTERSERVER_UPDATER_H__
 
+
 #include "base.h"
+#include "dll/steam_gameserver.h"
+
 
 class Steam_Masterserver_Updater :
 public ISteamMasterServerUpdater
@@ -28,6 +31,7 @@ public ISteamMasterServerUpdater
     class SteamCallResults *callback_results{};
     class SteamCallBacks *callbacks{};
     class RunEveryRunCB *run_every_runcb{};
+    class Steam_GameServer *gameserver{};
 
     static void steam_callback(void *object, Common_Message *msg);
     static void steam_run_every_runcb(void *object);
@@ -36,7 +40,7 @@ public ISteamMasterServerUpdater
     void Callback(Common_Message *msg);
 
 public:
-    Steam_Masterserver_Updater(class Settings *settings, class Networking *network, class SteamCallResults *callback_results, class SteamCallBacks *callbacks, class RunEveryRunCB *run_every_runcb);
+    Steam_Masterserver_Updater(class Settings *settings, class Networking *network, class SteamCallResults *callback_results, class SteamCallBacks *callbacks, class RunEveryRunCB *run_every_runcb, class Steam_GameServer *gameserver);
     ~Steam_Masterserver_Updater();
 
     // Call this as often as you like to tell the master server updater whether or not

--- a/dll/steam_client.cpp
+++ b/dll/steam_client.cpp
@@ -143,7 +143,7 @@ Steam_Client::Steam_Client()
     steam_gameserver_networking_sockets_serialized = new Steam_Networking_Sockets_Serialized(settings_server, network, callback_results_server, callbacks_server, run_every_runcb);
     steam_gameserver_networking_messages = new Steam_Networking_Messages(settings_server, network, callback_results_server, callbacks_server, run_every_runcb);
     steam_gameserver_game_coordinator = new Steam_Game_Coordinator(settings_server, network, callback_results_server, callbacks_server, run_every_runcb);
-    steam_masterserver_updater = new Steam_Masterserver_Updater(settings_server, network, callback_results_server, callbacks_server, run_every_runcb);
+    steam_masterserver_updater = new Steam_Masterserver_Updater(settings_server, network, callback_results_server, callbacks_server, run_every_runcb, steam_gameserver);
     steam_gameserver_gamestats = new Steam_GameStats(settings_server, network, callback_results_server, callbacks_server, run_every_runcb);
 
     PRINT_DEBUG("init AppTicket");

--- a/dll/steam_gameserver.cpp
+++ b/dll/steam_gameserver.cpp
@@ -789,6 +789,7 @@ void Steam_GameServer::ForceHeartbeat()
 void Steam_GameServer::ForceMasterServerHeartbeat_DEPRECATED()
 {
     PRINT_DEBUG_TODO();
+    ForceHeartbeat();
 }
 
 
@@ -845,12 +846,14 @@ void Steam_GameServer::RunCallbacks()
     }
 
     if (temp_call_servers_disconnected) {
-        SteamServersDisconnected_t data;
+        PRINT_DEBUG("Gameserver is disconnected");
+        SteamServersDisconnected_t data{};
         data.m_eResult = k_EResultOK;
         callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
 
         if (!logged_in) {
-            Common_Message msg;
+            PRINT_DEBUG("notifying all that Gameserver is not logged in");
+            Common_Message msg{};
             msg.set_source_id(settings->get_local_steam_id().ConvertToUint64());
             msg.set_allocated_gameserver(new Gameserver(server_data));
             msg.mutable_gameserver()->set_offline(true);


### PR DESCRIPTION
solves and closes #74

game is using the very old interface ISteamMasterServerUpdater and expects a SteamServersDisconnected_t callback to shutdown server properly, also we have to notify everyone on the network that the server is now offline.
all of that are already implemented in ISteamGameServer, plus they have the same API set, hence it is made as a proxy.