### PR TITLE
attempt to fix some memory leaks

### DIFF
--- a/dll/dll/local_storage.h
+++ b/dll/dll/local_storage.h
@@ -81,7 +81,7 @@ public:
     unsigned int data_settings_size(std::string file);
     int get_data_settings(std::string file, char *data, unsigned int max_length);
     int count_files(std::string folder);
-    bool iterate_file(std::string folder, int index, char *output_filename, int32 *output_size);
+    bool iterate_file(std::string folder, int index, std::string &output_filename, int32 *output_size);
     bool file_exists(std::string folder, std::string file);
     unsigned int file_size(std::string folder, std::string file);
     bool file_delete(std::string folder, std::string file);

--- a/dll/dll/steam_matchmaking_servers.h
+++ b/dll/dll/steam_matchmaking_servers.h
@@ -19,6 +19,7 @@
 #define __INCLUDED_STEAM_MATCHMAKING_SERVERS_H__
 
 #include "base.h"
+#include "common_helpers/forgettable_memory.hpp"
 #include <ssq/a2s.h>
 
 struct Steam_Matchmaking_Servers_Direct_IP_Request {
@@ -67,6 +68,8 @@ public ISteamMatchmakingServers
     std::vector <struct Steam_Matchmaking_Servers_Gameserver_Friends> gameservers_friends{};
     std::vector <struct Steam_Matchmaking_Request> requests{};
     std::vector <struct Steam_Matchmaking_Servers_Direct_IP_Request> direct_ip_requests{};
+
+	common_helpers::ForgettableMemory<gameserveritem_t> requests_from_GetServerDetails{};
 
 	HServerListRequest RequestServerList(AppId_t iApp, ISteamMatchmakingServerListResponse *pRequestServersResponse, EMatchMakingType type);
 	void RequestOldServerList(AppId_t iApp, ISteamMatchmakingServerListResponse001 *pRequestServersResponse, EMatchMakingType type);

--- a/dll/dll/steam_remote_storage.h
+++ b/dll/dll/steam_remote_storage.h
@@ -20,6 +20,7 @@
 
 #include "base.h"
 #include "ugc_remote_storage_bridge.h"
+#include "common_helpers/forgettable_memory.hpp"
 
 struct Async_Read {
  SteamAPICall_t api_call{};
@@ -86,6 +87,7 @@ private:
     class Local_Storage *local_storage{};
     class SteamCallResults *callback_results{};
     class SteamCallBacks *callbacks{};
+    class RunEveryRunCB *run_every_runcb{};
 
     std::vector<struct Async_Read> async_reads{};
     std::vector<struct Stream_Write> stream_writes{};
@@ -94,9 +96,16 @@ private:
     
     bool steam_cloud_enabled = true;
 
+    common_helpers::ForgettableMemory<std::string> requests_GetFileNameAndSize{};
+    common_helpers::ForgettableMemory<std::string> requests_GetUGCDetails{};
+
+    static void steam_run_every_runcb(void *object);
+    void RunCallbacks();
+
 public:
 
-    Steam_Remote_Storage(class Settings *settings, class Ugc_Remote_Storage_Bridge *ugc_bridge, class Local_Storage *local_storage, class SteamCallResults *callback_results, class SteamCallBacks *callbacks);
+    Steam_Remote_Storage(class Settings *settings, class Ugc_Remote_Storage_Bridge *ugc_bridge, class Local_Storage *local_storage, class SteamCallResults *callback_results, class SteamCallBacks *callbacks, class RunEveryRunCB *run_every_runcb);
+    ~Steam_Remote_Storage();
 
     // NOTE
     //

--- a/dll/local_storage.cpp
+++ b/dll/local_storage.cpp
@@ -170,7 +170,7 @@ uint64_t Local_Storage::file_timestamp(std::string folder, std::string file)
     return 0;
 }
 
-bool Local_Storage::iterate_file(std::string folder, int index, char *output_filename, int32 *output_size)
+bool Local_Storage::iterate_file(std::string folder, int index, std::string &output_filename, int32 *output_size)
 {
     return false;
 }
@@ -766,8 +766,11 @@ uint64_t Local_Storage::file_timestamp(std::string folder, std::string file)
     return buffer.st_mtime;
 }
 
