### PR TITLE
Allow returning empty path in `Steam_Apps::GetAppInstallDir()`

### DIFF
--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -401,7 +401,7 @@ public:
 
     //App Install paths
     void setAppInstallPath(AppId_t appID, const std::string &path);
-    std::string getAppInstallPath(AppId_t appID);
+    bool getAppInstallPath(AppId_t appID, std::string &path);
 
     //mod stuff
     void addMod(PublishedFileId_t id, const std::string &title, const std::string &path);

--- a/dll/settings.cpp
+++ b/dll/settings.cpp
@@ -328,9 +328,16 @@ void Settings::setAppInstallPath(AppId_t appID, const std::string &path)
     app_paths[appID] = path;
 }
 
-std::string Settings::getAppInstallPath(AppId_t appID)
+bool Settings::getAppInstallPath(AppId_t appID, std::string &path)
 {
-    return app_paths[appID];
+    auto app_path = app_paths.find(appID);
+    if (app_paths.end() != app_path)
+    {
+        path = app_path->second;
+        return true;
+    }
+
+    return false;
 }
 
 void Settings::setLeaderboard(const std::string &leaderboard, enum ELeaderboardSortMethod sort_method, enum ELeaderboardDisplayType display_type)

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -767,15 +767,18 @@ static void parse_app_paths(class Settings *settings_client, Settings *settings_
 
     for (const auto &id : ids) {
         auto val_ptr = ini.GetValue("app::paths", id.pItem);
-        if (!val_ptr || !val_ptr[0]) continue;
+        // NOTE: empty path means we actively disable the path to the appid specified
+        if (!val_ptr) continue;
 
         AppId_t appid = (AppId_t)std::stoul(id.pItem);
         std::string rel_path(val_ptr);
-        std::string path = canonical_path(program_path + rel_path);
+        std::string path{};
+        if (rel_path.size())
+            path = canonical_path(program_path + rel_path);
 
         if (appid) {
-            if (path.size()) {
-                PRINT_DEBUG("Adding app path: %u|%s|", appid, path.c_str());
+            if (!rel_path.size() || path.size()) {
+                PRINT_DEBUG("Adding app path: %u|%s|%s", appid, rel_path.c_str(), path.c_str());
                 settings_client->setAppInstallPath(appid, path);
                 settings_server->setAppInstallPath(appid, path);
             } else {

--- a/dll/steam_apps.cpp
+++ b/dll/steam_apps.cpp
@@ -321,9 +321,9 @@ uint32 Steam_Apps::GetAppInstallDir( AppId_t appID, char *pchFolder, uint32 cchF
     PRINT_DEBUG("%u %p %u", appID, pchFolder, cchFolderBufferSize);
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
     //TODO return real path instead of dll path
-    std::string installed_path = settings->getAppInstallPath(appID);
+    std::string installed_path;
 
-    if (installed_path.empty()) {
+    if (!settings->getAppInstallPath(appID, installed_path)) {
         std::string dll_path = get_full_program_path();
         std::string current_path = get_current_path();
         PRINT_DEBUG("  dll: '%s', current: '%s'", dll_path.c_str(), current_path.c_str());
@@ -334,6 +334,9 @@ uint32 Steam_Apps::GetAppInstallDir( AppId_t appID, char *pchFolder, uint32 cchF
         } else {
             installed_path = dll_path;
         }
+    }
+    else if (installed_path.empty()) {
+        return 0; // NOTE: empty path means we actively disable the path to the appid specified
     }
 
     PRINT_DEBUG("  final path '%s'", installed_path.c_str());

--- a/post_build/steam_settings.EXAMPLE/configs.app.EXAMPLE.ini
+++ b/post_build/steam_settings.EXAMPLE/configs.app.EXAMPLE.ini
@@ -24,7 +24,13 @@ unlock_all=0
 56789=This is another example DLC name
 
 [app::paths]
+# some rare games might need to be provided one or more paths to appids
+# for example the path to where a DLC is installed
+# this sets the paths returned by the Steam_Apps::GetAppInstallDir function
 556760=../DLCRoot0
 1234=./folder_where_steam_api_is
 3456=../folder_one_level_above_where_steam_api_is
 5678=../../folder_two_levels_above_where_steam_api_is
+# however some other games might expect this function to return empty paths to properly load DLCs
+# you can deliberately set the path to be empty to specify this behavior like lines below
+1337=


### PR DESCRIPTION
Some games like appid 1113560 request DLC paths by `GetAppInstallDir()` API but for some reasons real steam returns 0 and fills nothing to the path buffer, and such games actually expect this behavior to properly load DLC content or they will either miss DLC models or simply crash. However, current code indicates other games may instead requiring proper paths to be set to load DLCs. So I end up with this solution that makes emu accept `app:paths` lines like "1337=" to indicate we deliberately set such DLC path to be empty to resolve both problems.
Related issue: #232 . After testing that game and making sure it works, I will set this PR as ready.