### PR TITLE
Link linux experimental with X11

### DIFF
--- a/.github/workflows/emu-build-all-linux.yml
+++ b/.github/workflows/emu-build-all-linux.yml
@@ -92,6 +92,7 @@ jobs:
       - name: "Install required packages"
         shell: "bash"
         run: |
+          sudo dpkg --add-architecture i386
           sudo apt update -y
           sudo apt install -y coreutils # echo, printf, etc...
           sudo apt install -y build-essential
@@ -100,6 +101,7 @@ jobs:
           # sudo apt install -y clang
           sudo apt install -y libglx-dev # needed for overlay build (header files such as GL/glx.h)
           sudo apt install -y libgl-dev # needed for overlay build (header files such as GL/gl.h)
+          sudo apt install -y libx11-dev:i386 # needed for overlay build
           # sudo apt install -y binutils # (optional) contains the tool 'readelf' mainly, and other usefull binary stuff
 
       # build target

--- a/.github/workflows/emu-deps-linux.yml
+++ b/.github/workflows/emu-deps-linux.yml
@@ -68,6 +68,7 @@ jobs:
       - name: "Install required packages"
         shell: "bash"
         run: |
+          sudo dpkg --add-architecture i386
           sudo apt update -y
           sudo apt install -y coreutils # echo, printf, etc...
           sudo apt install -y build-essential
@@ -76,6 +77,7 @@ jobs:
           # sudo apt install -y clang
           sudo apt install -y libglx-dev # needed for overlay build (header files such as GL/glx.h)
           sudo apt install -y libgl-dev # needed for overlay build (header files such as GL/gl.h)
+          sudo apt install -y libx11-dev:i386 # needed for overlay build
           # sudo apt install -y binutils # (optional) contains the tool 'readelf' mainly, and other usefull binary stuff
 
       - name: "Build deps"

--- a/premake5.lua
+++ b/premake5.lua
@@ -890,6 +890,7 @@ project "api_experimental"
     filter { "system:not windows", }
         links {
             common_link_linux,
+            "X11"
         }
 
 


### PR DESCRIPTION
Fix crash when using experimental, even with overlay disabled, it was throwing `undefined symbol: XSetSelectionOwner`.

All the following symbols were undefined:
```
undefined symbol: XSetSelectionOwner	(libsteam_api.so)
undefined symbol: XOpenDisplay	(libsteam_api.so)
undefined symbol: XGetGeometry	(libsteam_api.so)
undefined symbol: XQueryPointer	(libsteam_api.so)
undefined symbol: XPeekEvent	(libsteam_api.so)
undefined symbol: XPutBackEvent	(libsteam_api.so)
undefined symbol: XGetTextProperty	(libsteam_api.so)
undefined symbol: XChangeProperty	(libsteam_api.so)
undefined symbol: XkbKeycodeToKeysym	(libsteam_api.so)
undefined symbol: XFree	(libsteam_api.so)
undefined symbol: XInternAtom	(libsteam_api.so)
undefined symbol: XNextEvent	(libsteam_api.so)
undefined symbol: XGetWindowProperty	(libsteam_api.so)
undefined symbol: XKeysymToKeycode	(libsteam_api.so)
undefined symbol: XQueryKeymap	(libsteam_api.so)
undefined symbol: XSendEvent	(libsteam_api.so)
undefined symbol: XQueryTree	(libsteam_api.so)
undefined symbol: XConvertSelection	(libsteam_api.so)
undefined symbol: XCloseDisplay	(libsteam_api.so)
```