-bool Local_Storage::iterate_file(std::string folder, int index, char *output_filename, int32 *output_size)
+bool Local_Storage::iterate_file(std::string folder, int index, std::string &output_filename, int32 *output_size)
 {
+    output_filename.clear();
+    if (output_size) *output_size = 0;
+    
     if (folder.size() && folder.back() != *PATH_SEPARATOR) {
         folder.append(PATH_SEPARATOR);
     }
@@ -777,10 +780,12 @@ bool Local_Storage::iterate_file(std::string folder, int index, char *output_fil
 
     std::string name(desanitize_file_name(files[index].name));
     if (output_size) *output_size = file_size(folder, name);
+
 #if defined(STEAM_WIN32)
     name = replace_with(name, PATH_SEPARATOR, "/");
 #endif
-    strcpy(output_filename, name.c_str());
+
+    output_filename = std::move(name);
     return true;
 }
 

--- a/dll/steam_client.cpp
+++ b/dll/steam_client.cpp
@@ -100,7 +100,7 @@ Steam_Client::Steam_Client()
     steam_user_stats = new Steam_User_Stats(settings_client, network, local_storage, callback_results_client, callbacks_client, run_every_runcb, steam_overlay);
     steam_apps = new Steam_Apps(settings_client, callback_results_client, callbacks_client);
     steam_networking = new Steam_Networking(settings_client, network, callbacks_client, run_every_runcb);
-    steam_remote_storage = new Steam_Remote_Storage(settings_client, ugc_bridge, local_storage, callback_results_client, callbacks_client);
+    steam_remote_storage = new Steam_Remote_Storage(settings_client, ugc_bridge, local_storage, callback_results_client, callbacks_client, run_every_runcb);
     steam_screenshots = new Steam_Screenshots(local_storage, callbacks_client);
     steam_http = new Steam_HTTP(settings_client, network, callback_results_client, callbacks_client);
     steam_controller = new Steam_Controller(settings_client, callback_results_client, callbacks_client, run_every_runcb);

--- a/dll/steam_matchmaking_servers.cpp
+++ b/dll/steam_matchmaking_servers.cpp
@@ -395,10 +395,10 @@ gameserveritem_t *Steam_Matchmaking_Servers::GetServerDetails( HServerListReques
     }
 
     Gameserver *gs = &gameservers_filtered[iServer].server;
-    gameserveritem_t *server = new gameserveritem_t(); //TODO: is the new here ok?
-    server_details(gs, server);
+    auto &server = requests_from_GetServerDetails.create(std::chrono::hours(1));
+    server_details(gs, &server);
     PRINT_DEBUG("  Returned server details");
-    return server;
+    return &server;
 }
 
 
@@ -910,6 +910,8 @@ void Steam_Matchmaking_Servers::RunCallbacks()
         if (r.players_response) r.players_response->PlayersRefreshComplete();
         if (r.ping_response) r.ping_response->ServerFailedToRespond();
     }
+
+    requests_from_GetServerDetails.cleanup();
 }
 
 void Steam_Matchmaking_Servers::Callback(Common_Message *msg)

--- a/helpers/common_helpers/forgettable_memory.hpp
+++ b/helpers/common_helpers/forgettable_memory.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <chrono>
+#include <mutex>
+#include <forward_list>
+#include <utility>
+#include <algorithm>
+
+
+namespace common_helpers
+{
+  template<typename Ty>
+  class ForgettableMemory {
+    struct ForgettableBlock {
+      Ty block;
+      std::chrono::high_resolution_clock::time_point due_time;
+
+      template<typename Rep, typename Period, class... Args>
+      ForgettableBlock(std::chrono::duration<Rep, Period> duration, Args&&... args)
+        : due_time(std::chrono::high_resolution_clock::now() + duration),
+          block(  std::forward<Args>(args)... )
+      { }
+    };
+
+    std::recursive_mutex mtx{};
+    std::forward_list<ForgettableBlock> storage{};
+
+
+  public:
+    template<typename Rep, typename Period, class... Args>
+    Ty& create(std::chrono::duration<Rep, Period> duration, Args&&... args) {
+      std::lock_guard lock(mtx);
+
+      auto& new_ele = storage.emplace_front(duration, std::forward<Args>(args)...);
+      return new_ele.block;
+    }
+
+    bool is_alive(const Ty& block) {
+      std::lock_guard lock(mtx);
+      
+      auto ele_it = std::find_if(storage.begin(), storage.end(), [&block](const ForgettableBlock &item){
+        return &item.block == &block;
+      });
+      return storage.end() != ele_it;
+    }
+
+    void destroy(const Ty& block) {
+      std::lock_guard lock(mtx);
+      
+      storage.remove_if([&block](const ForgettableBlock &item){
+        return &item.block == &block;
+      });
+    }
+
+    void destroy_all() {
+      std::lock_guard lock(mtx);
+      
+      storage.clear();
+    }
+
+    void cleanup() {
+      std::lock_guard lock(mtx);
+      
+      const auto now = std::chrono::high_resolution_clock::now();
+      storage.remove_if([&now](const ForgettableBlock &item){
+        return now > item.due_time;
+      });
+
+    }
+
+  };
+}


### PR DESCRIPTION
this introduces a simple/cheap managed memory allocator, each allocated object is given a due/deadline time, after which the object is deallocated.
this memory manager relies on constant polling, just like the rest of the steam ecosystem, meaning that it doesn't spawn any threads and so it becomes the responsibility of the **containing class**.

if the containing class failed to perform this polling operation, the behavior becomes similar to simply using the `new` operator and storing the addresses (as if we were using `std::vector<void *>`), and since the allocator stores a reference to all allocated objects at least they will be deallocated once the *containing class itself* is destroyed.

I don't know for how long should these objects stay alive though, so I set each one to a comically large number.

used in:
* `Steam_Remote_Storage::GetFileNameAndSize()` (also removes the 300 chars filename limit)
* `Steam_Matchmaking_Servers::GetServerDetails()`
* `Steam_Remote_Storage::GetUGCDetails()`

feel free to reject this PR if it seems unsafe, it's understandable that this might be problematic.