### PR TITLE
Implement GetUGCDetails

### DIFF
--- a/dll/steam_remote_storage.cpp
+++ b/dll/steam_remote_storage.cpp
@@ -495,8 +495,33 @@ bool Steam_Remote_Storage::GetUGCDownloadProgress( UGCHandle_t hContent, uint32 
 // Gets metadata for a file after it has been downloaded. This is the same metadata given in the RemoteStorageDownloadUGCResult_t call result
 bool Steam_Remote_Storage::GetUGCDetails( UGCHandle_t hContent, AppId_t *pnAppID, STEAM_OUT_STRING() char **ppchName, int32 *pnFileSizeInBytes, STEAM_OUT_STRUCT() CSteamID *pSteamIDOwner )
 {
-    PRINT_DEBUG_ENTRY();
+    PRINT_DEBUG("%llu", hContent);
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (hContent == k_UGCHandleInvalid) return false;
+
+    if (pnAppID) *pnAppID = settings->get_local_game_id().AppID();
+    if (pSteamIDOwner) *pSteamIDOwner = k_steamIDNil;
+    if (pnFileSizeInBytes) *pnFileSizeInBytes = 0;
+    if (ppchName) *ppchName = nullptr;
+
+    if (auto query_res = ugc_bridge->get_ugc_query_result(hContent)) {
+        auto mod = settings->getMod(query_res.value().mod_id);
+        auto &mod_name = query_res.value().is_primary_file
+            ? mod.primaryFileName
+            : mod.previewFileName;
+        int32 mod_size = query_res.value().is_primary_file
+            ? mod.primaryFileSize
+            : mod.previewFileSize;
+
+        if (ppchName) {
+            *ppchName = new char[mod_name.size() + 1];
+            std::strcpy(*ppchName, mod_name.c_str());
+        }
+        if (pnFileSizeInBytes) *pnFileSizeInBytes = mod_size;
+        if (pSteamIDOwner) *pSteamIDOwner = mod.steamIDOwner;
+
+        return true;
+    }
     
     return false;
 }


### PR DESCRIPTION
This is needed in Half-Life 2 to get Workshop mods image.

@universal963 recommended the following change to avoid memory leak in case API consumer doesn't free ppchName.

```patch
diff --git a/dll/steam_remote_storage.cpp b/dll/steam_remote_storage.cpp
index babc96a5..9d0efb7f 100644
--- a/dll/steam_remote_storage.cpp
+++ b/dll/steam_remote_storage.cpp
@@ -512,10 +512,7 @@ bool Steam_Remote_Storage::GetUGCDetails( UGCHandle_t hContent, AppId_t *pnAppID
             ? mod.primaryFileSize
             : mod.previewFileSize;
 
-        if (ppchName) {
-            *ppchName = new char[mod_name.size() + 1];
-            std::strcpy(*ppchName, mod_name.c_str());
-        }
+        if (ppchName) *ppchName = (char*)mod_name.c_str();
         if (pnFileSizeInBytes) *pnFileSizeInBytes = mod_size;
         if (pSteamIDOwner) *pSteamIDOwner = mod.steamIDOwner;
 
```

I don't entirely agree, as this could result in dangling pointers. However, that seems to be how the Steam API works. I couldn't find any documentation stating whether the API consumer should copy the string or free it. I tried making that change with HL2, but it caused a segmentation fault in engine.so within SteamCallResults::runCallResults. We also sometimes get logs like `[CWorkshopImage] Unknown image file type... UGC=0000000000000004.` just before the segmentation fault. 