### PR TITLE
Fix total_files_sizes fallback

### DIFF
--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -1015,7 +1015,7 @@ static void try_parse_mods_file(class Settings *settings_client, Settings *setti
             }
             newMod.previewFileSize = mod.value().value("preview_filesize", preview_filesize);
 
-            newMod.total_files_sizes = mod.value().value("total_files_sizes", primary_filesize);
+            newMod.total_files_sizes = mod.value().value("total_files_sizes", newMod.primaryFileSize);
             newMod.min_game_branch = mod.value().value("min_game_branch", "");
             newMod.max_game_branch = mod.value().value("max_game_branch", "");
             


### PR DESCRIPTION
I was wondering why my mod refused to work when `primary_filename` was empty, even though Steam itself used an empty string for it. This was because the game required `total_files_sizes`, and instead of falling back to the `primary_file_size` that I had set, it was using the fallback `primaryFileSize`, which was incorrect without setting `primary_filename`. 