### PR TITLE
add some old interfaces

### DIFF
--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -212,48 +212,48 @@ bool steamclient_has_ipv6_functions()
 static void *create_client_interface(const char *ver)
 {
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
-    void *steam_client = nullptr;
 
+    Steam_Client *client_ptr = get_steam_client();
     if (strstr(ver, "SteamClient") == ver) {
-        if (strcmp(ver, "SteamClient007") == 0) {
-            steam_client = static_cast<ISteamClient007 *>(get_steam_client());
+        if (strcmp(ver, "SteamClient006") == 0) {
+            return static_cast<ISteamClient006 *>(client_ptr);
+        } else if (strcmp(ver, "SteamClient007") == 0) {
+            return static_cast<ISteamClient007 *>(client_ptr);
         } else if (strcmp(ver, "SteamClient008") == 0) {
-            steam_client = static_cast<ISteamClient008 *>(get_steam_client());
+            return static_cast<ISteamClient008 *>(client_ptr);
         } else if (strcmp(ver, "SteamClient009") == 0) {
-            steam_client = static_cast<ISteamClient009 *>(get_steam_client());
+            return static_cast<ISteamClient009 *>(client_ptr);
         } else if (strcmp(ver, "SteamClient010") == 0) {
-            steam_client = static_cast<ISteamClient010 *>(get_steam_client());
+            return static_cast<ISteamClient010 *>(client_ptr);
         } else if (strcmp(ver, "SteamClient011") == 0) {
-            steam_client = static_cast<ISteamClient011 *>(get_steam_client());
+            return static_cast<ISteamClient011 *>(client_ptr);
         } else if (strcmp(ver, "SteamClient012") == 0) {
-            steam_client = static_cast<ISteamClient012 *>(get_steam_client());
+            return static_cast<ISteamClient012 *>(client_ptr);
         } else if (strcmp(ver, "SteamClient013") == 0) {
-            steam_client = static_cast<ISteamClient013 *>(get_steam_client());
+            return static_cast<ISteamClient013 *>(client_ptr);
         } else if (strcmp(ver, "SteamClient014") == 0) {
-            steam_client = static_cast<ISteamClient014 *>(get_steam_client());
+            return static_cast<ISteamClient014 *>(client_ptr);
         } else if (strcmp(ver, "SteamClient015") == 0) {
-            steam_client = static_cast<ISteamClient015 *>(get_steam_client());
+            return static_cast<ISteamClient015 *>(client_ptr);
         } else if (strcmp(ver, "SteamClient016") == 0) {
-            steam_client = static_cast<ISteamClient016 *>(get_steam_client());
+            return static_cast<ISteamClient016 *>(client_ptr);
         } else if (strcmp(ver, "SteamClient017") == 0) {
-            steam_client = static_cast<ISteamClient017 *>(get_steam_client());
+            return static_cast<ISteamClient017 *>(client_ptr);
         } else if (strcmp(ver, "SteamClient018") == 0) {
-            steam_client = static_cast<ISteamClient018 *>(get_steam_client());
+            return static_cast<ISteamClient018 *>(client_ptr);
         } else if (strcmp(ver, "SteamClient019") == 0) {
-            steam_client = static_cast<ISteamClient019 *>(get_steam_client());
-        } else if (strcmp(ver, "SteamClient020") == 0) {
-            steamclient_has_ipv6_functions_flag = true;
-            steam_client = static_cast<ISteamClient020 *>(get_steam_client());
+            return static_cast<ISteamClient019 *>(client_ptr);
+        }
+        
+        steamclient_has_ipv6_functions_flag = true;
+        if (strcmp(ver, "SteamClient020") == 0) {
+            return static_cast<ISteamClient020 *>(client_ptr);
         } else if (strcmp(ver, STEAMCLIENT_INTERFACE_VERSION) == 0) {
-            steamclient_has_ipv6_functions_flag = true;
-            steam_client = static_cast<ISteamClient *>(get_steam_client());
-        } else {
-            PRINT_DEBUG("requested unknown steamclient version '%s'", ver);
-            get_steam_client()->report_missing_impl_and_exit(ver, EMU_FUNC_NAME);
+            return static_cast<ISteamClient *>(client_ptr);
         }
     }
     
-    return steam_client;
+    client_ptr->report_missing_impl_and_exit(ver, EMU_FUNC_NAME);
 }
 
 STEAMAPI_API void * S_CALLTYPE SteamInternal_CreateInterface( const char *ver )

--- a/dll/dll/steam_billing.h
+++ b/dll/dll/steam_billing.h
@@ -1,0 +1,97 @@
+/* Copyright (C) 2019 Mr Goldberg
+   This file is part of the Goldberg Emulator
+
+   The Goldberg Emulator is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
+
+   The Goldberg Emulator is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the Goldberg Emulator; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#ifndef __INCLUDED_STEAM_BILLING_H__
+#define __INCLUDED_STEAM_BILLING_H__
+
+#include "base.h"
+
+class Steam_Billing:
+public ISteamBilling
+{
+    class Settings *settings{};
+    class Networking *network{};
+    class SteamCallResults *callback_results{};
+    class SteamCallBacks *callbacks{};
+    class RunEveryRunCB *run_every_runcb{};
+    
+
+    static void steam_network_callback(void *object, Common_Message *msg);
+    static void steam_run_every_runcb(void *object);
+
+    void steam_run_callback();
+    void network_callback(Common_Message *msg);
+
+public:
+    Steam_Billing(class Settings *settings, class Networking *network, class SteamCallResults *callback_results, class SteamCallBacks *callbacks, class RunEveryRunCB *run_every_runcb);
+    ~Steam_Billing();
+
+    bool _unknown_fn_1( );
+    bool _unknown_fn_2( );
+    bool _unknown_fn_3( );
+    bool _unknown_fn_4( );
+    bool _unknown_fn_5( );
+    bool _unknown_fn_6( );
+    bool _unknown_fn_7( );
+    bool _unknown_fn_8( );
+    bool _unknown_fn_9( );
+    bool _unknown_fn_10( );
+    bool _unknown_fn_11( );
+    bool _unknown_fn_12( );
+    bool _unknown_fn_13( );
+    bool _unknown_fn_14( );
+    bool _unknown_fn_15( );
+    bool _unknown_fn_16( );
+    bool _unknown_fn_17( );
+    bool _unknown_fn_18( );
+    bool _unknown_fn_19( );
+
+    int _unknown_fn_20( );
+    int _unknown_fn_21( );
+    int _unknown_fn_22( );
+    int _unknown_fn_23( );
+    int _unknown_fn_24( );
+    int _unknown_fn_25( );
+    int _unknown_fn_26( );
+
+    const char* _unknown_fn_27( ); // returns null string (str address is inside .rdata so it can't change at runtime)
+
+    int _unknown_fn_28( );
+
+    int _unknown_fn_29( ); // mov eax, 2
+
+    int _unknown_fn_30( );
+    int _unknown_fn_31( );
+    int _unknown_fn_32( );
+    int _unknown_fn_33( );
+    int _unknown_fn_34( );
+    int _unknown_fn_35( );
+    int _unknown_fn_36( );
+    int _unknown_fn_37( );
+
+    const char* _unknown_fn_38( ); // returns null string (str address is inside .rdata so it can't change at runtime)
+
+    int _unknown_fn_39( );
+    int _unknown_fn_40( );
+
+    bool _unknown_fn_41( );
+    bool _unknown_fn_42( );
+    bool _unknown_fn_43( );
+
+};
+
+#endif // __INCLUDED_STEAM_BILLING_H__

--- a/dll/dll/steam_client.h
+++ b/dll/dll/steam_client.h
@@ -51,6 +51,7 @@
 #include "steam_parties.h"
 #include "steam_remoteplay.h"
 #include "steam_tv.h"
+#include "steam_billing.h"
 
 #include "steam_gameserver.h"
 #include "steam_gameserverstats.h"
@@ -142,6 +143,7 @@ public:
     Steam_GameStats *steam_gamestats{};
     Steam_Timeline *steam_timeline{};
     Steam_App_Disable_Update *steam_app_disable_update{};
+    Steam_Billing *steam_billing{};
 
     Steam_GameServer *steam_gameserver{};
     Steam_Utils *steam_gameserver_utils{};
@@ -248,6 +250,8 @@ public:
 	// steam appp disable update
 	ISteamAppDisableUpdate *GetISteamAppDisableUpdate( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
 
+    // steam billing
+    ISteamBilling *GetISteamBilling( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
 
 	// Deprecated. Applications should use SteamAPI_RunCallbacks() or SteamGameServer_RunCallbacks() instead.
 	STEAM_PRIVATE_API( void RunFrame() );

--- a/dll/dll/steam_client.h
+++ b/dll/dll/steam_client.h
@@ -69,6 +69,7 @@ enum Steam_Pipe {
 };
 
 class Steam_Client :
+public ISteamClient006,
 public ISteamClient007,
 public ISteamClient008,
 public ISteamClient009,
@@ -346,6 +347,22 @@ public:
     bool IsUserLogIn();
 
     void DestroyAllInterfaces();
+
+    // older sdk ----------------------------------------------------------
+    // https://github.com/ValveSoftware/Proton/blob/proton_9.0/lsteamclient/steamworks_sdk_099v/isteamclient.h
+    // https://workshop.perforce.com/files/guest/knut_wikstrom/ValveSDKCode/public/steam/isteamclient.h
+
+    // creates a global instance of a steam user, so that other processes can share it
+    // used by the steam UI, to share it's account info/connection with any games it launches
+    // fails (returns NULL) if an existing instance already exists
+    HSteamUser CreateGlobalUser( HSteamPipe *phSteamPipe );
+    // retrieves the IVac interface associated with the handle
+    // there is normally only one instance of VAC running, but using this connects it to the right user/account
+    void *GetIVAC( HSteamUser hSteamUser );
+    // returns the name of a universe
+    const char *GetUniverseName( EUniverse eUniverse );
+    void *GetISteamBilling_old( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // older sdk ----------------------------------------------------------
 
     void report_missing_impl(std::string_view itf, std::string_view caller);
     [[noreturn]] void report_missing_impl_and_exit(std::string_view itf, std::string_view caller);

--- a/dll/dll/steam_gameserver.h
+++ b/dll/dll/steam_gameserver.h
@@ -26,10 +26,10 @@
 //-----------------------------------------------------------------------------
 
 struct Gameserver_Outgoing_Packet {
-	std::vector<uint8_t> data{};
+    std::vector<uint8_t> data{};
 
-	uint32 ip{};
-	uint16 port{};
+    uint32 ip{};
+    uint16 port{};
 };
 
 struct Gameserver_Player_Info_t {
@@ -39,6 +39,8 @@ struct Gameserver_Player_Info_t {
 };
 
 class Steam_GameServer : 
+public ISteamGameServer002,
+public ISteamGameServer003,
 public ISteamGameServer004,
 public ISteamGameServer005,
 public ISteamGameServer008,
@@ -70,6 +72,8 @@ public ISteamGameServer
 
     std::vector<struct Gameserver_Outgoing_Packet> outgoing_packets{};
 
+    void set_version(const char *pchVersionString);
+
 
 public:
     Steam_GameServer(class Settings *settings, class Networking *network, class SteamCallBacks *callbacks);
@@ -82,228 +86,228 @@ public:
 // may not be changed after logged in.
 //
 
-	/// This is called by SteamGameServer_Init, and you will usually not need to call it directly
-	bool InitGameServer( uint32 unIP, uint16 usGamePort, uint16 usQueryPort, uint32 unFlags, AppId_t nGameAppId, const char *pchVersionString );
+    /// This is called by SteamGameServer_Init, and you will usually not need to call it directly
+    bool InitGameServer( uint32 unIP, uint16 usGamePort, uint16 usQueryPort, uint32 unFlags, AppId_t nGameAppId, const char *pchVersionString );
 
-	/// Game product identifier.  This is currently used by the master server for version checking purposes.
-	/// It's a required field, but will eventually will go away, and the AppID will be used for this purpose.
-	void SetProduct( const char *pszProduct );
+    /// Game product identifier.  This is currently used by the master server for version checking purposes.
+    /// It's a required field, but will eventually will go away, and the AppID will be used for this purpose.
+    void SetProduct( const char *pszProduct );
 
-	/// Description of the game.  This is a required field and is displayed in the steam server browser....for now.
-	/// This is a required field, but it will go away eventually, as the data should be determined from the AppID.
-	void SetGameDescription( const char *pszGameDescription );
+    /// Description of the game.  This is a required field and is displayed in the steam server browser....for now.
+    /// This is a required field, but it will go away eventually, as the data should be determined from the AppID.
+    void SetGameDescription( const char *pszGameDescription );
 
-	/// If your game is a "mod," pass the string that identifies it.  The default is an empty string, meaning
-	/// this application is the original game, not a mod.
-	///
-	/// @see k_cbMaxGameServerGameDir
-	void SetModDir( const char *pszModDir );
+    /// If your game is a "mod," pass the string that identifies it.  The default is an empty string, meaning
+    /// this application is the original game, not a mod.
+    ///
+    /// @see k_cbMaxGameServerGameDir
+    void SetModDir( const char *pszModDir );
 
-	/// Is this is a dedicated server?  The default value is false.
-	void SetDedicatedServer( bool bDedicated );
+    /// Is this is a dedicated server?  The default value is false.
+    void SetDedicatedServer( bool bDedicated );
 
 //
 // Login
 //
 
-	/// Begin process to login to a persistent game server account
-	///
-	/// You need to register for callbacks to determine the result of this operation.
-	/// @see SteamServersConnected_t
-	/// @see SteamServerConnectFailure_t
-	/// @see SteamServersDisconnected_t
-	void LogOn( const char *pszToken );
-	void LogOn(
-		const char *pszAccountName,
-		const char *pszPassword
-	);
-	void LogOn();
+    /// Begin process to login to a persistent game server account
+    ///
+    /// You need to register for callbacks to determine the result of this operation.
+    /// @see SteamServersConnected_t
+    /// @see SteamServerConnectFailure_t
+    /// @see SteamServersDisconnected_t
+    void LogOn( const char *pszToken );
+    void LogOn(
+        const char *pszAccountName,
+        const char *pszPassword
+    );
+    void LogOn();
 
-	/// Login to a generic, anonymous account.
-	///
-	/// Note: in previous versions of the SDK, this was automatically called within SteamGameServer_Init,
-	/// but this is no longer the case.
-	void LogOnAnonymous();
+    /// Login to a generic, anonymous account.
+    ///
+    /// Note: in previous versions of the SDK, this was automatically called within SteamGameServer_Init,
+    /// but this is no longer the case.
+    void LogOnAnonymous();
 
-	/// Begin process of logging game server out of steam
-	void LogOff();
-	
-	// status functions
-	bool BLoggedOn();
-	bool BSecure(); 
-	CSteamID GetSteamID();
+    /// Begin process of logging game server out of steam
+    void LogOff();
+    
+    // status functions
+    bool BLoggedOn();
+    bool BSecure(); 
+    CSteamID GetSteamID();
 
-	/// Returns true if the master server has requested a restart.
-	/// Only returns true once per request.
-	bool WasRestartRequested();
+    /// Returns true if the master server has requested a restart.
+    /// Only returns true once per request.
+    bool WasRestartRequested();
 
 //
 // Server state.  These properties may be changed at any time.
 //
 
-	/// Max player count that will be reported to server browser and client queries
-	void SetMaxPlayerCount( int cPlayersMax );
+    /// Max player count that will be reported to server browser and client queries
+    void SetMaxPlayerCount( int cPlayersMax );
 
-	/// Number of bots.  Default value is zero
-	void SetBotPlayerCount( int cBotplayers );
+    /// Number of bots.  Default value is zero
+    void SetBotPlayerCount( int cBotplayers );
 
-	/// Set the name of server as it will appear in the server browser
-	///
-	/// @see k_cbMaxGameServerName
-	void SetServerName( const char *pszServerName );
+    /// Set the name of server as it will appear in the server browser
+    ///
+    /// @see k_cbMaxGameServerName
+    void SetServerName( const char *pszServerName );
 
-	/// Set name of map to report in the server browser
-	///
-	/// @see k_cbMaxGameServerName
-	void SetMapName( const char *pszMapName );
+    /// Set name of map to report in the server browser
+    ///
+    /// @see k_cbMaxGameServerName
+    void SetMapName( const char *pszMapName );
 
-	/// Let people know if your server will require a password
-	void SetPasswordProtected( bool bPasswordProtected );
+    /// Let people know if your server will require a password
+    void SetPasswordProtected( bool bPasswordProtected );
 
-	/// Spectator server.  The default value is zero, meaning the service
-	/// is not used.
-	void SetSpectatorPort( uint16 unSpectatorPort );
+    /// Spectator server.  The default value is zero, meaning the service
+    /// is not used.
+    void SetSpectatorPort( uint16 unSpectatorPort );
 
-	/// Name of the spectator server.  (Only used if spectator port is nonzero.)
-	///
-	/// @see k_cbMaxGameServerMapName
-	void SetSpectatorServerName( const char *pszSpectatorServerName );
+    /// Name of the spectator server.  (Only used if spectator port is nonzero.)
+    ///
+    /// @see k_cbMaxGameServerMapName
+    void SetSpectatorServerName( const char *pszSpectatorServerName );
 
-	/// Call this to clear the whole list of key/values that are sent in rules queries.
-	void ClearAllKeyValues();
-	
-	/// Call this to add/update a key/value pair.
-	void SetKeyValue( const char *pKey, const char *pValue );
+    /// Call this to clear the whole list of key/values that are sent in rules queries.
+    void ClearAllKeyValues();
+    
+    /// Call this to add/update a key/value pair.
+    void SetKeyValue( const char *pKey, const char *pValue );
 
-	/// Sets a string defining the "gametags" for this server, this is optional, but if it is set
-	/// it allows users to filter in the matchmaking/server-browser interfaces based on the value
-	///
-	/// @see k_cbMaxGameServerTags
-	void SetGameTags( const char *pchGameTags );
+    /// Sets a string defining the "gametags" for this server, this is optional, but if it is set
+    /// it allows users to filter in the matchmaking/server-browser interfaces based on the value
+    ///
+    /// @see k_cbMaxGameServerTags
+    void SetGameTags( const char *pchGameTags );
 
-	/// Sets a string defining the "gamedata" for this server, this is optional, but if it is set
-	/// it allows users to filter in the matchmaking/server-browser interfaces based on the value
-	/// don't set this unless it actually changes, its only uploaded to the master once (when
-	/// acknowledged)
-	///
-	/// @see k_cbMaxGameServerGameData
-	void SetGameData( const char *pchGameData );
+    /// Sets a string defining the "gamedata" for this server, this is optional, but if it is set
+    /// it allows users to filter in the matchmaking/server-browser interfaces based on the value
+    /// don't set this unless it actually changes, its only uploaded to the master once (when
+    /// acknowledged)
+    ///
+    /// @see k_cbMaxGameServerGameData
+    void SetGameData( const char *pchGameData );
 
-	/// Region identifier.  This is an optional field, the default value is empty, meaning the "world" region
-	void SetRegion( const char *pszRegion );
+    /// Region identifier.  This is an optional field, the default value is empty, meaning the "world" region
+    void SetRegion( const char *pszRegion );
 
 //
 // Player list management / authentication
 //
 
-	// Handles receiving a new connection from a Steam user.  This call will ask the Steam
-	// servers to validate the users identity, app ownership, and VAC status.  If the Steam servers 
-	// are off-line, then it will validate the cached ticket itself which will validate app ownership 
-	// and identity.  The AuthBlob here should be acquired on the game client using SteamUser()->InitiateGameConnection()
-	// and must then be sent up to the game server for authentication.
-	//
-	// Return Value: returns true if the users ticket passes basic checks. pSteamIDUser will contain the Steam ID of this user. pSteamIDUser must NOT be NULL
-	// If the call succeeds then you should expect a GSClientApprove_t or GSClientDeny_t callback which will tell you whether authentication
-	// for the user has succeeded or failed (the steamid in the callback will match the one returned by this call)
-	bool SendUserConnectAndAuthenticate( uint32 unIPClient, const void *pvAuthBlob, uint32 cubAuthBlobSize, CSteamID *pSteamIDUser );
-	void SendUserConnectAndAuthenticate( CSteamID steamIDUser, uint32 unIPClient, void *pvAuthBlob, uint32 cubAuthBlobSize );
+    // Handles receiving a new connection from a Steam user.  This call will ask the Steam
+    // servers to validate the users identity, app ownership, and VAC status.  If the Steam servers 
+    // are off-line, then it will validate the cached ticket itself which will validate app ownership 
+    // and identity.  The AuthBlob here should be acquired on the game client using SteamUser()->InitiateGameConnection()
+    // and must then be sent up to the game server for authentication.
+    //
+    // Return Value: returns true if the users ticket passes basic checks. pSteamIDUser will contain the Steam ID of this user. pSteamIDUser must NOT be NULL
+    // If the call succeeds then you should expect a GSClientApprove_t or GSClientDeny_t callback which will tell you whether authentication
+    // for the user has succeeded or failed (the steamid in the callback will match the one returned by this call)
+    bool SendUserConnectAndAuthenticate( uint32 unIPClient, const void *pvAuthBlob, uint32 cubAuthBlobSize, CSteamID *pSteamIDUser );
+    void SendUserConnectAndAuthenticate( CSteamID steamIDUser, uint32 unIPClient, void *pvAuthBlob, uint32 cubAuthBlobSize );
 
-	// Creates a fake user (ie, a bot) which will be listed as playing on the server, but skips validation.  
-	// 
-	// Return Value: Returns a SteamID for the user to be tracked with, you should call HandleUserDisconnect()
-	// when this user leaves the server just like you would for a real user.
-	CSteamID CreateUnauthenticatedUserConnection();
+    // Creates a fake user (ie, a bot) which will be listed as playing on the server, but skips validation.  
+    // 
+    // Return Value: Returns a SteamID for the user to be tracked with, you should call HandleUserDisconnect()
+    // when this user leaves the server just like you would for a real user.
+    CSteamID CreateUnauthenticatedUserConnection();
 
-	// Should be called whenever a user leaves our game server, this lets Steam internally
-	// track which users are currently on which servers for the purposes of preventing a single
-	// account being logged into multiple servers, showing who is currently on a server, etc.
-	void SendUserDisconnect( CSteamID steamIDUser );
+    // Should be called whenever a user leaves our game server, this lets Steam internally
+    // track which users are currently on which servers for the purposes of preventing a single
+    // account being logged into multiple servers, showing who is currently on a server, etc.
+    void SendUserDisconnect( CSteamID steamIDUser );
 
-	// Update the data to be displayed in the server browser and matchmaking interfaces for a user
-	// currently connected to the server.  For regular users you must call this after you receive a
-	// GSUserValidationSuccess callback.
-	// 
-	// Return Value: true if successful, false if failure (ie, steamIDUser wasn't for an active player)
-	bool BUpdateUserData( CSteamID steamIDUser, const char *pchPlayerName, uint32 uScore );
+    // Update the data to be displayed in the server browser and matchmaking interfaces for a user
+    // currently connected to the server.  For regular users you must call this after you receive a
+    // GSUserValidationSuccess callback.
+    // 
+    // Return Value: true if successful, false if failure (ie, steamIDUser wasn't for an active player)
+    bool BUpdateUserData( CSteamID steamIDUser, const char *pchPlayerName, uint32 uScore );
 
-	// You shouldn't need to call this as it is called internally by SteamGameServer_Init() and can only be called once.
-	//
-	// To update the data in this call which may change during the servers lifetime see UpdateServerStatus() below.
-	//
-	// Input:	nGameAppID - The Steam assigned AppID for the game
-	//			unServerFlags - Any applicable combination of flags (see k_unServerFlag____ constants below)
-	//			unGameIP - The IP Address the server is listening for client connections on (might be INADDR_ANY)
-	//			unGamePort - The port which the server is listening for client connections on
-	//			unSpectatorPort - the port on which spectators can join to observe the server, 0 if spectating is not supported
-	//			usQueryPort - The port which the ISteamMasterServerUpdater API should use in order to listen for matchmaking requests
-	//			pchGameDir - A unique string identifier for your game
-	//			pchVersion - The current version of the server as a string like 1.0.0.0
-	//			bLanMode - Is this a LAN only server?
-	//			
-	// bugbug jmccaskey - figure out how to remove this from the API and only expose via SteamGameServer_Init... or make this actually used,
-	// and stop calling it in SteamGameServer_Init()?
-	bool BSetServerType( uint32 unServerFlags, uint32 unGameIP, uint16 unGamePort, 
-								uint16 unSpectatorPort, uint16 usQueryPort, const char *pchGameDir, const char *pchVersion, bool bLANMode );
+    // You shouldn't need to call this as it is called internally by SteamGameServer_Init() and can only be called once.
+    //
+    // To update the data in this call which may change during the servers lifetime see UpdateServerStatus() below.
+    //
+    // Input:    nGameAppID - The Steam assigned AppID for the game
+    //            unServerFlags - Any applicable combination of flags (see k_unServerFlag____ constants below)
+    //            unGameIP - The IP Address the server is listening for client connections on (might be INADDR_ANY)
+    //            unGamePort - The port which the server is listening for client connections on
+    //            unSpectatorPort - the port on which spectators can join to observe the server, 0 if spectating is not supported
+    //            usQueryPort - The port which the ISteamMasterServerUpdater API should use in order to listen for matchmaking requests
+    //            pchGameDir - A unique string identifier for your game
+    //            pchVersion - The current version of the server as a string like 1.0.0.0
+    //            bLanMode - Is this a LAN only server?
+    //            
+    // bugbug jmccaskey - figure out how to remove this from the API and only expose via SteamGameServer_Init... or make this actually used,
+    // and stop calling it in SteamGameServer_Init()?
+    bool BSetServerType( uint32 unServerFlags, uint32 unGameIP, uint16 unGamePort, 
+                                uint16 unSpectatorPort, uint16 usQueryPort, const char *pchGameDir, const char *pchVersion, bool bLANMode );
 
-	bool BSetServerType( int32 nGameAppId, uint32 unServerFlags, uint32 unGameIP, uint16 unGamePort, 
-									uint16 unSpectatorPort, uint16 usQueryPort, const char *pchGameDir, const char *pchVersion, bool bLANMode );
+    bool BSetServerType( int32 nGameAppId, uint32 unServerFlags, uint32 unGameIP, uint16 unGamePort, 
+                                    uint16 unSpectatorPort, uint16 usQueryPort, const char *pchGameDir, const char *pchVersion, bool bLANMode );
 
-	// Updates server status values which shows up in the server browser and matchmaking APIs
-	void UpdateServerStatus( int cPlayers, int cPlayersMax, int cBotPlayers, 
-									 const char *pchServerName, const char *pSpectatorServerName, 
-									 const char *pchMapName );
+    // Updates server status values which shows up in the server browser and matchmaking APIs
+    void UpdateServerStatus( int cPlayers, int cPlayersMax, int cBotPlayers, 
+                                     const char *pchServerName, const char *pSpectatorServerName, 
+                                     const char *pchMapName );
 
-	// This can be called if spectator goes away or comes back (passing 0 means there is no spectator server now).
-	void UpdateSpectatorPort( uint16 unSpectatorPort );
+    // This can be called if spectator goes away or comes back (passing 0 means there is no spectator server now).
+    void UpdateSpectatorPort( uint16 unSpectatorPort );
 
-	// Sets a string defining the "gametype" for this server, this is optional, but if it is set
-	// it allows users to filter in the matchmaking/server-browser interfaces based on the value
-	void SetGameType( const char *pchGameType ); 
+    // Sets a string defining the "gametype" for this server, this is optional, but if it is set
+    // it allows users to filter in the matchmaking/server-browser interfaces based on the value
+    void SetGameType( const char *pchGameType ); 
 
-	// Ask if a user has a specific achievement for this game, will get a callback on reply
+    // Ask if a user has a specific achievement for this game, will get a callback on reply
     bool BGetUserAchievementStatus( CSteamID steamID, const char *pchAchievementName );
 
-	// New auth system APIs - do not mix with the old auth system APIs.
-	// ----------------------------------------------------------------
+    // New auth system APIs - do not mix with the old auth system APIs.
+    // ----------------------------------------------------------------
 
-	// Retrieve ticket to be sent to the entity who wishes to authenticate you ( using BeginAuthSession API ). 
-	// pcbTicket retrieves the length of the actual ticket.
-	HAuthTicket GetAuthSessionTicket( void *pTicket, int cbMaxTicket, uint32 *pcbTicket );
-	// SteamNetworkingIdentity is an optional parameter to hold the public IP address of the entity you are connecting to
-	// if an IP address is passed Steam will only allow the ticket to be used by an entity with that IP address
-	HAuthTicket GetAuthSessionTicket( void *pTicket, int cbMaxTicket, uint32 *pcbTicket, const SteamNetworkingIdentity *pSnid );
+    // Retrieve ticket to be sent to the entity who wishes to authenticate you ( using BeginAuthSession API ). 
+    // pcbTicket retrieves the length of the actual ticket.
+    HAuthTicket GetAuthSessionTicket( void *pTicket, int cbMaxTicket, uint32 *pcbTicket );
+    // SteamNetworkingIdentity is an optional parameter to hold the public IP address of the entity you are connecting to
+    // if an IP address is passed Steam will only allow the ticket to be used by an entity with that IP address
+    HAuthTicket GetAuthSessionTicket( void *pTicket, int cbMaxTicket, uint32 *pcbTicket, const SteamNetworkingIdentity *pSnid );
 
-	// Authenticate ticket ( from GetAuthSessionTicket ) from entity steamID to be sure it is valid and isnt reused
-	// Registers for callbacks if the entity goes offline or cancels the ticket ( see ValidateAuthTicketResponse_t callback and EAuthSessionResponse )
-	EBeginAuthSessionResult BeginAuthSession( const void *pAuthTicket, int cbAuthTicket, CSteamID steamID );
+    // Authenticate ticket ( from GetAuthSessionTicket ) from entity steamID to be sure it is valid and isnt reused
+    // Registers for callbacks if the entity goes offline or cancels the ticket ( see ValidateAuthTicketResponse_t callback and EAuthSessionResponse )
+    EBeginAuthSessionResult BeginAuthSession( const void *pAuthTicket, int cbAuthTicket, CSteamID steamID );
 
-	// Stop tracking started by BeginAuthSession - called when no longer playing game with this entity
-	void EndAuthSession( CSteamID steamID );
+    // Stop tracking started by BeginAuthSession - called when no longer playing game with this entity
+    void EndAuthSession( CSteamID steamID );
 
-	// Cancel auth ticket from GetAuthSessionTicket, called when no longer playing game with the entity you gave the ticket to
-	void CancelAuthTicket( HAuthTicket hAuthTicket );
+    // Cancel auth ticket from GetAuthSessionTicket, called when no longer playing game with the entity you gave the ticket to
+    void CancelAuthTicket( HAuthTicket hAuthTicket );
 
-	// After receiving a user's authentication data, and passing it to SendUserConnectAndAuthenticate, use this function
-	// to determine if the user owns downloadable content specified by the provided AppID.
-	EUserHasLicenseForAppResult UserHasLicenseForApp( CSteamID steamID, AppId_t appID );
+    // After receiving a user's authentication data, and passing it to SendUserConnectAndAuthenticate, use this function
+    // to determine if the user owns downloadable content specified by the provided AppID.
+    EUserHasLicenseForAppResult UserHasLicenseForApp( CSteamID steamID, AppId_t appID );
 
-	// Ask if a user in in the specified group, results returns async by GSUserGroupStatus_t
-	// returns false if we're not connected to the steam servers and thus cannot ask
-	bool RequestUserGroupStatus( CSteamID steamIDUser, CSteamID steamIDGroup );
+    // Ask if a user in in the specified group, results returns async by GSUserGroupStatus_t
+    // returns false if we're not connected to the steam servers and thus cannot ask
+    bool RequestUserGroupStatus( CSteamID steamIDUser, CSteamID steamIDGroup );
 
 
-	// these two functions s are deprecated, and will not return results
-	// they will be removed in a future version of the SDK
-	void GetGameplayStats( );
-	STEAM_CALL_RESULT( GSReputation_t )
-	SteamAPICall_t GetServerReputation();
+    // these two functions s are deprecated, and will not return results
+    // they will be removed in a future version of the SDK
+    void GetGameplayStats( );
+    STEAM_CALL_RESULT( GSReputation_t )
+    SteamAPICall_t GetServerReputation();
 
-	// Returns the public IP of the server according to Steam, useful when the server is 
-	// behind NAT and you want to advertise its IP in a lobby for other clients to directly
-	// connect to
-	uint32 GetPublicIP_old();
-	SteamIPAddress_t GetPublicIP();
-	void GetPublicIP_fix(SteamIPAddress_t *out);
+    // Returns the public IP of the server according to Steam, useful when the server is 
+    // behind NAT and you want to advertise its IP in a lobby for other clients to directly
+    // connect to
+    uint32 GetPublicIP_old();
+    SteamIPAddress_t GetPublicIP();
+    void GetPublicIP_fix(SteamIPAddress_t *out);
 
 // These are in GameSocketShare mode, where instead of ISteamGameServer creating its own
 // socket to talk to the master server on, it lets the game use its socket to forward messages
@@ -311,63 +315,88 @@ public:
 // in their firewalls.
 //
 // the IP address and port should be in host order, i.e 127.0.0.1 == 0x7f000001
-	
-	// These are used when you've elected to multiplex the game server's UDP socket
-	// rather than having the master server updater use its own sockets.
-	// 
-	// Source games use this to simplify the job of the server admins, so they 
-	// don't have to open up more ports on their firewalls.
-	
-	// Call this when a packet that starts with 0xFFFFFFFF comes in. That means
-	// it's for us.
-	bool HandleIncomingPacket( const void *pData, int cbData, uint32 srcIP, uint16 srcPort );
+    
+    // These are used when you've elected to multiplex the game server's UDP socket
+    // rather than having the master server updater use its own sockets.
+    // 
+    // Source games use this to simplify the job of the server admins, so they 
+    // don't have to open up more ports on their firewalls.
+    
+    // Call this when a packet that starts with 0xFFFFFFFF comes in. That means
+    // it's for us.
+    bool HandleIncomingPacket( const void *pData, int cbData, uint32 srcIP, uint16 srcPort );
 
-	// AFTER calling HandleIncomingPacket for any packets that came in that frame, call this.
-	// This gets a packet that the master server updater needs to send out on UDP.
-	// It returns the length of the packet it wants to send, or 0 if there are no more packets to send.
-	// Call this each frame until it returns 0.
-	int GetNextOutgoingPacket( void *pOut, int cbMaxOut, uint32 *pNetAdr, uint16 *pPort );
+    // AFTER calling HandleIncomingPacket for any packets that came in that frame, call this.
+    // This gets a packet that the master server updater needs to send out on UDP.
+    // It returns the length of the packet it wants to send, or 0 if there are no more packets to send.
+    // Call this each frame until it returns 0.
+    int GetNextOutgoingPacket( void *pOut, int cbMaxOut, uint32 *pNetAdr, uint16 *pPort );
 
 //
 // Control heartbeats / advertisement with master server
 //
 
-	// Call this as often as you like to tell the master server updater whether or not
-	// you want it to be active (default: off).
-	void EnableHeartbeats( bool bActive );
+    // Call this as often as you like to tell the master server updater whether or not
+    // you want it to be active (default: off).
+    void EnableHeartbeats( bool bActive );
 
-	/// Indicate whether you wish to be listed on the master server list
-	/// and/or respond to server browser / LAN discovery packets.
-	/// The server starts with this value set to false.  You should set all
-	/// relevant server parameters before enabling advertisement on the server.
-	///
-	/// (This function used to be named EnableHeartbeats, so if you are wondering
-	/// where that function went, it's right here.  It does the same thing as before,
-	/// the old name was just confusing.)
-	void SetAdvertiseServerActive( bool bActive );
+    /// Indicate whether you wish to be listed on the master server list
+    /// and/or respond to server browser / LAN discovery packets.
+    /// The server starts with this value set to false.  You should set all
+    /// relevant server parameters before enabling advertisement on the server.
+    ///
+    /// (This function used to be named EnableHeartbeats, so if you are wondering
+    /// where that function went, it's right here.  It does the same thing as before,
+    /// the old name was just confusing.)
+    void SetAdvertiseServerActive( bool bActive );
 
-	// You usually don't need to modify this.
-	// Pass -1 to use the default value for iHeartbeatInterval.
-	// Some mods change this.
-	void SetHeartbeatInterval( int iHeartbeatInterval );
+    // You usually don't need to modify this.
+    // Pass -1 to use the default value for iHeartbeatInterval.
+    // Some mods change this.
+    void SetHeartbeatInterval( int iHeartbeatInterval );
 
-	// Force a heartbeat to steam at the next opportunity
-	void ForceHeartbeat();
+    // Force a heartbeat to steam at the next opportunity
+    void ForceHeartbeat();
 
-	void SetMasterServerHeartbeatInterval_DEPRECATED( int iHeartbeatInterval );
-	void ForceMasterServerHeartbeat_DEPRECATED();
+    void SetMasterServerHeartbeatInterval_DEPRECATED( int iHeartbeatInterval );
+    void ForceMasterServerHeartbeat_DEPRECATED();
 
-	// associate this game server with this clan for the purposes of computing player compat
-	STEAM_CALL_RESULT( AssociateWithClanResult_t )
-	SteamAPICall_t AssociateWithClan( CSteamID steamIDClan );
-	
-	// ask if any of the current players dont want to play with this new player - or vice versa
-	STEAM_CALL_RESULT( ComputeNewPlayerCompatibilityResult_t )
-	SteamAPICall_t ComputeNewPlayerCompatibility( CSteamID steamIDNewPlayer );
+    // associate this game server with this clan for the purposes of computing player compat
+    STEAM_CALL_RESULT( AssociateWithClanResult_t )
+    SteamAPICall_t AssociateWithClan( CSteamID steamIDClan );
+    
+    // ask if any of the current players dont want to play with this new player - or vice versa
+    STEAM_CALL_RESULT( ComputeNewPlayerCompatibilityResult_t )
+    SteamAPICall_t ComputeNewPlayerCompatibility( CSteamID steamIDNewPlayer );
 
 
     // called by steam_client::runcallbacks
     void RunCallbacks();
+
+
+    // older sdk -----------------------------------------------
+    void GSSetSpawnCount( uint32 ucSpawn );
+    bool GSGetSteam2GetEncryptionKeyToSendToNewClient( void *pvEncryptionKey, uint32 *pcbEncryptionKey, uint32 cbMaxEncryptionKey );
+    bool GSSendSteam2UserConnect(  uint32 unUserID, const void *pvRawKey, uint32 unKeyLen, uint32 unIPPublic, uint16 usPort, const void *pvCookie, uint32 cubCookie );
+    bool GSSendSteam3UserConnect( CSteamID steamID, uint32 unIPPublic, const void *pvCookie, uint32 cubCookie );
+    bool GSRemoveUserConnect( uint32 unUserID );
+    bool GSSendUserDisconnect( CSteamID steamID, uint32 unUserID );
+    bool GSSendUserStatusResponse( CSteamID steamID, int nSecondsConnected, int nSecondsSinceLast );
+    bool Obsolete_GSSetStatus( int32 nAppIdServed, uint32 unServerFlags, int cPlayers, int cPlayersMax, int cBotPlayers, int unGamePort, const char *pchServerName, const char *pchGameDir, const char *pchMapName, const char *pchVersion );
+    bool GSUpdateStatus( int cPlayers, int cPlayersMax, int cBotPlayers, const char *pchServerName, const char *pchMapName );
+    bool GSSetServerType( int32 nGameAppId, uint32 unServerFlags, uint32 unGameIP, uint32 unGamePort, const char *pchGameDir, const char *pchVersion );
+    bool GSSetServerType2( int32 nGameAppId, uint32 unServerFlags, uint32 unGameIP, uint16 unGamePort, uint16 unSpectatorPort, uint16 usQueryPort, const char *pchGameDir, const char *pchVersion, bool bLANMode );
+    bool GSUpdateStatus2( int cPlayers, int cPlayersMax, int cBotPlayers, const char *pchServerName, const char *pSpectatorServerName, const char *pchMapName );
+    bool GSCreateUnauthenticatedUser( CSteamID *pSteamID );
+    bool GSSetUserData( CSteamID steamID, const char *pPlayerName, uint32 nFrags );
+    void GSUpdateSpectatorPort( uint16 unSpectatorPort );
+    void GSSetGameType( const char *pchType );
+
+    bool GSSendUserConnect( uint32 unUserID, uint32 unIPPublic, uint16 usPort, const void *pvCookie, uint32 cubCookie );
+    bool GSSetServerType( int32 nGameAppId, uint32 unServerFlags, uint32 unGameIP, uint16 unGamePort, uint16 unSpectatorPort, uint16 usQueryPort, const char *pchGameDir, const char *pchVersion, bool bLANMode );
+    bool GSUpdateStatus( int cPlayers, int cPlayersMax, int cBotPlayers, const char *pchServerName, const char *pSpectatorServerName, const char *pchMapName );
+    bool GSGetUserAchievementStatus( CSteamID steamID, const char *pchAchievementName );
+    // older sdk -----------------------------------------------
 
 };
 

--- a/dll/dll/steam_matchmaking.h
+++ b/dll/dll/steam_matchmaking.h
@@ -41,11 +41,11 @@ struct Data_Requested {
 };
 
 struct Filter_Values {
-	std::string key{};
-	std::string value_string{};
-	int value_int{};
-	bool is_int{};
-	ELobbyComparison eComparisonType{};
+    std::string key{};
+    std::string value_string{};
+    int value_int{};
+    bool is_int{};
+    ELobbyComparison eComparisonType{};
 };
 
 struct Chat_Entry {
@@ -56,6 +56,7 @@ struct Chat_Entry {
 
 
 class Steam_Matchmaking :
+public ISteamMatchmaking001,
 public ISteamMatchmaking002,
 public ISteamMatchmaking003,
 public ISteamMatchmaking004,
@@ -383,6 +384,30 @@ public:
     // you must be the lobby owner of both lobbies
     bool SetLinkedLobby( CSteamID steamIDLobby, CSteamID steamIDLobbyDependent );
 
+
+    // older sdk -------------------------------------------------------------------
+
+    // returns the details of the game server
+    // iGame is of range [0,GetFavoriteGameCount())
+    // *pnIP, *pnConnPort are filled in the with IP:port of the game server
+    // *punFlags specify whether the game server was stored as an explicit favorite or in the history of connections
+    // *pRTime32LastPlayedOnServer is filled in the with the Unix time the favorite was added
+    bool GetFavoriteGame( int iGame, uint32 *pnAppID, uint32 *pnIP, uint16 *pnConnPort, uint32 *punFlags, uint32 *pRTime32LastPlayedOnServer );
+
+    // adds the game server to the local list; updates the time played of the server if it already exists in the list
+    int AddFavoriteGame( uint32 nAppID, uint32 nIP, uint16 nConnPort, uint32 unFlags, uint32 rTime32LastPlayedOnServer );
+    
+    // removes the game server from the local storage; returns true if one was removed
+    bool RemoveFavoriteGame( uint32 nAppID, uint32 nIP, uint16 nConnPort, uint32 unFlags );
+    bool GetFavoriteGame2( int iGame, uint32 *pnAppID, uint32 *pnIP, uint16 *pnConnPort, uint16 *pnQueryPort, uint32 *punFlags, uint32 *pRTime32LastPlayedOnServer );
+    int AddFavoriteGame2( uint32 nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags, uint32 rTime32LastPlayedOnServer );
+    bool RemoveFavoriteGame2( uint32 nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags );
+    void RequestLobbyList( uint64 ulGameID, MatchMakingKeyValuePair_t *pFilters, uint32 nFilters );
+    void CreateLobby( uint64 ulGameID, bool bPrivate );
+    bool SetLobbyMemberData_OLD( CSteamID steamIDLobby, const char *pchKey, const char *pchValue );
+
+    // older sdk -------------------------------------------------------------------
+    
 };
 
 #endif // __INCLUDED_STEAM_MATCHMAKING_H__

--- a/dll/dll/steam_user_stats.h
+++ b/dll/dll/steam_user_stats.h
@@ -58,6 +58,8 @@ struct achievement_trigger {
 };
 
 class Steam_User_Stats :
+public ISteamUserStats001,
+public ISteamUserStats002,
 public ISteamUserStats003,
 public ISteamUserStats004,
 public ISteamUserStats005,
@@ -403,6 +405,31 @@ public:
     bool GetAchievementProgressLimits( const char *pchName, int32 *pnMinProgress, int32 *pnMaxProgress );
 
     bool GetAchievementProgressLimits( const char *pchName, float *pfMinProgress, float *pfMaxProgress );
+
+    // old interface version
+    uint32 GetNumStats( CGameID nGameID );
+    const char *GetStatName( CGameID nGameID, uint32 iStat );
+    ESteamUserStatType GetStatType( CGameID nGameID, const char *pchName );
+    uint32 GetNumAchievements( CGameID nGameID );
+    const char *GetAchievementName( CGameID nGameID, uint32 iAchievement );
+    uint32 GetNumGroupAchievements( CGameID nGameID );
+    const char *GetGroupAchievementName( CGameID nGameID, uint32 iAchievement );
+    bool RequestCurrentStats( CGameID nGameID );
+    bool GetStat( CGameID nGameID, const char *pchName, int32 *pData );
+    bool GetStat( CGameID nGameID, const char *pchName, float *pData );
+    bool SetStat( CGameID nGameID, const char *pchName, int32 nData );
+    bool SetStat( CGameID nGameID, const char *pchName, float fData );
+    bool UpdateAvgRateStat( CGameID nGameID, const char *pchName, float flCountThisSession, double dSessionLength );
+    bool GetAchievement( CGameID nGameID, const char *pchName, bool *pbAchieved );
+    bool GetGroupAchievement( CGameID nGameID, const char *pchName, bool *pbAchieved );
+    bool SetAchievement( CGameID nGameID, const char *pchName );
+    bool SetGroupAchievement( CGameID nGameID, const char *pchName );
+    bool StoreStats( CGameID nGameID );
+    bool ClearAchievement( CGameID nGameID, const char *pchName );
+    bool ClearGroupAchievement( CGameID nGameID, const char *pchName );
+    int GetAchievementIcon( CGameID nGameID, const char *pchName );
+    const char *GetAchievementDisplayAttribute( CGameID nGameID, const char *pchName, const char *pchKey );
+    bool IndicateAchievementProgress( CGameID nGameID, const char *pchName, uint32 nCurProgress, uint32 nMaxProgress );
 
 };
 

--- a/dll/net.proto
+++ b/dll/net.proto
@@ -162,6 +162,7 @@ message Gameserver {
     bool secure = 17;
     uint32 num_players = 18;
     uint32 version = 19;
+    bytes game_dir = 20;
 
     uint32 ip = 32;
     uint32 port = 33;

--- a/dll/steam_billing.cpp
+++ b/dll/steam_billing.cpp
@@ -1,0 +1,427 @@
+/* Copyright (C) 2019 Mr Goldberg
+   This file is part of the Goldberg Emulator
+
+   The Goldberg Emulator is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
+
+   The Goldberg Emulator is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the Goldberg Emulator; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+
+// this interface is not found in public SDK archives, it is based on reversing the returned vftable from steamclient64.dll
+// real client returns 0/false in all these functions, the TODO notes are just for the names
+
+
+#include "dll/steam_billing.h"
+
+
+void Steam_Billing::steam_run_every_runcb(void *object)
+{
+    // PRINT_DEBUG_ENTRY();
+
+    auto inst = (Steam_Billing *)object;
+    inst->steam_run_callback();
+}
+
+void Steam_Billing::steam_network_callback(void *object, Common_Message *msg)
+{
+    // PRINT_DEBUG_ENTRY();
+
+    auto inst = (Steam_Billing *)object;
+    inst->network_callback(msg);
+}
+
+
+
+Steam_Billing::Steam_Billing(class Settings *settings, class Networking *network, class SteamCallResults *callback_results, class SteamCallBacks *callbacks, class RunEveryRunCB *run_every_runcb)
+{
+    this->settings = settings;
+    this->network = network;
+    this->callback_results = callback_results;
+    this->callbacks = callbacks;
+    this->run_every_runcb = run_every_runcb;
+    
+    this->network->setCallback(CALLBACK_ID_USER_STATUS, settings->get_local_steam_id(), &Steam_Billing::steam_network_callback, this);
+    this->run_every_runcb->add(&Steam_Billing::steam_run_every_runcb, this);
+}
+
+Steam_Billing::~Steam_Billing()
+{
+    this->network->rmCallback(CALLBACK_ID_USER_STATUS, settings->get_local_steam_id(), &Steam_Billing::steam_network_callback, this);
+    this->run_every_runcb->remove(&Steam_Billing::steam_run_every_runcb, this);
+}
+
+
+bool Steam_Billing::_unknown_fn_1( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_2( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_3( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_4( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_5( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_6( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_7( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_8( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_9( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_10( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_11( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_12( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_13( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_14( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_15( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_16( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_17( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_18( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_19( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+int Steam_Billing::_unknown_fn_20( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+int Steam_Billing::_unknown_fn_21( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+int Steam_Billing::_unknown_fn_22( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+int Steam_Billing::_unknown_fn_23( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+int Steam_Billing::_unknown_fn_24( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+int Steam_Billing::_unknown_fn_25( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+int Steam_Billing::_unknown_fn_26( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+const char* Steam_Billing::_unknown_fn_27( ) // returns null string (str address is inside .rdata so it can't change at runtime)
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return "";
+}
+
+int Steam_Billing::_unknown_fn_28( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+int Steam_Billing::_unknown_fn_29( ) // mov eax, 2
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+int Steam_Billing::_unknown_fn_30( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+int Steam_Billing::_unknown_fn_31( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+int Steam_Billing::_unknown_fn_32( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+int Steam_Billing::_unknown_fn_33( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+int Steam_Billing::_unknown_fn_34( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+int Steam_Billing::_unknown_fn_35( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+int Steam_Billing::_unknown_fn_36( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+int Steam_Billing::_unknown_fn_37( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+const char* Steam_Billing::_unknown_fn_38( ) // returns null string (str address is inside .rdata so it can't change at runtime)
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return "";
+}
+
+int Steam_Billing::_unknown_fn_39( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+int Steam_Billing::_unknown_fn_40( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return 0;
+}
+
+bool Steam_Billing::_unknown_fn_41( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_42( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+bool Steam_Billing::_unknown_fn_43( )
+{
+    PRINT_DEBUG_TODO();
+    std::lock_guard lock(global_mutex);
+
+    return false;
+}
+
+
+
+void Steam_Billing::steam_run_callback()
+{
+
+}
+
+
+
+void Steam_Billing::network_callback(Common_Message *msg)
+{
+    if (msg->has_low_level()) {
+        if (msg->low_level().type() == Low_Level::CONNECT) {
+            
+        }
+
+        if (msg->low_level().type() == Low_Level::DISCONNECT) {
+
+        }
+    }
+}

--- a/dll/steam_client.cpp
+++ b/dll/steam_client.cpp
@@ -962,3 +962,53 @@ void Steam_Client::DestroyAllInterfaces()
 {
     PRINT_DEBUG_TODO();
 }
+
+// older sdk ----------------------------------------------------------
+
+// creates a global instance of a steam user, so that other processes can share it
+// used by the steam UI, to share it's account info/connection with any games it launches
+// fails (returns NULL) if an existing instance already exists
+HSteamUser Steam_Client::CreateGlobalUser( HSteamPipe *phSteamPipe )
+{
+    // TODO not sure if this implementation is correct
+    PRINT_DEBUG_TODO();
+    for (const auto& [pipe_handle, pipe_type] : steam_pipes) {
+        if (pipe_type == Steam_Pipe::CLIENT) {
+            if (phSteamPipe) *phSteamPipe = pipe_handle;
+            return 0;
+        }
+    }
+
+    HSteamPipe pipe = CreateSteamPipe();
+    if (phSteamPipe) *phSteamPipe = pipe;
+
+    steam_pipes[pipe] = Steam_Pipe::CLIENT;
+    return CLIENT_HSTEAMUSER;
+}
+
+// retrieves the IVac interface associated with the handle
+// there is normally only one instance of VAC running, but using this connects it to the right user/account
+void *Steam_Client::GetIVAC( HSteamUser hSteamUser )
+{
+    PRINT_DEBUG_ENTRY();
+    // actual value from steamclient64.dll
+    return nullptr;
+}
+
+// returns the name of a universe
+const char *Steam_Client::GetUniverseName( EUniverse eUniverse )
+{
+    PRINT_DEBUG("%i", (int)eUniverse);
+    // actual values returned by steamclient64.dll
+    switch (eUniverse)
+    {
+    case EUniverse::k_EUniverseInvalid: return "Invalid";
+    case EUniverse::k_EUniversePublic: return "Public";
+    case EUniverse::k_EUniverseBeta: return "Beta";
+    case EUniverse::k_EUniverseInternal: return "Internal";
+    case EUniverse::k_EUniverseDev: return "Dev";
+    }
+
+    return "Unknown";
+}
+// older sdk ----------------------------------------------------------

--- a/dll/steam_client.cpp
+++ b/dll/steam_client.cpp
@@ -125,6 +125,7 @@ Steam_Client::Steam_Client()
     steam_gamestats = new Steam_GameStats(settings_client, network, callback_results_client, callbacks_client, run_every_runcb);
     steam_timeline = new Steam_Timeline(settings_client, network, callback_results_client, callbacks_client, run_every_runcb);
     steam_app_disable_update = new Steam_App_Disable_Update(settings_client, network, callback_results_client, callbacks_client, run_every_runcb);
+    steam_billing = new Steam_Billing(settings_client, network, callback_results_client, callbacks_client, run_every_runcb);
 
     // server
     PRINT_DEBUG("init gameserver");
@@ -207,6 +208,7 @@ Steam_Client::~Steam_Client()
     DEL_INST(steam_gamestats);
     DEL_INST(steam_timeline);
     DEL_INST(steam_app_disable_update);
+    DEL_INST(steam_billing);
 
     DEL_INST(steam_utils);
     DEL_INST(steam_friends);

--- a/dll/steam_client_interface_getter.cpp
+++ b/dll/steam_client_interface_getter.cpp
@@ -347,7 +347,9 @@ void *Steam_Client::GetISteamGenericInterface( HSteamUser hSteamUser, HSteamPipe
             steam_networking_sockets_serialized_temp = steam_networking_sockets_serialized;
         }
 
-        if (strcmp(pchVersion, "SteamNetworkingSocketsSerialized002") == 0) {
+        if (strcmp(pchVersion, "SteamNetworkingSocketsSerialized001") == 0) { // not found in public archives, defined as an alias to v002 in proton src
+            return reinterpret_cast<void *>(static_cast<ISteamNetworkingSocketsSerialized002 *>(steam_networking_sockets_serialized_temp));
+        } else if (strcmp(pchVersion, "SteamNetworkingSocketsSerialized002") == 0) {
             return reinterpret_cast<void *>(static_cast<ISteamNetworkingSocketsSerialized002 *>(steam_networking_sockets_serialized_temp));
         } else if (strcmp(pchVersion, "SteamNetworkingSocketsSerialized003") == 0) {
             return reinterpret_cast<void *>(static_cast<ISteamNetworkingSocketsSerialized003 *>(steam_networking_sockets_serialized_temp));
@@ -372,6 +374,7 @@ void *Steam_Client::GetISteamGenericInterface( HSteamUser hSteamUser, HSteamPipe
             return reinterpret_cast<void *>(static_cast<ISteamNetworkingSockets003 *>( steam_networking_sockets_temp));
         } else if (strcmp(pchVersion, "SteamNetworkingSockets004") == 0) {
             return reinterpret_cast<void *>(static_cast<ISteamNetworkingSockets004 *>( steam_networking_sockets_temp));
+        // TODO SteamNetworkingSockets005 not found in public archives
         } else if (strcmp(pchVersion, "SteamNetworkingSockets006") == 0) {
             return reinterpret_cast<void *>(static_cast<ISteamNetworkingSockets006 *>( steam_networking_sockets_temp));
         } else if (strcmp(pchVersion, "SteamNetworkingSockets007") == 0) { // Not found in public Archive, real steamclient64.dll returns null
@@ -451,7 +454,7 @@ void *Steam_Client::GetISteamGenericInterface( HSteamUser hSteamUser, HSteamPipe
         return GetISteamUser(hSteamUser, hSteamPipe, pchVersion);
     } else if (strstr(pchVersion, "SteamUtils") == pchVersion) {
         return GetISteamUtils(hSteamPipe, pchVersion);
-    } else if (strstr(pchVersion, "STEAMAPPS_INTERFACE_VERSION") == pchVersion) {
+    } else if ((strstr(pchVersion, "STEAMAPPS_INTERFACE_VERSION") == pchVersion) || (strstr(pchVersion, "SteamApps") == pchVersion)) {
         return GetISteamApps(hSteamUser, hSteamPipe, pchVersion);
     } else if (strstr(pchVersion, "STEAMSCREENSHOTS_INTERFACE_VERSION") == pchVersion) {
         return GetISteamScreenshots(hSteamUser, hSteamPipe, pchVersion);
@@ -558,7 +561,7 @@ ISteamApps *Steam_Client::GetISteamApps( HSteamUser hSteamUser, HSteamPipe hStea
     } else {
         steam_apps_temp = steam_apps;
     }
-    if (strcmp(pchVersion, "STEAMAPPS_INTERFACE_VERSION001") == 0) {
+    if ((strcmp(pchVersion, "STEAMAPPS_INTERFACE_VERSION001") == 0) || (strcmp(pchVersion, "SteamApps001") == 0)) {
         return reinterpret_cast<ISteamApps *>(static_cast<ISteamApps001 *>(steam_apps_temp));
     } else if (strcmp(pchVersion, "STEAMAPPS_INTERFACE_VERSION002") == 0) {
         return reinterpret_cast<ISteamApps *>(static_cast<ISteamApps002 *>(steam_apps_temp));
@@ -726,8 +729,12 @@ ISteamController *Steam_Client::GetISteamController( HSteamUser hSteamUser, HSte
     PRINT_DEBUG("%s", pchVersion);
     if (!steam_pipes.count(hSteamPipe) || !hSteamUser) return NULL;
 
-    if (strcmp(pchVersion, "STEAMCONTROLLER_INTERFACE_VERSION") == 0) {
+    if (strcmp(pchVersion, "STEAMCONTROLLER_INTERFACE_VERSION") == 0) { // SDK <= 1.34
         return reinterpret_cast<ISteamController *>(static_cast<ISteamController001 *>(steam_controller));
+    } else if (strcmp(pchVersion, "SteamController001") == 0) {
+        return nullptr; // real steamclient64.dll returns null
+    } else if (strcmp(pchVersion, "SteamController002") == 0) {
+        return nullptr; // real steamclient64.dll returns null
     } else if (strcmp(pchVersion, "SteamController003") == 0) {
         return reinterpret_cast<ISteamController *>(static_cast<ISteamController003 *>(steam_controller));
     } else if (strcmp(pchVersion, "SteamController004") == 0) {

--- a/dll/steam_client_interface_getter.cpp
+++ b/dll/steam_client_interface_getter.cpp
@@ -33,6 +33,12 @@ ISteamBilling *Steam_Client::GetISteamBilling( HSteamUser hSteamUser, HSteamPipe
     report_missing_impl_and_exit(pchVersion, EMU_FUNC_NAME);
 }
 
+void *Steam_Client::GetISteamBilling_old( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion )
+{
+    PRINT_DEBUG("old");
+    return GetISteamBilling(hSteamUser, hSteamPipe, pchVersion);
+}
+
 // retrieves the ISteamAppDisableUpdate interface associated with the handle
 ISteamAppDisableUpdate *Steam_Client::GetISteamAppDisableUpdate( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion )
 {

--- a/dll/steam_client_interface_getter.cpp
+++ b/dll/steam_client_interface_getter.cpp
@@ -18,6 +18,21 @@
 #include "dll/steam_client.h"
 
 
+// retrieves the ISteamBilling interface associated with the handle
+ISteamBilling *Steam_Client::GetISteamBilling( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion )
+{
+    PRINT_DEBUG("%s", pchVersion);
+    if (!steam_pipes.count(hSteamPipe) || !hSteamUser) return nullptr;
+
+    if (strcmp(pchVersion, "SteamBilling001") == 0) {
+        return nullptr; // real steamclient64.dll returns null
+    } else if (strcmp(pchVersion, STEAMBILLING_INTERFACE_VERSION) == 0) {
+        return reinterpret_cast<ISteamBilling *>(static_cast<ISteamBilling *>(steam_billing));
+    }
+
+    report_missing_impl_and_exit(pchVersion, EMU_FUNC_NAME);
+}
+
 // retrieves the ISteamAppDisableUpdate interface associated with the handle
 ISteamAppDisableUpdate *Steam_Client::GetISteamAppDisableUpdate( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion )
 {
@@ -466,6 +481,8 @@ void *Steam_Client::GetISteamGenericInterface( HSteamUser hSteamUser, HSteamPipe
         return GetISteamTimeline(hSteamUser, hSteamPipe, pchVersion);
     } else if (strstr(pchVersion, "SteamAppDisableUpdate") == pchVersion) {
         return GetISteamAppDisableUpdate(hSteamUser, hSteamPipe, pchVersion);
+    } else if (strstr(pchVersion, "SteamBilling") == pchVersion) {
+        return GetISteamBilling(hSteamUser, hSteamPipe, pchVersion);
     }
     
     PRINT_DEBUG("No interface: %s", pchVersion);

--- a/dll/steam_client_interface_getter.cpp
+++ b/dll/steam_client_interface_getter.cpp
@@ -478,8 +478,11 @@ ISteamUserStats *Steam_Client::GetISteamUserStats( HSteamUser hSteamUser, HSteam
     PRINT_DEBUG("%s", pchVersion);
     if (!steam_pipes.count(hSteamPipe) || !hSteamUser) return NULL;
 
-     // v001, v002 Not found in public Archive, must be before 1.00
-    if (strcmp(pchVersion, "STEAMUSERSTATS_INTERFACE_VERSION003") == 0) {
+    if (strcmp(pchVersion, "STEAMUSERSTATS_INTERFACE_VERSION001") == 0) {
+        return reinterpret_cast<ISteamUserStats *>(static_cast<ISteamUserStats001 *>(steam_user_stats));
+    } else if (strcmp(pchVersion, "STEAMUSERSTATS_INTERFACE_VERSION002") == 0) {
+        return reinterpret_cast<ISteamUserStats *>(static_cast<ISteamUserStats002 *>(steam_user_stats));
+    } else if (strcmp(pchVersion, "STEAMUSERSTATS_INTERFACE_VERSION003") == 0) {
         return reinterpret_cast<ISteamUserStats *>(static_cast<ISteamUserStats003 *>(steam_user_stats));
     } else if (strcmp(pchVersion, "STEAMUSERSTATS_INTERFACE_VERSION004") == 0) {
         return reinterpret_cast<ISteamUserStats *>(static_cast<ISteamUserStats004 *>(steam_user_stats));

--- a/dll/steam_client_interface_getter.cpp
+++ b/dll/steam_client_interface_getter.cpp
@@ -128,13 +128,20 @@ ISteamGameServer *Steam_Client::GetISteamGameServer( HSteamUser hSteamUser, HSte
     PRINT_DEBUG("%s", pchVersion);
     if (!steam_pipes.count(hSteamPipe) || !hSteamUser) return NULL;
 
-    if (strcmp(pchVersion, "SteamGameServer004") == 0) {
+
+    if (strcmp(pchVersion, "SteamGameServer001") == 0) {
+        return nullptr;
+    } else if (strcmp(pchVersion, "SteamGameServer002") == 0) {
+        return reinterpret_cast<ISteamGameServer *>(static_cast<ISteamGameServer002 *>(steam_gameserver)); // not found in public archives, from proton repo src
+    } else if (strcmp(pchVersion, "SteamGameServer003") == 0) {
+        return reinterpret_cast<ISteamGameServer *>(static_cast<ISteamGameServer003 *>(steam_gameserver)); // not found in public archives, from proton repo src
+    } else if (strcmp(pchVersion, "SteamGameServer004") == 0) {
         return reinterpret_cast<ISteamGameServer *>(static_cast<ISteamGameServer004 *>(steam_gameserver));
     } else if (strcmp(pchVersion, "SteamGameServer005") == 0) {
         return reinterpret_cast<ISteamGameServer *>(static_cast<ISteamGameServer005 *>(steam_gameserver));
-    } else if (strcmp(pchVersion, "SteamGameServer006") == 0) {
+    } else if (strcmp(pchVersion, "SteamGameServer006") == 0) { // Not found in public Archive, defined as an alias to v008 in proton src
         return reinterpret_cast<ISteamGameServer *>(static_cast<ISteamGameServer008 *>(steam_gameserver)); // SteamGameServer006 Not exists
-    } else if (strcmp(pchVersion, "SteamGameServer007") == 0) {
+    } else if (strcmp(pchVersion, "SteamGameServer007") == 0) { // Not found in public Archive, defined as an alias to v008 in proton src
         return reinterpret_cast<ISteamGameServer *>(static_cast<ISteamGameServer008 *>(steam_gameserver)); // SteamGameServer007 Not exists
     } else if (strcmp(pchVersion, "SteamGameServer008") == 0) {
         return reinterpret_cast<ISteamGameServer *>(static_cast<ISteamGameServer008 *>(steam_gameserver));
@@ -146,14 +153,14 @@ ISteamGameServer *Steam_Client::GetISteamGameServer( HSteamUser hSteamUser, HSte
         return reinterpret_cast<ISteamGameServer *>(static_cast<ISteamGameServer011 *>(steam_gameserver));
     } else if (strcmp(pchVersion, "SteamGameServer012") == 0) {
         return reinterpret_cast<ISteamGameServer *>(static_cast<ISteamGameServer012 *>(steam_gameserver));
-    } else if (strcmp(pchVersion, "SteamGameServer013") == 0) {
+    }
+
     gameserver_has_ipv6_functions = true;
+    if (strcmp(pchVersion, "SteamGameServer013") == 0) {
         return reinterpret_cast<ISteamGameServer *>(static_cast<ISteamGameServer013 *>(steam_gameserver));
     } else if (strcmp(pchVersion, "SteamGameServer014") == 0) {
-        gameserver_has_ipv6_functions = true;
         return reinterpret_cast<ISteamGameServer *>(static_cast<ISteamGameServer014 *>(steam_gameserver));
     } else if (strcmp(pchVersion, STEAMGAMESERVER_INTERFACE_VERSION) == 0) {
-        gameserver_has_ipv6_functions = true;
         return reinterpret_cast<ISteamGameServer *>(static_cast<ISteamGameServer *>(steam_gameserver));
     }
     

--- a/dll/steam_client_interface_getter.cpp
+++ b/dll/steam_client_interface_getter.cpp
@@ -251,9 +251,8 @@ ISteamMatchmaking *Steam_Client::GetISteamMatchmaking( HSteamUser hSteamUser, HS
     PRINT_DEBUG("%s", pchVersion);
     if (!steam_pipes.count(hSteamPipe) || !hSteamUser) return NULL;
 
-    if (strcmp(pchVersion, "SteamMatchMaking001") == 0) { // SteamMatchMaking001 Not found in public Archive, must be before 1.00
-        //TODO
-        return reinterpret_cast<ISteamMatchmaking *>(static_cast<ISteamMatchmaking002 *>(steam_matchmaking));
+    if (strcmp(pchVersion, "SteamMatchMaking001") == 0) { // SteamMatchMaking001 Not found in public Archive, from proton src
+        return reinterpret_cast<ISteamMatchmaking *>(static_cast<ISteamMatchmaking001 *>(steam_matchmaking));
     } else if (strcmp(pchVersion, "SteamMatchMaking002") == 0) {
         return reinterpret_cast<ISteamMatchmaking *>(static_cast<ISteamMatchmaking002 *>(steam_matchmaking));
     } else if (strcmp(pchVersion, "SteamMatchMaking003") == 0) {

--- a/dll/steam_matchmaking.cpp
+++ b/dll/steam_matchmaking.cpp
@@ -1242,6 +1242,79 @@ bool Steam_Matchmaking::SetLinkedLobby( CSteamID steamIDLobby, CSteamID steamIDL
 
 
 
+// older sdk -------------------------------------------------------------------
+
+// returns the details of the game server
+// iGame is of range [0,GetFavoriteGameCount())
+// *pnIP, *pnConnPort are filled in the with IP:port of the game server
+// *punFlags specify whether the game server was stored as an explicit favorite or in the history of connections
+// *pRTime32LastPlayedOnServer is filled in the with the Unix time the favorite was added
+bool Steam_Matchmaking::GetFavoriteGame( int iGame, uint32 *pnAppID, uint32 *pnIP, uint16 *pnConnPort, uint32 *punFlags, uint32 *pRTime32LastPlayedOnServer )
+{
+    PRINT_DEBUG("old");
+    return GetFavoriteGame(iGame, reinterpret_cast<AppId_t *>(pnAppID), pnIP, pnConnPort, 0, punFlags, pRTime32LastPlayedOnServer );
+}
+
+// adds the game server to the local list; updates the time played of the server if it already exists in the list
+int Steam_Matchmaking::AddFavoriteGame( uint32 nAppID, uint32 nIP, uint16 nConnPort, uint32 unFlags, uint32 rTime32LastPlayedOnServer )
+{
+    PRINT_DEBUG("old");
+    return AddFavoriteGame( (AppId_t)nAppID, nIP, nConnPort, 0, unFlags, rTime32LastPlayedOnServer );
+}
+
+// removes the game server from the local storage; returns true if one was removed
+bool Steam_Matchmaking::RemoveFavoriteGame( uint32 nAppID, uint32 nIP, uint16 nConnPort, uint32 unFlags )
+{
+    PRINT_DEBUG("old");
+    return RemoveFavoriteGame( (AppId_t)nAppID, nIP, nConnPort, 0, unFlags );
+}
+
+bool Steam_Matchmaking::GetFavoriteGame2( int iGame, uint32 *pnAppID, uint32 *pnIP, uint16 *pnConnPort, uint16 *pnQueryPort, uint32 *punFlags, uint32 *pRTime32LastPlayedOnServer )
+{
+    PRINT_DEBUG("old");
+    return GetFavoriteGame(iGame, reinterpret_cast<AppId_t *>(pnAppID), pnIP, pnConnPort, pnQueryPort, punFlags, pRTime32LastPlayedOnServer );
+}
+
+int Steam_Matchmaking::AddFavoriteGame2( uint32 nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags, uint32 rTime32LastPlayedOnServer )
+{
+    PRINT_DEBUG("old");
+    return AddFavoriteGame( (AppId_t)nAppID, nIP, nConnPort, nQueryPort, unFlags, rTime32LastPlayedOnServer );
+}
+
+bool Steam_Matchmaking::RemoveFavoriteGame2( uint32 nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags )
+{
+    PRINT_DEBUG("old");
+    return RemoveFavoriteGame( (AppId_t)nAppID, nIP, nConnPort, nQueryPort, unFlags );
+}
+
+void Steam_Matchmaking::RequestLobbyList( uint64 ulGameID, MatchMakingKeyValuePair_t *pFilters, uint32 nFilters )
+{
+    PRINT_DEBUG("old");
+    if (pFilters && nFilters > 0) {
+        for (size_t fidx = 0; fidx < nFilters; ++fidx) {
+            auto &kv = pFilters[fidx];
+            AddRequestLobbyListFilter(kv.m_szKey, kv.m_szValue);
+        }
+    }
+    RequestLobbyList();
+}
+
+void Steam_Matchmaking::CreateLobby( uint64 ulGameID, bool bPrivate )
+{
+    PRINT_DEBUG("old");
+    CreateLobby(bPrivate);
+}
+
+bool Steam_Matchmaking::SetLobbyMemberData_OLD( CSteamID steamIDLobby, const char *pchKey, const char *pchValue )
+{
+    PRINT_DEBUG("old");
+    SetLobbyMemberData(steamIDLobby, pchKey, pchValue);
+    return true;
+}
+// older sdk -------------------------------------------------------------------
+
+
+
 void Steam_Matchmaking::remove_lobbies()
 {
     uint64 current_time = std::chrono::duration_cast<std::chrono::duration<uint64>>(std::chrono::system_clock::now().time_since_epoch()).count();

--- a/dll/steam_user_stats.cpp
+++ b/dll/steam_user_stats.cpp
@@ -152,6 +152,288 @@ SteamAPICall_t Steam_User_Stats::GetNumberOfCurrentPlayers()
 
 
 
+// --- old interface version
+
+uint32 Steam_User_Stats::GetNumStats( CGameID nGameID )
+{
+    PRINT_DEBUG("old %llu", nGameID.ToUint64());
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (settings->get_local_game_id() != nGameID) {
+        return 0;
+    }
+    return (uint32)settings->getStats().size();
+}
+
+const char *Steam_User_Stats::GetStatName( CGameID nGameID, uint32 iStat )
+{
+    PRINT_DEBUG("old %llu [%u]", nGameID.ToUint64(), iStat);
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+
+    auto &stats = settings->getStats();
+    if (settings->get_local_game_id() != nGameID || iStat >= stats.size()) {
+        return "";
+    }
+    
+    return std::next(stats.begin(), iStat)->first.c_str();
+}
+
+ESteamUserStatType Steam_User_Stats::GetStatType( CGameID nGameID, const char *pchName )
+{
+    PRINT_DEBUG("old %llu '%s'", nGameID.ToUint64(), pchName);
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    
+    if (settings->get_local_game_id() != nGameID || !pchName) {
+        return ESteamUserStatType::k_ESteamUserStatTypeINVALID;
+    }
+    
+    std::string stat_name(common_helpers::to_lower(pchName));
+    const auto &stats = settings->getStats();
+    auto stat_info = stats.find(stat_name);
+    if (stats.end() == stat_info) {
+        return ESteamUserStatType::k_ESteamUserStatTypeINVALID;
+    }
+
+    switch (stat_info->second.type)
+    {
+    case GameServerStats_Messages::StatInfo::STAT_TYPE_INT: return ESteamUserStatType::k_ESteamUserStatTypeINT;
+    case GameServerStats_Messages::StatInfo::STAT_TYPE_FLOAT: return ESteamUserStatType::k_ESteamUserStatTypeFLOAT;
+    case GameServerStats_Messages::StatInfo::STAT_TYPE_AVGRATE: return ESteamUserStatType::k_ESteamUserStatTypeAVGRATE;
+    
+    default: PRINT_DEBUG("[X] unhandled type %i", (int)stat_info->second.type); break;
+    }
+    
+    return ESteamUserStatType::k_ESteamUserStatTypeINVALID;
+}
+
+uint32 Steam_User_Stats::GetNumAchievements( CGameID nGameID )
+{
+    PRINT_DEBUG("old %llu", nGameID.ToUint64());
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (settings->get_local_game_id() != nGameID) {
+        return 0;
+    }
+    
+    return GetNumAchievements();
+}
+
+const char *Steam_User_Stats::GetAchievementName( CGameID nGameID, uint32 iAchievement )
+{
+    PRINT_DEBUG("old %llu [%u]", nGameID.ToUint64(), iAchievement);
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (settings->get_local_game_id() != nGameID) {
+        return "";
+    }
+    
+    return GetAchievementName(iAchievement);
+}
+
+uint32 Steam_User_Stats::GetNumGroupAchievements( CGameID nGameID )
+{
+    PRINT_DEBUG("old %llu // TODO", nGameID.ToUint64());
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (settings->get_local_game_id() != nGameID) {
+        return 0;
+    }
+    
+    return 0;
+}
+
+const char *Steam_User_Stats::GetGroupAchievementName( CGameID nGameID, uint32 iAchievement )
+{
+    PRINT_DEBUG("old %llu [%u] // TODO", nGameID.ToUint64(), iAchievement);
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (settings->get_local_game_id() != nGameID) {
+        return "";
+    }
+    
+    return "";
+}
+
+bool Steam_User_Stats::RequestCurrentStats( CGameID nGameID )
+{
+    PRINT_DEBUG("old %llu", nGameID.ToUint64());
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (settings->get_local_game_id() != nGameID) {
+        return false;
+    }
+    
+    return RequestCurrentStats();
+}
+
+bool Steam_User_Stats::GetStat( CGameID nGameID, const char *pchName, int32 *pData )
+{
+    PRINT_DEBUG("old %llu '%s' %p", nGameID.ToUint64(), pchName, pData);
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    
+    if (pData) *pData = 0;
+    if (settings->get_local_game_id() != nGameID) {
+        return false;
+    }
+    
+    return GetStat(pchName, pData);
+}
+
+bool Steam_User_Stats::GetStat( CGameID nGameID, const char *pchName, float *pData )
+{
+    PRINT_DEBUG("old %llu '%s' %p", nGameID.ToUint64(), pchName, pData);
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    
+    if (pData) *pData = 0;
+    if (settings->get_local_game_id() != nGameID) {
+        return false;
+    }
+    
+    return GetStat(pchName, pData);
+}
+
+bool Steam_User_Stats::SetStat( CGameID nGameID, const char *pchName, int32 nData )
+{
+    PRINT_DEBUG("old %llu '%s' %i", nGameID.ToUint64(), pchName, nData);
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (settings->get_local_game_id() != nGameID) {
+        return false;
+    }
+    
+    return SetStat(pchName, nData);
+}
+
+bool Steam_User_Stats::SetStat( CGameID nGameID, const char *pchName, float fData )
+{
+    PRINT_DEBUG("old %llu '%s' %f", nGameID.ToUint64(), pchName, fData);
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (settings->get_local_game_id() != nGameID) {
+        return false;
+    }
+    
+    return SetStat(pchName, fData);
+}
+
+bool Steam_User_Stats::UpdateAvgRateStat( CGameID nGameID, const char *pchName, float flCountThisSession, double dSessionLength )
+{
+    PRINT_DEBUG("old %llu '%s' %f %f", nGameID.ToUint64(), pchName, flCountThisSession, dSessionLength);
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (settings->get_local_game_id() != nGameID) {
+        return false;
+    }
+    
+    return UpdateAvgRateStat(pchName, flCountThisSession, dSessionLength);
+}
+
+bool Steam_User_Stats::GetAchievement( CGameID nGameID, const char *pchName, bool *pbAchieved )
+{
+    PRINT_DEBUG("old %llu '%s' %p", nGameID.ToUint64(), pchName, pbAchieved);
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    
+    if (pbAchieved) *pbAchieved = false;
+    if (settings->get_local_game_id() != nGameID) {
+        return false;
+    }
+    
+    return GetAchievement(pchName, pbAchieved);
+}
+
+bool Steam_User_Stats::GetGroupAchievement( CGameID nGameID, const char *pchName, bool *pbAchieved )
+{
+    PRINT_DEBUG("old %llu '%s' %p // TODO", nGameID.ToUint64(), pchName, pbAchieved);
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    
+    if (pbAchieved) *pbAchieved = false;
+    if (settings->get_local_game_id() != nGameID) {
+        return false;
+    }
+    
+    return false;
+}
+
+bool Steam_User_Stats::SetAchievement( CGameID nGameID, const char *pchName )
+{
+    PRINT_DEBUG("old %llu '%s'", nGameID.ToUint64(), pchName);
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (settings->get_local_game_id() != nGameID && settings->achievement_bypass) {
+        return false;
+    }
+    
+    return SetAchievement(pchName);
+}
+
+bool Steam_User_Stats::SetGroupAchievement( CGameID nGameID, const char *pchName )
+{
+    PRINT_DEBUG("old %llu '%s' // TODO", nGameID.ToUint64(), pchName);
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (settings->get_local_game_id() != nGameID) {
+        return false;
+    }
+    
+    return false;
+}
+
+bool Steam_User_Stats::StoreStats( CGameID nGameID )
+{
+    PRINT_DEBUG("old %llu", nGameID.ToUint64());
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (settings->get_local_game_id() != nGameID) {
+        return false;
+    }
+    
+    return StoreStats();
+}
+
+bool Steam_User_Stats::ClearAchievement( CGameID nGameID, const char *pchName )
+{
+    PRINT_DEBUG("old %llu '%s'", nGameID.ToUint64(), pchName);
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (settings->get_local_game_id() != nGameID) {
+        return false;
+    }
+    
+    return ClearAchievement(pchName);
+}
+
+bool Steam_User_Stats::ClearGroupAchievement( CGameID nGameID, const char *pchName )
+{
+    PRINT_DEBUG("old %llu '%s' // TODO", nGameID.ToUint64(), pchName);
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (settings->get_local_game_id() != nGameID) {
+        return 0;
+    }
+    
+    return false;
+}
+
+int Steam_User_Stats::GetAchievementIcon( CGameID nGameID, const char *pchName )
+{
+    PRINT_DEBUG("old %llu '%s'", nGameID.ToUint64(), pchName);
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (settings->get_local_game_id() != nGameID) {
+        return Settings::INVALID_IMAGE_HANDLE;
+    }
+    
+    return GetAchievementIcon(pchName);
+}
+
+const char *Steam_User_Stats::GetAchievementDisplayAttribute( CGameID nGameID, const char *pchName, const char *pchKey )
+{
+    PRINT_DEBUG("old %llu '%s' ['%s']", nGameID.ToUint64(), pchName, pchKey);
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (settings->get_local_game_id() != nGameID) {
+        return "";
+    }
+    
+    return GetAchievementDisplayAttribute(pchName, pchKey);
+}
+
+bool Steam_User_Stats::IndicateAchievementProgress( CGameID nGameID, const char *pchName, uint32 nCurProgress, uint32 nMaxProgress )
+{
+    PRINT_DEBUG("old %llu '%s' %u %u", nGameID.ToUint64(), pchName, nCurProgress, nMaxProgress);
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (settings->get_local_game_id() != nGameID) {
+        return false;
+    }
+    
+    return IndicateAchievementProgress(pchName, nCurProgress, nMaxProgress);
+}
+
+
 // --- steam callbacks
 
 void Steam_User_Stats::steam_run_callback()

--- a/sdk/steam/isteambilling.h
+++ b/sdk/steam/isteambilling.h
@@ -1,0 +1,65 @@
+
+#ifndef ISTEAMBILLING_H
+#define ISTEAMBILLING_H
+
+// this interface is not found in public SDK archives, it is based on reversing the returned vftable from steamclient64.dll
+
+class ISteamBilling
+{
+public:
+    virtual bool _unknown_fn_1( ) = 0;
+    virtual bool _unknown_fn_2( ) = 0;
+    virtual bool _unknown_fn_3( ) = 0;
+    virtual bool _unknown_fn_4( ) = 0;
+    virtual bool _unknown_fn_5( ) = 0;
+    virtual bool _unknown_fn_6( ) = 0;
+    virtual bool _unknown_fn_7( ) = 0;
+    virtual bool _unknown_fn_8( ) = 0;
+    virtual bool _unknown_fn_9( ) = 0;
+    virtual bool _unknown_fn_10( ) = 0;
+    virtual bool _unknown_fn_11( ) = 0;
+    virtual bool _unknown_fn_12( ) = 0;
+    virtual bool _unknown_fn_13( ) = 0;
+    virtual bool _unknown_fn_14( ) = 0;
+    virtual bool _unknown_fn_15( ) = 0;
+    virtual bool _unknown_fn_16( ) = 0;
+    virtual bool _unknown_fn_17( ) = 0;
+    virtual bool _unknown_fn_18( ) = 0;
+    virtual bool _unknown_fn_19( ) = 0;
+
+    virtual int _unknown_fn_20( ) = 0;
+    virtual int _unknown_fn_21( ) = 0;
+    virtual int _unknown_fn_22( ) = 0;
+    virtual int _unknown_fn_23( ) = 0;
+    virtual int _unknown_fn_24( ) = 0;
+    virtual int _unknown_fn_25( ) = 0;
+    virtual int _unknown_fn_26( ) = 0;
+
+    virtual const char* _unknown_fn_27( ) = 0; // returns null string (str address is inside .rdata so it can't change at runtime)
+
+    virtual int _unknown_fn_28( ) = 0;
+
+    virtual int _unknown_fn_29( ) = 0; // mov eax, 2
+
+    virtual int _unknown_fn_30( ) = 0;
+    virtual int _unknown_fn_31( ) = 0;
+    virtual int _unknown_fn_32( ) = 0;
+    virtual int _unknown_fn_33( ) = 0;
+    virtual int _unknown_fn_34( ) = 0;
+    virtual int _unknown_fn_35( ) = 0;
+    virtual int _unknown_fn_36( ) = 0;
+    virtual int _unknown_fn_37( ) = 0;
+
+    virtual const char* _unknown_fn_38( ) = 0; // returns null string (str address is inside .rdata so it can't change at runtime)
+
+    virtual int _unknown_fn_39( ) = 0;
+    virtual int _unknown_fn_40( ) = 0;
+
+    virtual bool _unknown_fn_41( ) = 0;
+    virtual bool _unknown_fn_42( ) = 0;
+    virtual bool _unknown_fn_43( ) = 0;
+};
+
+#define STEAMBILLING_INTERFACE_VERSION "SteamBilling002"
+
+#endif // ISTEAMBILLING_H

--- a/sdk/steam/isteamclient006.h
+++ b/sdk/steam/isteamclient006.h
@@ -1,0 +1,87 @@
+
+#ifndef ISTEAMCLIENT006_H
+#define ISTEAMCLIENT006_H
+#ifdef STEAM_WIN32
+#pragma once
+#endif
+
+// this interface version is not found in public SDK archives, it is based on proton src: https://github.com/ValveSoftware/Proton/tree/proton_9.0/lsteamclient
+
+#include "isteammasterserverupdater.h"
+
+class ISteamClient006
+{
+public:
+	// Creates a communication pipe to the Steam client
+	virtual HSteamPipe CreateSteamPipe() = 0;
+
+	// Releases a previously created communications pipe
+	virtual bool BReleaseSteamPipe( HSteamPipe hSteamPipe ) = 0;
+
+	// creates a global instance of a steam user, so that other processes can share it
+	// used by the steam UI, to share it's account info/connection with any games it launches
+	// fails (returns NULL) if an existing instance already exists
+	virtual HSteamUser CreateGlobalUser( HSteamPipe *phSteamPipe ) = 0;
+
+	// connects to an existing global user, failing if none exists
+	// used by the game to coordinate with the steamUI
+	virtual HSteamUser ConnectToGlobalUser( HSteamPipe hSteamPipe ) = 0;
+
+	// used by game servers, create a steam user that won't be shared with anyone else
+	virtual HSteamUser CreateLocalUser( HSteamPipe *phSteamPipe ) = 0;
+
+	// removes an allocated user
+	virtual void ReleaseUser( HSteamPipe hSteamPipe, HSteamUser hUser ) = 0;
+
+	// retrieves the ISteamUser interface associated with the handle
+	virtual ISteamUser *GetISteamUser( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// retrieves the IVac interface associated with the handle
+	// there is normally only one instance of VAC running, but using this connects it to the right user/account
+	virtual void *GetIVAC( HSteamUser hSteamUser ) = 0;
+
+	// retrieves the ISteamGameServer interface associated with the handle
+	virtual ISteamGameServer *GetISteamGameServer( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// set the local IP and Port to bind to
+	// this must be set before CreateLocalUser()
+	virtual void SetLocalIPBinding( uint32 unIP, uint16 usPort ) = 0; 
+
+	// returns the name of a universe
+	virtual const char *GetUniverseName( EUniverse eUniverse ) = 0;
+
+	// returns the ISteamFriends interface
+	virtual ISteamFriends *GetISteamFriends( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns the ISteamUtils interface
+	virtual ISteamUtils *GetISteamUtils( HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	virtual void *GetISteamBilling_old( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns the ISteamMatchmaking interface
+	virtual ISteamMatchmaking *GetISteamMatchmaking( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	virtual ISteamApps *GetISteamApps( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns the ISteamContentServer interface
+	virtual ISteamContentServer *GetISteamContentServer( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns the ISteamMasterServerUpdater interface
+	virtual ISteamMasterServerUpdater *GetISteamMasterServerUpdater( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns the ISteamMatchmakingServers interface
+	virtual ISteamMatchmakingServers *GetISteamMatchmakingServers( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// this needs to be called every frame to process matchmaking results
+	// redundant if you're already calling SteamAPI_RunCallbacks()
+	virtual void RunFrame() = 0;
+
+	// returns the number of IPC calls made since the last time this function was called
+	// Used for perf debugging so you can understand how many IPC calls your game makes per frame
+	// Every IPC call is at minimum a thread context switch if not a process one so you want to rate
+	// control how often you do them.
+	virtual uint32 GetIPCCallCount() = 0;
+};
+
+
+#endif // ISTEAMCLIENT006_H

--- a/sdk/steam/isteamgameserver002.h
+++ b/sdk/steam/isteamgameserver002.h
@@ -1,0 +1,36 @@
+
+#ifndef ISTEAMGAMESERVER002_H
+#define ISTEAMGAMESERVER002_H
+#ifdef STEAM_WIN32
+#pragma once
+#endif
+
+// this interface version is not found in public SDK archives, it is based on proton src: https://github.com/ValveSoftware/Proton/tree/proton_9.0/lsteamclient
+
+class ISteamGameServer002
+{
+public:
+	virtual void LogOn() = 0;
+	virtual void LogOff() = 0;
+	virtual bool BLoggedOn() = 0;
+	virtual void GSSetSpawnCount( uint32 ucSpawn ) = 0;
+	virtual bool GSGetSteam2GetEncryptionKeyToSendToNewClient( void *pvEncryptionKey, uint32 *pcbEncryptionKey, uint32 cbMaxEncryptionKey ) = 0;
+	virtual bool GSSendSteam2UserConnect(  uint32 unUserID, const void *pvRawKey, uint32 unKeyLen, uint32 unIPPublic, uint16 usPort, const void *pvCookie, uint32 cubCookie ) = 0;
+	virtual bool GSSendSteam3UserConnect( CSteamID steamID, uint32 unIPPublic, const void *pvCookie, uint32 cubCookie ) = 0;
+	virtual bool GSRemoveUserConnect( uint32 unUserID ) = 0;
+	virtual bool GSSendUserDisconnect( CSteamID steamID, uint32 unUserID ) = 0;
+	virtual bool GSSendUserStatusResponse( CSteamID steamID, int nSecondsConnected, int nSecondsSinceLast ) = 0;
+	virtual bool Obsolete_GSSetStatus( int32 nAppIdServed, uint32 unServerFlags, int cPlayers, int cPlayersMax, int cBotPlayers, int unGamePort, const char *pchServerName, const char *pchGameDir, const char *pchMapName, const char *pchVersion ) = 0;
+	virtual bool GSUpdateStatus( int cPlayers, int cPlayersMax, int cBotPlayers, const char *pchServerName, const char *pchMapName ) = 0;
+	virtual bool BSecure() = 0;
+	virtual CSteamID GetSteamID() = 0;
+	virtual bool GSSetServerType( int32 nGameAppId, uint32 unServerFlags, uint32 unGameIP, uint32 unGamePort, const char *pchGameDir, const char *pchVersion ) = 0;
+	virtual bool GSSetServerType2( int32 nGameAppId, uint32 unServerFlags, uint32 unGameIP, uint16 unGamePort, uint16 unSpectatorPort, uint16 usQueryPort, const char *pchGameDir, const char *pchVersion, bool bLANMode ) = 0;
+	virtual bool GSUpdateStatus2( int cPlayers, int cPlayersMax, int cBotPlayers, const char *pchServerName, const char *pSpectatorServerName, const char *pchMapName ) = 0;
+	virtual bool GSCreateUnauthenticatedUser( CSteamID *pSteamID ) = 0;
+	virtual bool GSSetUserData( CSteamID steamID, const char *pPlayerName, uint32 nFrags ) = 0;
+	virtual void GSUpdateSpectatorPort( uint16 unSpectatorPort ) = 0;
+	virtual void GSSetGameType( const char *pchType ) = 0;
+};
+
+#endif // ISTEAMGAMESERVER002_H

--- a/sdk/steam/isteamgameserver003.h
+++ b/sdk/steam/isteamgameserver003.h
@@ -1,0 +1,36 @@
+
+#ifndef ISTEAMGAMESERVER003_H
+#define ISTEAMGAMESERVER003_H
+#ifdef STEAM_WIN32
+#pragma once
+#endif
+
+// this interface version is not found in public SDK archives, it is based on proton src: https://github.com/ValveSoftware/Proton/tree/proton_9.0/lsteamclient
+
+class ISteamGameServer003
+{
+public:
+	// connection functions
+	virtual void LogOn() = 0;
+	virtual void LogOff() = 0;
+	
+	// status functions
+	virtual bool BLoggedOn() = 0;
+	virtual bool BSecure() = 0; 
+	virtual CSteamID GetSteamID() = 0;
+
+	virtual bool GSGetSteam2GetEncryptionKeyToSendToNewClient( void *pvEncryptionKey, uint32 *pcbEncryptionKey, uint32 cbMaxEncryptionKey ) = 0;
+	virtual bool GSSendUserConnect( uint32 unUserID, uint32 unIPPublic, uint16 usPort, const void *pvCookie, uint32 cubCookie ) = 0;
+	virtual bool GSRemoveUserConnect( uint32 unUserID ) = 0;
+	virtual bool GSSendUserDisconnect( CSteamID steamID, uint32 unUserID ) = 0;
+	virtual void GSSetSpawnCount( uint32 ucSpawn ) = 0;
+	virtual bool GSSetServerType( int32 nGameAppId, uint32 unServerFlags, uint32 unGameIP, uint16 unGamePort, uint16 unSpectatorPort, uint16 usQueryPort, const char *pchGameDir, const char *pchVersion, bool bLANMode ) = 0;
+	virtual bool GSUpdateStatus( int cPlayers, int cPlayersMax, int cBotPlayers, const char *pchServerName, const char *pSpectatorServerName, const char *pchMapName ) = 0;
+	virtual bool GSCreateUnauthenticatedUser( CSteamID *pSteamID ) = 0;
+	virtual bool GSSetUserData( CSteamID steamID, const char *pPlayerName, uint32 nFrags ) = 0;
+	virtual void GSUpdateSpectatorPort( uint16 unSpectatorPort ) = 0;
+	virtual void GSSetGameType( const char *pchType ) = 0;
+	virtual bool GSGetUserAchievementStatus( CSteamID steamID, const char *pchAchievementName ) = 0;
+};
+
+#endif // ISTEAMGAMESERVER003_H

--- a/sdk/steam/isteammatchmaking001.h
+++ b/sdk/steam/isteammatchmaking001.h
@@ -1,0 +1,83 @@
+#ifndef ISTEAMMATCHMAKING001_H
+#define ISTEAMMATCHMAKING001_H
+#ifdef STEAM_WIN32
+#pragma once
+#endif
+
+// this interface version is not found in public SDK archives, it is based on proton src: https://github.com/ValveSoftware/Proton/tree/proton_9.0/lsteamclient
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for match making services for clients to get to favorites
+//			and to operate on game lobbies.
+//-----------------------------------------------------------------------------
+class ISteamMatchmaking001
+{
+public:
+	// game server favorites storage
+	// saves basic details about a multiplayer game server locally
+
+	// returns the number of favorites servers the user has stored
+	virtual int GetFavoriteGameCount() = 0;
+	
+	// returns the details of the game server
+	// iGame is of range [0,GetFavoriteGameCount())
+	// *pnIP, *pnConnPort are filled in the with IP:port of the game server
+	// *punFlags specify whether the game server was stored as an explicit favorite or in the history of connections
+	// *pRTime32LastPlayedOnServer is filled in the with the Unix time the favorite was added
+	virtual bool GetFavoriteGame( int iGame, uint32 *pnAppID, uint32 *pnIP, uint16 *pnConnPort, uint32 *punFlags, uint32 *pRTime32LastPlayedOnServer ) = 0;
+
+	// adds the game server to the local list; updates the time played of the server if it already exists in the list
+	virtual int AddFavoriteGame( uint32 nAppID, uint32 nIP, uint16 nConnPort, uint32 unFlags, uint32 rTime32LastPlayedOnServer ) = 0;
+	
+	// removes the game server from the local storage; returns true if one was removed
+	virtual bool RemoveFavoriteGame( uint32 nAppID, uint32 nIP, uint16 nConnPort, uint32 unFlags ) = 0;
+
+	virtual bool GetFavoriteGame2( int iGame, uint32 *pnAppID, uint32 *pnIP, uint16 *pnConnPort, uint16 *pnQueryPort, uint32 *punFlags, uint32 *pRTime32LastPlayedOnServer ) = 0;
+	virtual int AddFavoriteGame2( uint32 nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags, uint32 rTime32LastPlayedOnServer ) = 0;
+	virtual bool RemoveFavoriteGame2( uint32 nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags ) = 0;
+
+	///////
+	// Game lobby functions
+	virtual void RequestLobbyList( uint64 ulGameID, MatchMakingKeyValuePair_t *pFilters, uint32 nFilters ) = 0;
+
+	virtual CSteamID GetLobbyByIndex( int iLobby ) = 0;
+	virtual void CreateLobby( uint64 ulGameID, bool bPrivate ) = 0;
+	virtual void JoinLobby_OLD( CSteamID steamIDLobby ) = 0;
+	virtual void LeaveLobby( CSteamID steamIDLobby ) = 0;
+	virtual bool InviteUserToLobby( CSteamID steamIDLobby, CSteamID steamIDInvitee ) = 0;
+	virtual int GetNumLobbyMembers( CSteamID steamIDLobby ) = 0;
+	virtual CSteamID GetLobbyMemberByIndex( CSteamID steamIDLobby, int iMember ) = 0;
+
+	virtual const char *GetLobbyData( CSteamID SteamIDLobby, const char *pchKey ) = 0;
+
+	// Sets a key/value pair in the lobby metadata
+	// each user in the lobby will be broadcast this new value, and any new users joining will receive any existing data
+	// this can be used to set lobby names, map, etc.
+	// to reset a key, just set it to ""
+	// other users in the lobby will receive notification of the lobby data change via a LobbyDataUpdate_t callback
+	virtual bool SetLobbyData( CSteamID steamIDLobby, const char *pchKey, const char *pchValue ) = 0;
+
+	// As above, but gets per-user data for someone in this lobby
+	virtual const char *GetLobbyMemberData( CSteamID steamIDLobby, CSteamID steamIDUser, const char *pchKey ) = 0;
+	// Sets per-user metadata (for the local user implicitly)
+	virtual bool SetLobbyMemberData_OLD( CSteamID steamIDLobby, const char *pchKey, const char *pchValue ) = 0;
+	
+	// Broadcasts a chat message to the all the users in the lobby
+	// users in the lobby (including the local user) will receive a LobbyChatMsg_t callback
+	// returns true if the message is successfully sent
+	virtual bool SendLobbyChatMsg( CSteamID steamIDLobby, const void *pvMsgBody, int cubMsgBody ) = 0;
+	// Get a chat message as specified in a LobbyChatMsg_t callback
+	// iChatID is the LobbyChatMsg_t::m_iChatID value in the callback
+	// *pSteamIDUser is filled in with the CSteamID of the member
+	// *pvData is filled in with the message itself
+	// return value is the number of bytes written into the buffer
+	virtual int GetLobbyChatEntry( CSteamID steamIDLobby, int iChatID, CSteamID *pSteamIDUser, void *pvData, int cubData, EChatEntryType *peChatEntryType ) = 0;
+
+	// Fetch metadata for a lobby you're not necessarily in right now
+	// this will send down all the metadata associated with a lobby
+	// this is an asynchronous call
+	// returns false if the local user is not connected to the Steam servers
+	virtual bool RequestLobbyData( CSteamID steamIDLobby ) = 0;
+};
+
+#endif // ISTEAMMATCHMAKING001_H

--- a/sdk/steam/steam_api.h
+++ b/sdk/steam/steam_api.h
@@ -85,6 +85,7 @@
 #include "isteamutils008.h"
 #include "isteamutils009.h"
 #include "isteammatchmaking.h"
+#include "isteammatchmaking001.h"
 #include "isteammatchmaking002.h"
 #include "isteammatchmaking003.h"
 #include "isteammatchmaking004.h"

--- a/sdk/steam/steam_api.h
+++ b/sdk/steam/steam_api.h
@@ -24,6 +24,7 @@
 #include "isteamappdisableupdate.h"
 #include "isteambilling.h"
 #include "isteamclient.h"
+#include "isteamclient006.h"
 #include "isteamclient007.h"
 #include "isteamclient008.h"
 #include "isteamclient009.h"

--- a/sdk/steam/steam_api.h
+++ b/sdk/steam/steam_api.h
@@ -22,6 +22,7 @@
 
 // All of the interfaces
 #include "isteamappdisableupdate.h"
+#include "isteambilling.h"
 #include "isteamclient.h"
 #include "isteamclient007.h"
 #include "isteamclient008.h"

--- a/sdk/steam/steam_api.h
+++ b/sdk/steam/steam_api.h
@@ -225,6 +225,8 @@
 #include "isteamgameserver008.h"
 #include "isteamgameserver005.h"
 #include "isteamgameserver004.h"
+#include "isteamgameserver003.h"
+#include "isteamgameserver002.h"
 #include "isteamgameserverstats.h"
 #include "isteamgamestats.h"
 

--- a/sdk/steam/steam_api.h
+++ b/sdk/steam/steam_api.h
@@ -104,6 +104,8 @@
 #include "isteamuserstats005.h"
 #include "isteamuserstats004.h"
 #include "isteamuserstats003.h"
+#include "isteamuserstats002.h"
+#include "isteamuserstats001.h"
 #include "isteamapps.h"
 #include "isteamapps007.h"
 #include "isteamapps006.h"


### PR DESCRIPTION
* `ISteamMatchmaking001`
* `ISteamGameServer002`
* `ISteamGameServer003`
* `ISteamUserStats001`
* `ISteamUserStats002`
* `ISteamBilling` (undocumented)
* `ISteamClient006`
* `ISteamNetworkingSocketsSerialized001` as a proxy for `ISteamNetworkingSocketsSerialized002` (similar to proton implementation)
* missing getter for old interface with name `SteamApps` (alias for `STEAMAPPS_INTERFACE_VERSION001`)
* null pointer for `ISteamController001` and `ISteamController002` (actual return value from steamclient64.dll)
* null pointer for `SteamGameServer001` (actual return value from steamclient64.dll)

behavior changes:
* call `InitGameServer()` inside `Steam_GameServer::BSetServerType()` since some old games ignore the initialization
* send server `game_dir` property over network, currently unused though