### PR TITLE
Fix building on Linux

### DIFF
--- a/premake5-deps.lua
+++ b/premake5-deps.lua
@@ -632,6 +632,7 @@ if _OPTIONS["build-curl"] or _OPTIONS["all-build"] then
         "CURL_USE_LIBPSL=OFF",
         "USE_LIBIDN2=OFF",
         "CURL_DISABLE_LDAP=ON",
+        "USE_NGHTTP2=OFF",
     }
     if os.target() == 'windows' and string.match(_ACTION, 'vs.+') then
         table.insert(curl_common_defs, "CURL_STATIC_CRT=ON")


### PR DESCRIPTION
Since deps upgrade, Linux build is failing with some linking issue, here the first few lines.
```
Linking tool_lobby_connect
/usr/bin/ld: ../../../../deps/linux/gmake2/curl/install32/lib/libcurl.a(cf-h2-proxy.c.o): in function `proxy_h2_process_pending_input':
cf-h2-proxy.c:(.text+0x10b): undefined reference to `nghttp2_session_mem_recv'
/usr/bin/ld: cf-h2-proxy.c:(.text+0x21f): undefined reference to `nghttp2_strerror'
/usr/bin/ld: cf-h2-proxy.c:(.text+0x26f): undefined reference to `nghttp2_session_mem_recv'
/usr/bin/ld: ../../../../deps/linux/gmake2/curl/install32/lib/libcurl.a(cf-h2-proxy.c.o): in function `cf_h2_proxy_is_alive':
cf-h2-proxy.c:(.text+0x456): undefined reference to `nghttp2_session_want_read'
/usr/bin/ld: cf-h2-proxy.c:(.text+0x46f): undefined reference to `nghttp2_session_want_write'
/usr/bin/ld: ../../../../deps/linux/gmake2/curl/install32/lib/libcurl.a(cf-h2-proxy.c.o): in function `proxy_h2_progress_egress':
cf-h2-proxy.c:(.text+0x4d0): undefined reference to `nghttp2_session_want_write'
/usr/bin/ld: cf-h2-proxy.c:(.text+0x4e2): undefined reference to `nghttp2_session_send'
/usr/bin/ld: cf-h2-proxy.c:(.text+0x4f8): undefined reference to `nghttp2_is_fatal'
/usr/bin/ld: cf-h2-proxy.c:(.text+0x60e): undefined reference to `nghttp2_strerror'
/usr/bin/ld: ../../../../deps/linux/gmake2/curl/install32/lib/libcurl.a(cf-h2-proxy.c.o): in function `proxy_h2_on_stream_close':
cf-h2-proxy.c:(.text+0xa47): undefined reference to `nghttp2_http2_strerror'
/usr/bin/ld: ../../../../deps/linux/gmake2/curl/install32/lib/libcurl.a(cf-h2-proxy.c.o): in function `cf_h2_proxy_recv':
cf-h2-proxy.c:(.text+0xd85): undefined reference to `nghttp2_session_consume'
/usr/bin/ld: cf-h2-proxy.c:(.text+0x1099): undefined reference to `nghttp2_http2_strerror'
/usr/bin/ld: ../../../../deps/linux/gmake2/curl/install32/lib/libcurl.a(cf-h2-proxy.c.o): in function `cf_h2_proxy_adjust_pollset':
cf-h2-proxy.c:(.text+0x11ff): undefined reference to `nghttp2_session_want_write'
/usr/bin/ld: cf-h2-proxy.c:(.text+0x121d): undefined reference to `nghttp2_session_want_read'
/usr/bin/ld: cf-h2-proxy.c:(.text+0x12a4): undefined reference to `nghttp2_session_get_remote_window_size'
/usr/bin/ld: cf-h2-proxy.c:(.text+0x137c): undefined reference to `nghttp2_session_want_write'
/usr/bin/ld: cf-h2-proxy.c:(.text+0x139a): undefined reference to `nghttp2_session_want_read'
[...]
```
The cause seems to be curl upgrade, particularly [this fix](https://github.com/curl/curl/pull/14136), before on Linux, curl was being built without nghttp2, it now is.

This PR disable building curl with nghttp2.