### PR TITLE
Initial implementation of `GetGlobalStat()`

### DIFF
--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -92,6 +92,10 @@ struct Stat_config {
         float default_value_float;
         int32 default_value_int;
     };
+    union {
+        double global_value_double;
+        int64 global_value_int64;
+    };
 };
 
 struct Image_Data {

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -831,25 +831,25 @@ static void parse_leaderboards(class Settings *settings_client, class Settings *
 // stats.json
 static void parse_stats(class Settings *settings_client, class Settings *settings_server, class Local_Storage *local_storage)
 {
-        nlohmann::json stats_items;
-        std::string stats_json_path = Local_Storage::get_game_settings_path() + "stats.json";
-        if (local_storage->load_json(stats_json_path, stats_items)) {
-            for (const auto &stats : stats_items) {
-                std::string stat_name;
-                std::string stat_type;
-                std::string stat_default_value = "0";
-                std::string stat_global_value = "0";
+    nlohmann::json stats_items;
+    std::string stats_json_path = Local_Storage::get_game_settings_path() + "stats.json";
+    if (local_storage->load_json(stats_json_path, stats_items)) {
+        for (const auto &stats : stats_items) {
+            std::string stat_name;
+            std::string stat_type;
+            std::string stat_default_value = "0";
+            std::string stat_global_value = "0";
 
-                try {
-                    stat_name = stats.value("name", std::string(""));
-                    stat_type = stats.value("type", std::string(""));
-                    stat_default_value = stats.value("default", std::string("0"));
-                    stat_global_value = stats.value("global", std::string("0"));
-                }
-                catch (const std::exception &e) {
-                    PRINT_DEBUG("Error reading current stat item in stats.json, reason: %s", e.what());
-                    continue;
-                }
+            try {
+                stat_name = stats.value("name", std::string(""));
+                stat_type = stats.value("type", std::string(""));
+                stat_default_value = stats.value("default", std::string("0"));
+                stat_global_value = stats.value("global", std::string("0"));
+            }
+            catch (const std::exception &e) {
+                PRINT_DEBUG("Error reading current stat item in stats.json, reason: %s", e.what());
+                continue;
+            }
 
             std::transform(stat_type.begin(), stat_type.end(), stat_type.begin(),[](unsigned char c){ return std::tolower(c); });
             struct Stat_config config = {};

--- a/dll/steam_user_stats_stats.cpp
+++ b/dll/steam_user_stats_stats.cpp
@@ -625,6 +625,18 @@ bool Steam_User_Stats::GetGlobalStat( const char *pchStatName, int64 *pData )
 {
     PRINT_DEBUG_TODO();
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (!pchStatName) return false;
+    std::string stat_name = common_helpers::to_lower(pchStatName);
+    const auto &stats_config = settings->getStats();
+    auto stats_data = stats_config.find(stat_name);
+    if (stats_data != stats_config.end()) {
+        if (stats_data->second.type != GameServerStats_Messages::StatInfo::STAT_TYPE_INT)
+            return false;
+
+        if (pData)
+            *pData = stats_data->second.global_value_int64;
+        return true;
+    }
     return false;
 }
 
@@ -632,6 +644,18 @@ bool Steam_User_Stats::GetGlobalStat( const char *pchStatName, double *pData )
 {
     PRINT_DEBUG_TODO();
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (!pchStatName) return false;
+    std::string stat_name = common_helpers::to_lower(pchStatName);
+    const auto &stats_config = settings->getStats();
+    auto stats_data = stats_config.find(stat_name);
+    if (stats_data != stats_config.end()) {
+        if (stats_data->second.type == GameServerStats_Messages::StatInfo::STAT_TYPE_INT)
+            return false;
+
+        if (pData)
+            *pData = stats_data->second.global_value_double;
+        return true;
+    }
     return false;
 }
 


### PR DESCRIPTION
Some games "creatively" unlock DLCs by checking global stats of some stats, for example, appid 102600. In order to unlock "Orc Slayer DLC" in that game, the global stat "totalkills" must be larger than 250,000,000, and currently the emu just fails when calling the function, resulting the DLC locked.
**NOTE:** to conveniently implement the function, a **breaking change** has been introduced: `stats.txt` -> `stats.json`. I think by using json it would be easier to attach multiple attributes to a single stat, and to add more attributes in the future if needed.
Due to a breaking change introduced and tests needed, I currently set this PR to a draft.