### PR TITLE
Implement page logic for all UGC query APIs

### DIFF
--- a/dll/dll/steam_ugc.h
+++ b/dll/dll/steam_ugc.h
@@ -21,10 +21,20 @@
 #include "base.h"
 #include "ugc_remote_storage_bridge.h"
 
+enum EQueryType {
+	eUserUGCRequest = 0,
+	eAllUGCRequestPage,
+	eAllUGCRequestCursor,
+	eUGCDetailsRequest
+};
+
 struct UGC_query {
     UGCQueryHandle_t handle{};
     std::set<PublishedFileId_t> return_only{};
     bool return_all_subscribed{};
+    uint32 page{};
+    bool next_cursor = true;
+    EQueryType query_type{};
 
     std::set<PublishedFileId_t> results{};
     
@@ -75,7 +85,10 @@ private:
     std::set<PublishedFileId_t> favorites{};
 
     UGCQueryHandle_t new_ugc_query(
+        EQueryType query_type,
         bool return_all_subscribed = false,
+        uint32 page = 0,
+        bool next_cursor = true,
         const std::set<PublishedFileId_t> &return_only = std::set<PublishedFileId_t>());
 
     std::optional<Mod_entry> get_query_ugc(UGCQueryHandle_t handle, uint32 index);


### PR DESCRIPTION
Some apps like 1920960 may strangely call `CreateQueryAllUGCRequest()` to query UGCs, which is currently not implemented in emu and will return 0 results. And some other apps like 1213210 depend on `unPage` parameter of `CreateQueryUserUGCRequest()` being correctly handled, or they may crash otherwise. And when there are more than 50 UGCs locally installed, `unPage` cannot be ignored because real steam returns the results in pages. So it is needed to implement it somehow.
For `CreateQueryAllUGCRequest()`, it should be noted that:
1. Of course we are unable to fetch all UGCs of steam workshop for one app when totally not get connected to steam server, and it is mostly not needed to fetch that much info anyway, so I implemented it to return all UGCs currently locally installed instead.
2. For `CreateQueryAllUGCRequest()`, there is a variant featuring "deep paging interface", which unfortunately I have no clues on what the cursor really means. However, since normally an app must rely on cursor returned by api, I choose to emu it to be a text of page number instead, which I hope to somehow make it functional.