### PR TITLE
Fix `GetItemState()`

### DIFF
--- a/dll/steam_ugc.cpp
+++ b/dll/steam_ugc.cpp
@@ -1462,8 +1462,14 @@ uint32 Steam_UGC::GetItemState( PublishedFileId_t nPublishedFileID )
     }
 
     if (ugc_bridge->has_subbed_mod(nPublishedFileID)) {
-        PRINT_DEBUG("  mod is subscribed and installed");
-        return k_EItemStateInstalled | k_EItemStateSubscribed;
+        if (subscribed_disabled.count(nPublishedFileID)) {
+            PRINT_DEBUG("  mod is subscribed but disabled");
+            return k_EItemStateDisabledLocally | k_EItemStateSubscribed;
+        }
+        else {
+            PRINT_DEBUG("  mod is subscribed and installed");
+            return k_EItemStateInstalled | k_EItemStateSubscribed;
+        }
     }
 
 


### PR DESCRIPTION
From my tests this api actually behaves differently when requesting ids that have been previously disabled by calling new `SetItemsDisabledLocally()`. So a fix is needed.