### PR TITLE
Mark optional steps in mods setup as such

### DIFF
--- a/post_build/README.release.md
+++ b/post_build/README.release.md
@@ -112,8 +112,8 @@ Note that paths are treated as relative paths **from where the steam_api dll is 
 
 ## Mods:
 * Put your mod in the `steam_settings\mods\<MOD NUMBER>\` folder
-* Modify `mods.json` and specify `primary_filename` and `preview_filename`, other options in this json file are optional.  
-* Put the mod image/preview inside `steam_settings\mod_images\<MOD NUMBER>`
+* (Optional) Modify `mods.json` and specify `primary_filename` and `preview_filename`, other options in this json file are optional.  
+* (Optional) Put the mod image/preview inside `steam_settings\mod_images\<MOD NUMBER>`
 
 Mod data folder must be a number corresponding to the file id of the mod.
 


### PR DESCRIPTION
It's currently easy to misunderstand the mod setup instructions regarding "mods.json" as mandatory.
I've tested the mod setup to behave the same way as the original GBE without "mods.json" being set up as described in the readme, and it worked fine.
So i think this should be clarified in the readme.

Here's an example of a user being confused by the current phrasing:
https://cs.rin.ru/forum/viewtopic.php?p=3208082#p3208082