### PR TITLE
wip: emulate steam_input through sdl3

### DIFF
--- a/dll/dll/common_includes.h
+++ b/dll/dll/common_includes.h
@@ -146,7 +146,7 @@ static inline void reset_LastError()
 #endif
 
 // Other libs includes
-#include "gamepad/gamepad.h"
+// #include "gamepad/gamepad.h"
 
 // Steamsdk includes
 #include "steam/steam_api.h"

--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -307,7 +307,10 @@ public:
     //controller
     struct Controller_Settings controller_settings{};
     std::string glyphs_directory{};
-
+    bool flip_nintendo_layout = false;
+    bool combine_joycons = true;
+    uint16 inner_deadzone = 2000;
+    uint16 outer_deadzone = 3000;
 
     // allow Steam_User_Stats::FindLeaderboard() to always succeed and create the given unknown leaderboard
     bool disable_leaderboards_create_unknown = false;

--- a/dll/dll/steam_controller.h
+++ b/dll/dll/steam_controller.h
@@ -17,9 +17,10 @@
 
 #ifndef __INCLUDED_STEAM_CONTROLLER_H__
 #define __INCLUDED_STEAM_CONTROLLER_H__
+#define GAMEPAD_COUNT 4
 
 #include "base.h"
-
+#include "gamepad_provider/gamepad_provider.hpp"
 
 struct Controller_Map {
     std::map<ControllerDigitalActionHandle_t, std::set<int>> active_digital{};
@@ -30,10 +31,13 @@ struct Controller_Action {
     ControllerHandle_t controller_handle{};
     struct Controller_Map active_map{};
     ControllerDigitalActionHandle_t active_set{};
+    std::map<ControllerActionSetHandle_t, struct Controller_Map> active_layers{};
 
     Controller_Action(ControllerHandle_t controller_handle);
 
     void activate_action_set(ControllerDigitalActionHandle_t active_set, std::map<ControllerActionSetHandle_t, struct Controller_Map> &controller_maps);
+    void activate_action_set_layer(ControllerActionSetHandle_t active_layer, std::map<ControllerActionSetHandle_t, struct Controller_Map> &controller_maps);
+    void deactivate_action_set_layer(ControllerActionSetHandle_t active_layer);
     std::set<int> button_id(ControllerDigitalActionHandle_t handle);
     std::pair<std::set<int>, enum EInputSourceMode> analog_id(ControllerAnalogActionHandle_t handle);
 };
@@ -101,6 +105,7 @@ public ISteamInput
     std::map<EInputActionOrigin, std::string> steaminput_glyphs{};
     std::map<EControllerActionOrigin, std::string> steamcontroller_glyphs{};
 
+    std::thread sdl_thread{};
     std::thread background_rumble_thread{};
     Rumble_Thread_Data *rumble_thread_data{};
 
@@ -108,7 +113,8 @@ public ISteamInput
     bool initialized{};
     bool explicitly_call_run_frame{};
 
-    void set_handles(std::map<std::string, std::map<std::string, std::pair<std::set<std::string>, std::string>>> action_sets);
+    void set_handles(std::map<std::string, std::map<std::string, std::pair<std::set<std::string>, std::string>>> action_sets,
+        std::map<std::string, std::map<std::string, std::pair<std::set<std::string>, std::string>>> action_set_layers);
 
     void RunCallbacks();
 

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -453,66 +453,72 @@ static void split_string(const std::string &s, char delim, Out result) {
 // folder "controller"
 static void load_gamecontroller_settings(Settings *settings)
 {
-    std::string path = Local_Storage::get_game_settings_path() + "controller";
-    std::vector<std::string> paths = Local_Storage::get_filenames_path(path);
+    auto process_paths = [&](std::string path, std::map<std::string, std::map<std::string, std::pair<std::set<std::string>, std::string>>> action_sets) {
+        std::vector<std::string> paths = Local_Storage::get_filenames_path(path);
+        for (auto& p : paths) {
+            size_t length = p.length();
+            if (length < 4) continue;
+            if (std::toupper(p.back()) != 'T') continue;
+            if (std::toupper(p[length - 2]) != 'X') continue;
+            if (std::toupper(p[length - 3]) != 'T') continue;
+            if (p[length - 4] != '.') continue;
 
-    for (auto & p: paths) {
-        size_t length = p.length();
-        if (length < 4) continue;
-        if ( std::toupper(p.back()) != 'T') continue;
-        if ( std::toupper(p[length - 2]) != 'X') continue;
-        if ( std::toupper(p[length - 3]) != 'T') continue;
-        if (p[length - 4] != '.') continue;
+            PRINT_DEBUG("controller config %s", p.c_str());
+            std::string action_set_name = p.substr(0, length - 4);
+            std::transform(action_set_name.begin(), action_set_name.end(), action_set_name.begin(), [](unsigned char c) { return std::toupper(c); });
 
-        PRINT_DEBUG("controller config %s", p.c_str());
-        std::string action_set_name = p.substr(0, length - 4);
-        std::transform(action_set_name.begin(), action_set_name.end(), action_set_name.begin(),[](unsigned char c){ return std::toupper(c); });
+            std::string controller_config_path = path + PATH_SEPARATOR + p;
+            std::ifstream input(std::filesystem::u8path(controller_config_path));
+            if (input.is_open()) {
+                common_helpers::consume_bom(input);
+                std::map<std::string, std::pair<std::set<std::string>, std::string>> button_pairs;
 
-        std::string controller_config_path = path + PATH_SEPARATOR + p;
-        std::ifstream input( std::filesystem::u8path(controller_config_path) );
-        if (input.is_open()) {
-            common_helpers::consume_bom(input);
-            std::map<std::string, std::pair<std::set<std::string>, std::string>> button_pairs;
-
-            for( std::string line; getline( input, line ); ) {
-                if (!line.empty() && line[line.length()-1] == '\n') {
-                    line.pop_back();
-                }
-
-                if (!line.empty() && line[line.length()-1] == '\r') {
-                    line.pop_back();
-                }
-
-                std::string action_name;
-                std::string button_name;
-                std::string source_mode;
-
-                std::size_t deliminator = line.find("=");
-                if (deliminator != 0 && deliminator != std::string::npos && deliminator != line.size()) {
-                    action_name = line.substr(0, deliminator);
-                    std::size_t deliminator2 = line.find("=", deliminator + 1);
-
-                    if (deliminator2 != std::string::npos && deliminator2 != line.size()) {
-                        button_name = line.substr(deliminator + 1, deliminator2 - (deliminator + 1));
-                        source_mode = line.substr(deliminator2 + 1);
-                    } else {
-                        button_name = line.substr(deliminator + 1);
-                        source_mode = "";
+                for (std::string line; getline(input, line); ) {
+                    if (!line.empty() && line[line.length() - 1] == '\n') {
+                        line.pop_back();
                     }
+
+                    if (!line.empty() && line[line.length() - 1] == '\r') {
+                        line.pop_back();
+                    }
+
+                    std::string action_name;
+                    std::string button_name;
+                    std::string source_mode;
+
+                    std::size_t deliminator = line.find("=");
+                    if (deliminator != 0 && deliminator != std::string::npos && deliminator != line.size()) {
+                        action_name = line.substr(0, deliminator);
+                        std::size_t deliminator2 = line.find("=", deliminator + 1);
+
+                        if (deliminator2 != std::string::npos && deliminator2 != line.size()) {
+                            button_name = line.substr(deliminator + 1, deliminator2 - (deliminator + 1));
+                            source_mode = line.substr(deliminator2 + 1);
+                        }
+                        else {
+                            button_name = line.substr(deliminator + 1);
+                            source_mode = "";
+                        }
+                    }
+
+                    std::transform(action_name.begin(), action_name.end(), action_name.begin(), [](unsigned char c) { return std::toupper(c); });
+                    std::transform(button_name.begin(), button_name.end(), button_name.begin(), [](unsigned char c) { return std::toupper(c); });
+                    std::pair<std::set<std::string>, std::string> button_config = { {}, source_mode };
+                    split_string(button_name, ',', std::inserter(button_config.first, button_config.first.begin()));
+                    button_pairs[action_name] = button_config;
+                    PRINT_DEBUG("Added %s %s %s", action_name.c_str(), button_name.c_str(), source_mode.c_str());
                 }
 
-                std::transform(action_name.begin(), action_name.end(), action_name.begin(),[](unsigned char c){ return std::toupper(c); });
-                std::transform(button_name.begin(), button_name.end(), button_name.begin(),[](unsigned char c){ return std::toupper(c); });
-                std::pair<std::set<std::string>, std::string> button_config = {{}, source_mode};
-                split_string(button_name, ',', std::inserter(button_config.first, button_config.first.begin()));
-                button_pairs[action_name] = button_config;
-                PRINT_DEBUG("Added %s %s %s", action_name.c_str(), button_name.c_str(), source_mode.c_str());
+                action_sets[action_set_name] = button_pairs;
+                PRINT_DEBUG("Added %zu action names to %s", button_pairs.size(), action_set_name.c_str());
             }
-
-            settings->controller_settings.action_sets[action_set_name] = button_pairs;
-            PRINT_DEBUG("Added %zu action names to %s", button_pairs.size(), action_set_name.c_str());
         }
-    }
+    };
+
+    std::string path = Local_Storage::get_game_settings_path() + "controller";
+    std::string layers_path = path + (PATH_SEPARATOR "layers" PATH_SEPARATOR);
+    process_paths(path, settings->controller_settings.action_sets);
+    process_paths(layers_path, settings->controller_settings.action_set_layers);
 
     settings->glyphs_directory = path + (PATH_SEPARATOR "glyphs" PATH_SEPARATOR);
 }

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -21,6 +21,7 @@
 #define SI_SUPPORT_IOSTREAMS
 #define SI_NO_MBCS
 #include "simpleini/SimpleIni.h"
+#include "gamepad_provider/gamepad_provider.hpp"
 
 
 constexpr const static char config_ini_app[]     = "configs.app.ini";
@@ -1513,6 +1514,20 @@ static void parse_simple_features(class Settings *settings_client, class Setting
     settings_server->enable_builtin_preowned_ids = ini.GetBoolValue("main::misc", "enable_steam_preowned_ids", settings_server->enable_builtin_preowned_ids);
 }
 
+// [main::gamepad] 
+static void parse_user_gamepad_settings(class Settings* settings_client, class Settings* settings_server) {
+    settings_client->flip_nintendo_layout = ini.GetBoolValue("main::gamepad", "flip_nintendo_layout", settings_client->flip_nintendo_layout);
+    settings_server->flip_nintendo_layout = ini.GetBoolValue("main::gamepad", "flip_nintendo_layout", settings_server->flip_nintendo_layout);
+
+    settings_client->combine_joycons = ini.GetBoolValue("main::gamepad", "combine_joycons", settings_client->combine_joycons);
+    settings_server->combine_joycons = ini.GetBoolValue("main::gamepad", "combine_joycons", settings_server->combine_joycons);
+
+    settings_client->inner_deadzone = std::min(static_cast<uint16>(ini.GetLongValue("main::gamepad", "inner_deadzone", settings_client->inner_deadzone)), static_cast<uint16>(JOYSTICK_MAX));
+    settings_server->inner_deadzone = std::min(static_cast<uint16>(ini.GetLongValue("main::gamepad", "inner_deadzone", settings_server->inner_deadzone)), static_cast<uint16>(JOYSTICK_MAX));
+    settings_client->outer_deadzone = std::min(static_cast<uint16>(ini.GetLongValue("main::gamepad", "outer_deadzone", settings_client->outer_deadzone)), static_cast<uint16>(JOYSTICK_MAX));
+    settings_server->outer_deadzone = std::min(static_cast<uint16>(ini.GetLongValue("main::gamepad", "outer_deadzone", settings_server->outer_deadzone)), static_cast<uint16>(JOYSTICK_MAX));
+}
+
 // [main::stats]
 static void parse_stats_features(class Settings *settings_client, class Settings *settings_server)
 {
@@ -1791,6 +1806,7 @@ uint32 create_localstorage_settings(Settings **settings_client_out, Settings **s
 
     parse_simple_features(settings_client, settings_server);
     parse_stats_features(settings_client, settings_server);
+    parse_user_gamepad_settings(settings_client, settings_server);
 
     parse_dlc(settings_client, settings_server);
     parse_installed_app_Ids(settings_client, settings_server);

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -453,7 +453,7 @@ static void split_string(const std::string &s, char delim, Out result) {
 // folder "controller"
 static void load_gamecontroller_settings(Settings *settings)
 {
-    auto process_paths = [&](std::string path, std::map<std::string, std::map<std::string, std::pair<std::set<std::string>, std::string>>> action_sets) {
+    auto process_paths = [&](std::string &path, std::map<std::string, std::map<std::string, std::pair<std::set<std::string>, std::string>>> &action_sets) {
         std::vector<std::string> paths = Local_Storage::get_filenames_path(path);
         for (auto& p : paths) {
             size_t length = p.length();

--- a/dll/steam_controller.cpp
+++ b/dll/steam_controller.cpp
@@ -506,7 +506,7 @@ ControllerActionSetHandle_t Steam_Controller::GetCurrentActionSet(ControllerHand
 
 void Steam_Controller::ActivateActionSetLayer(ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetLayerHandle)
 {
-    PRINT_DEBUG_ENTRY();
+    PRINT_DEBUG_TODO();
     auto controller = controllers.find(controllerHandle);
     if (controller == controllers.end()) return;
     controller->second.activate_action_set_layer(actionSetLayerHandle, controller_maps);
@@ -514,7 +514,7 @@ void Steam_Controller::ActivateActionSetLayer(ControllerHandle_t controllerHandl
 
 void Steam_Controller::DeactivateActionSetLayer(ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetLayerHandle)
 {
-    PRINT_DEBUG_ENTRY();
+    PRINT_DEBUG_TODO();
     auto controller = controllers.find(controllerHandle);
     if (controller == controllers.end()) return;
     controller->second.deactivate_action_set_layer(actionSetLayerHandle);
@@ -522,7 +522,7 @@ void Steam_Controller::DeactivateActionSetLayer(ControllerHandle_t controllerHan
 
 void Steam_Controller::DeactivateAllActionSetLayers(ControllerHandle_t controllerHandle)
 {
-    PRINT_DEBUG_ENTRY();
+    PRINT_DEBUG_TODO();
     auto controller = controllers.find(controllerHandle);
     if (controller == controllers.end()) return;
     controller->second.active_layers.clear();
@@ -530,7 +530,7 @@ void Steam_Controller::DeactivateAllActionSetLayers(ControllerHandle_t controlle
 
 int Steam_Controller::GetActiveActionSetLayers(ControllerHandle_t controllerHandle, ControllerActionSetHandle_t* handlesOut)
 {
-    PRINT_DEBUG_ENTRY();
+    PRINT_DEBUG_TODO();
     auto controller = controllers.find(controllerHandle);
     if (controller == controllers.end()) return 0;
     int count = 0;
@@ -1396,6 +1396,126 @@ const char* Steam_Controller::GetGlyphForActionOrigin(EControllerActionOrigin eO
         steamcontroller_glyphs[k_EControllerActionOrigin_XBox360_DPad_West] = dir + "xbox_button_dpad_w.png";
         steamcontroller_glyphs[k_EControllerActionOrigin_XBox360_DPad_East] = dir + "xbox_button_dpad_e.png";
         steamcontroller_glyphs[k_EControllerActionOrigin_XBox360_DPad_Move] = dir + "xbox_button_dpad_move.png";
+
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_A] = dir + "button_a.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_B] = dir + "button_b.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_X] = dir + "button_x.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_Y] = dir + "button_y.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_LeftBumper] = dir + "shoulder_l.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_RightBumper] = dir + "shoulder_r.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_Menu] = dir + "xbox_button_menu.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_View] = dir + "xbox_button_view.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_LeftTrigger_Pull] = dir + "trigger_l_pull.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_LeftTrigger_Click] = dir + "trigger_l_click.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_RightTrigger_Pull] = dir + "trigger_r_pull.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_RightTrigger_Click] = dir + "trigger_r_click.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_LeftStick_Move] = dir + "stick_l_move.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_LeftStick_Click] = dir + "stick_l_click.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_LeftStick_DPadNorth] = dir + "stick_dpad_n.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_LeftStick_DPadSouth] = dir + "stick_dpad_s.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_LeftStick_DPadWest] = dir + "stick_dpad_w.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_LeftStick_DPadEast] = dir + "stick_dpad_e.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_RightStick_Move] = dir + "stick_r_move.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_RightStick_Click] = dir + "stick_r_click.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_RightStick_DPadNorth] = dir + "stick_dpad_n.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_RightStick_DPadSouth] = dir + "stick_dpad_s.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_RightStick_DPadWest] = dir + "stick_dpad_w.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_RightStick_DPadEast] = dir + "stick_dpad_e.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_DPad_North] = dir + "xbox_button_dpad_n.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_DPad_South] = dir + "xbox_button_dpad_s.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_DPad_West] = dir + "xbox_button_dpad_w.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_DPad_East] = dir + "xbox_button_dpad_e.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_XBoxOne_DPad_Move] = dir + "xbox_button_dpad_move.png";
+
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_X] = dir + "ps4_button_x.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_Circle] = dir + "ps4_button_circle.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_Square] = dir + "ps4_button_square.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_Triangle] = dir + "ps4_button_triangle.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_LeftBumper] = dir + "ps4_l1.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_RightBumper] = dir + "ps4_r1.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_Options] = dir + "ps4_button_options.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_Share] = dir + "ps4_button_share.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_LeftTrigger_Pull] = dir + "ps4_l2_pull.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_LeftTrigger_Click] = dir + "ps4_l2_click.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_RightTrigger_Pull] = dir + "ps4_r2_pull.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_RightTrigger_Click] = dir + "ps4_r2_click.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_LeftStick_Move] = dir + "stick_l_move.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_LeftStick_Click] = dir + "stick_l_click.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_LeftStick_DPadNorth] = dir + "stick_dpad_n.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_LeftStick_DPadSouth] = dir + "stick_dpad_s.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_LeftStick_DPadWest] = dir + "stick_dpad_w.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_LeftStick_DPadEast] = dir + "stick_dpad_e.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_RightStick_Move] = dir + "stick_r_move.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_RightStick_Click] = dir + "stick_r_click.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_RightStick_DPadNorth] = dir + "stick_dpad_n.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_RightStick_DPadSouth] = dir + "stick_dpad_s.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_RightStick_DPadWest] = dir + "stick_dpad_w.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_RightStick_DPadEast] = dir + "stick_dpad_e.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_DPad_North] = dir + "ps4_button_dpad_n.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_DPad_South] = dir + "ps4_button_dpad_s.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_DPad_West] = dir + "ps4_button_dpad_w.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_DPad_East] = dir + "ps4_button_dpad_e.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS4_DPad_Move] = dir + "ps4_button_dpad_move.png";
+
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_X] = dir + "ps5_button_x.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_Circle] = dir + "ps5_button_circle.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_Square] = dir + "ps5_button_square.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_Triangle] = dir + "ps5_button_triangle.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_LeftBumper] = dir + "ps5_l1.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_RightBumper] = dir + "ps5_r1.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_Option] = dir + "ps5_button_option.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_Create] = dir + "ps5_button_create.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_LeftTrigger_Pull] = dir + "ps5_l2_pull.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_LeftTrigger_Click] = dir + "ps5_l2_click.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_RightTrigger_Pull] = dir + "ps5_r2_pull.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_RightTrigger_Click] = dir + "ps5_r2_click.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_LeftStick_Move] = dir + "stick_l_move.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_LeftStick_Click] = dir + "stick_l_click.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_LeftStick_DPadNorth] = dir + "stick_dpad_n.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_LeftStick_DPadSouth] = dir + "stick_dpad_s.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_LeftStick_DPadWest] = dir + "stick_dpad_w.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_LeftStick_DPadEast] = dir + "stick_dpad_e.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_RightStick_Move] = dir + "stick_r_move.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_RightStick_Click] = dir + "stick_r_click.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_RightStick_DPadNorth] = dir + "stick_dpad_n.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_RightStick_DPadSouth] = dir + "stick_dpad_s.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_RightStick_DPadWest] = dir + "stick_dpad_w.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_RightStick_DPadEast] = dir + "stick_dpad_e.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_DPad_North] = dir + "ps5_button_dpad_n.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_DPad_South] = dir + "ps5_button_dpad_s.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_DPad_West] = dir + "ps5_button_dpad_w.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_DPad_East] = dir + "ps5_button_dpad_e.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_PS5_DPad_Move] = dir + "ps5_button_dpad_move.png";
+
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_A] = dir + "switch_button_a.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_B] = dir + "switch_button_b.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_X] = dir + "switch_button_x.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_Y] = dir + "switch_button_y.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_LeftBumper] = dir + "switch_l.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_RightBumper] = dir + "switch_r.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_Plus] = dir + "switch_button_plus.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_Minus] = dir + "switch_button_minus.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_LeftTrigger_Pull] = dir + "switch_zl_pull.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_LeftTrigger_Click] = dir + "switch_zl_click.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_RightTrigger_Pull] = dir + "switch_zr_pull.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_RightTrigger_Click] = dir + "switch_zr_click.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_LeftStick_Move] = dir + "stick_l_move.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_LeftStick_Click] = dir + "stick_l_click.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_LeftStick_DPadNorth] = dir + "stick_dpad_n.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_LeftStick_DPadSouth] = dir + "stick_dpad_s.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_LeftStick_DPadWest] = dir + "stick_dpad_w.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_LeftStick_DPadEast] = dir + "stick_dpad_e.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_RightStick_Move] = dir + "stick_r_move.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_RightStick_Click] = dir + "stick_r_click.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_RightStick_DPadNorth] = dir + "stick_dpad_n.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_RightStick_DPadSouth] = dir + "stick_dpad_s.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_RightStick_DPadWest] = dir + "stick_dpad_w.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_RightStick_DPadEast] = dir + "stick_dpad_e.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_DPad_North] = dir + "switch_button_dpad_n.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_DPad_South] = dir + "switch_button_dpad_s.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_DPad_West] = dir + "switch_button_dpad_w.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_DPad_East] = dir + "switch_button_dpad_e.png";
+        steamcontroller_glyphs[k_EControllerActionOrigin_Switch_DPad_Move] = dir + "switch_button_dpad_move.png";
     }
 
     auto glyph = steamcontroller_glyphs.find(eOrigin);
@@ -1409,9 +1529,7 @@ const char* Steam_Controller::GetGlyphForActionOrigin(EInputActionOrigin eOrigin
 {
     PRINT_DEBUG("steaminput %i", eOrigin);
     if (steaminput_glyphs.empty()) {
-        //std::string base_dir = settings->glyphs_directory;
         std::string dir = settings->glyphs_directory;
-        //dir = base_dir + (PATH_SEPARATOR "XBox360" PATH_SEPARATOR);
         steaminput_glyphs[k_EInputActionOrigin_XBox360_A] = dir + "button_a.png";
         steaminput_glyphs[k_EInputActionOrigin_XBox360_B] = dir + "button_b.png";
         steaminput_glyphs[k_EInputActionOrigin_XBox360_X] = dir + "button_x.png";
@@ -1441,6 +1559,126 @@ const char* Steam_Controller::GetGlyphForActionOrigin(EInputActionOrigin eOrigin
         steaminput_glyphs[k_EInputActionOrigin_XBox360_DPad_West] = dir + "xbox_button_dpad_w.png";
         steaminput_glyphs[k_EInputActionOrigin_XBox360_DPad_East] = dir + "xbox_button_dpad_e.png";
         steaminput_glyphs[k_EInputActionOrigin_XBox360_DPad_Move] = dir + "xbox_button_dpad_move.png";
+
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_A] = dir + "button_a.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_B] = dir + "button_b.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_X] = dir + "button_x.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_Y] = dir + "button_y.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_LeftBumper] = dir + "shoulder_l.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_RightBumper] = dir + "shoulder_r.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_Menu] = dir + "xbox_button_menu.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_View] = dir + "xbox_button_view.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_LeftTrigger_Pull] = dir + "trigger_l_pull.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_LeftTrigger_Click] = dir + "trigger_l_click.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_RightTrigger_Pull] = dir + "trigger_r_pull.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_RightTrigger_Click] = dir + "trigger_r_click.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_LeftStick_Move] = dir + "stick_l_move.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_LeftStick_Click] = dir + "stick_l_click.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_LeftStick_DPadNorth] = dir + "stick_dpad_n.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_LeftStick_DPadSouth] = dir + "stick_dpad_s.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_LeftStick_DPadWest] = dir + "stick_dpad_w.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_LeftStick_DPadEast] = dir + "stick_dpad_e.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_RightStick_Move] = dir + "stick_r_move.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_RightStick_Click] = dir + "stick_r_click.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_RightStick_DPadNorth] = dir + "stick_dpad_n.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_RightStick_DPadSouth] = dir + "stick_dpad_s.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_RightStick_DPadWest] = dir + "stick_dpad_w.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_RightStick_DPadEast] = dir + "stick_dpad_e.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_DPad_North] = dir + "xbox_button_dpad_n.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_DPad_South] = dir + "xbox_button_dpad_s.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_DPad_West] = dir + "xbox_button_dpad_w.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_DPad_East] = dir + "xbox_button_dpad_e.png";
+        steaminput_glyphs[k_EInputActionOrigin_XBoxOne_DPad_Move] = dir + "xbox_button_dpad_move.png";
+
+        steaminput_glyphs[k_EInputActionOrigin_PS4_X] = dir + "ps4_button_x.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_Circle] = dir + "ps4_button_circle.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_Square] = dir + "ps4_button_square.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_Triangle] = dir + "ps4_button_triangle.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_LeftBumper] = dir + "ps4_l1.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_RightBumper] = dir + "ps4_r1.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_Options] = dir + "ps4_button_options.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_Share] = dir + "ps4_button_share.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_LeftTrigger_Pull] = dir + "ps4_l2_pull.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_LeftTrigger_Click] = dir + "ps4_l2_click.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_RightTrigger_Pull] = dir + "ps4_r2_pull.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_RightTrigger_Click] = dir + "ps4_r2_click.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_LeftStick_Move] = dir + "stick_l_move.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_LeftStick_Click] = dir + "stick_l_click.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_LeftStick_DPadNorth] = dir + "stick_dpad_n.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_LeftStick_DPadSouth] = dir + "stick_dpad_s.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_LeftStick_DPadWest] = dir + "stick_dpad_w.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_LeftStick_DPadEast] = dir + "stick_dpad_e.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_RightStick_Move] = dir + "stick_r_move.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_RightStick_Click] = dir + "stick_r_click.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_RightStick_DPadNorth] = dir + "stick_dpad_n.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_RightStick_DPadSouth] = dir + "stick_dpad_s.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_RightStick_DPadWest] = dir + "stick_dpad_w.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_RightStick_DPadEast] = dir + "stick_dpad_e.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_DPad_North] = dir + "ps4_button_dpad_n.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_DPad_South] = dir + "ps4_button_dpad_s.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_DPad_West] = dir + "ps4_button_dpad_w.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_DPad_East] = dir + "ps4_button_dpad_e.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS4_DPad_Move] = dir + "ps4_button_dpad_move.png";
+
+        steaminput_glyphs[k_EInputActionOrigin_PS5_X] = dir + "ps5_button_x.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_Circle] = dir + "ps5_button_circle.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_Square] = dir + "ps5_button_square.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_Triangle] = dir + "ps5_button_triangle.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_LeftBumper] = dir + "ps5_l1.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_RightBumper] = dir + "ps5_r1.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_Option] = dir + "ps5_button_option.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_Create] = dir + "ps5_button_create.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_LeftTrigger_Pull] = dir + "ps5_l2_pull.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_LeftTrigger_Click] = dir + "ps5_l2_click.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_RightTrigger_Pull] = dir + "ps5_r2_pull.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_RightTrigger_Click] = dir + "ps5_r2_click.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_LeftStick_Move] = dir + "stick_l_move.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_LeftStick_Click] = dir + "stick_l_click.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_LeftStick_DPadNorth] = dir + "stick_dpad_n.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_LeftStick_DPadSouth] = dir + "stick_dpad_s.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_LeftStick_DPadWest] = dir + "stick_dpad_w.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_LeftStick_DPadEast] = dir + "stick_dpad_e.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_RightStick_Move] = dir + "stick_r_move.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_RightStick_Click] = dir + "stick_r_click.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_RightStick_DPadNorth] = dir + "stick_dpad_n.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_RightStick_DPadSouth] = dir + "stick_dpad_s.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_RightStick_DPadWest] = dir + "stick_dpad_w.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_RightStick_DPadEast] = dir + "stick_dpad_e.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_DPad_North] = dir + "ps5_button_dpad_n.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_DPad_South] = dir + "ps5_button_dpad_s.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_DPad_West] = dir + "ps5_button_dpad_w.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_DPad_East] = dir + "ps5_button_dpad_e.png";
+        steaminput_glyphs[k_EInputActionOrigin_PS5_DPad_Move] = dir + "ps5_button_dpad_move.png";
+
+        steaminput_glyphs[k_EInputActionOrigin_Switch_A] = dir + "switch_button_a.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_B] = dir + "switch_button_b.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_X] = dir + "switch_button_x.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_Y] = dir + "switch_button_y.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_LeftBumper] = dir + "switch_l.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_RightBumper] = dir + "switch_r.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_Plus] = dir + "switch_button_plus.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_Minus] = dir + "switch_button_minus.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_LeftTrigger_Pull] = dir + "switch_zl_pull.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_LeftTrigger_Click] = dir + "switch_zl_click.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_RightTrigger_Pull] = dir + "switch_zr_pull.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_RightTrigger_Click] = dir + "switch_zr_click.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_LeftStick_Move] = dir + "stick_l_move.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_LeftStick_Click] = dir + "stick_l_click.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_LeftStick_DPadNorth] = dir + "stick_dpad_n.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_LeftStick_DPadSouth] = dir + "stick_dpad_s.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_LeftStick_DPadWest] = dir + "stick_dpad_w.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_LeftStick_DPadEast] = dir + "stick_dpad_e.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_RightStick_Move] = dir + "stick_r_move.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_RightStick_Click] = dir + "stick_r_click.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_RightStick_DPadNorth] = dir + "stick_dpad_n.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_RightStick_DPadSouth] = dir + "stick_dpad_s.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_RightStick_DPadWest] = dir + "stick_dpad_w.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_RightStick_DPadEast] = dir + "stick_dpad_e.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_DPad_North] = dir + "switch_button_dpad_n.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_DPad_South] = dir + "switch_button_dpad_s.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_DPad_West] = dir + "switch_button_dpad_w.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_DPad_East] = dir + "switch_button_dpad_e.png";
+        steaminput_glyphs[k_EInputActionOrigin_Switch_DPad_Move] = dir + "switch_button_dpad_move.png";
         //steaminput_glyphs[] = dir + "";
     }
 

--- a/dll/steam_controller.cpp
+++ b/dll/steam_controller.cpp
@@ -19,47 +19,63 @@
 
 #define JOY_ID_START 10
 #define STICK_DPAD 3
-#define DEADZONE_BUTTON_STICK 0.3
 
-
-
-#if !defined(CONTROLLER_SUPPORT)
-
-inline void GamepadInit(void) {}
-inline void GamepadShutdown(void) {}
-inline void GamepadUpdate(void) {}
-inline GAMEPAD_BOOL GamepadIsConnected(GAMEPAD_DEVICE device) { return GAMEPAD_FALSE; }
-inline GAMEPAD_BOOL GamepadButtonDown(GAMEPAD_DEVICE device, GAMEPAD_BUTTON button) { return GAMEPAD_FALSE; }
-inline float GamepadTriggerLength(GAMEPAD_DEVICE device, GAMEPAD_TRIGGER trigger) { return 0.0; }
-inline GAMEPAD_STICKDIR GamepadStickDir(GAMEPAD_DEVICE device, GAMEPAD_STICK stick) { return STICKDIR_CENTER; }
-inline void GamepadStickNormXY(GAMEPAD_DEVICE device, GAMEPAD_STICK stick, float* outX, float* outY) {}
-inline float GamepadStickLength(GAMEPAD_DEVICE device, GAMEPAD_STICK stick) { return 0.0; }
-inline void GamepadSetRumble(GAMEPAD_DEVICE device, float left, float right,  unsigned int rumble_length_ms) {}
-
-#endif
-
-
+using namespace gamepad_provider::sdl;
 
 Controller_Action::Controller_Action(ControllerHandle_t controller_handle) {
     this->controller_handle = controller_handle;
 }
 
-void Controller_Action::activate_action_set(ControllerDigitalActionHandle_t active_set, std::map<ControllerActionSetHandle_t, struct Controller_Map> &controller_maps) {
+void Controller_Action::activate_action_set(ControllerDigitalActionHandle_t active_set, std::map<ControllerActionSetHandle_t, struct Controller_Map>& controller_maps) {
     auto map = controller_maps.find(active_set);
     if (map == controller_maps.end()) return;
     this->active_set = active_set;
     this->active_map = map->second;
+    this->active_layers.clear();
+}
+
+void Controller_Action::activate_action_set_layer(ControllerActionSetHandle_t active_layer, std::map<ControllerActionSetHandle_t, struct Controller_Map>& controller_maps) {
+    auto map = controller_maps.find(active_layer);
+    auto layer = this->active_layers.find(active_layer);
+    if (map == controller_maps.end() || layer != this->active_layers.end()) return;
+    this->active_layers.insert(std::pair<ControllerActionSetHandle_t, struct Controller_Map>(active_layer, map->second));
+}
+
+void Controller_Action::deactivate_action_set_layer(ControllerActionSetHandle_t active_layer) {
+    auto layer = this->active_layers.find(active_layer);
+    if (layer == this->active_layers.end()) return;
+    this->active_layers.erase(layer);
 }
 
 std::set<int> Controller_Action::button_id(ControllerDigitalActionHandle_t handle) {
-    auto a = active_map.active_digital.find(handle);
-    if (a == active_map.active_digital.end()) return {};
+    Controller_Map map{};
+    for (auto iter = active_layers.rbegin(); iter != active_layers.rend(); ++iter) {
+        map = iter->second;
+        auto a = map.active_digital.find(handle);
+        if (a == map.active_digital.end()) continue;
+        return a->second;
+    }
+
+    // Active base action set
+    map = this->active_map;
+    auto a = map.active_digital.find(handle);
+    if (a == map.active_digital.end()) return {};
     return a->second;
 }
 
 std::pair<std::set<int>, enum EInputSourceMode> Controller_Action::analog_id(ControllerAnalogActionHandle_t handle) {
-    auto a = active_map.active_analog.find(handle);
-    if (a == active_map.active_analog.end()) return std::pair<std::set<int>, enum EInputSourceMode>({}, k_EInputSourceMode_None);
+    Controller_Map map{};
+    for (auto iter = active_layers.rbegin(); iter != active_layers.rend(); ++iter) {
+        map = iter->second;
+        auto a = map.active_analog.find(handle);
+        if (a == map.active_analog.end()) continue;
+        return a->second;
+    }
+
+    // Active base action set
+    map = this->active_map;
+    auto a = map.active_analog.find(handle);
+    if (a == map.active_analog.end()) return {};
     return a->second;
 }
 
@@ -107,31 +123,36 @@ const std::map<std::string, enum EInputSourceMode> Steam_Controller::analog_inpu
 };
 
 
-void Steam_Controller::set_handles(std::map<std::string, std::map<std::string, std::pair<std::set<std::string>, std::string>>> action_sets)
+void Steam_Controller::set_handles(std::map<std::string, std::map<std::string, std::pair<std::set<std::string>, std::string>>> action_sets,
+    std::map<std::string, std::map<std::string, std::pair<std::set<std::string>, std::string>>> action_set_layers)
 {
+    // TODO Load action_set_layers properly?
     uint64 handle_num = 1;
-    for (auto & set : action_sets) {
+
+    auto storeActionSetHandle = [&](std::pair<std::string, std::map<std::string, std::pair<std::set<std::string>, std::string>>> set) {
         ControllerActionSetHandle_t action_handle_num = handle_num;
         ++handle_num;
 
         action_handles[set.first] = action_handle_num;
-        for (auto & config_key : set.second) {
+        for (auto& config_key : set.second) {
             uint64 current_handle_num = handle_num;
             ++handle_num;
 
-            for (auto & button_string : config_key.second.first) {
+            for (auto& button_string : config_key.second.first) {
                 auto digital = button_strings.find(button_string);
                 if (digital != button_strings.end()) {
                     ControllerDigitalActionHandle_t digital_handle_num = current_handle_num;
 
                     if (digital_action_handles.find(config_key.first) == digital_action_handles.end()) {
                         digital_action_handles[config_key.first] = digital_handle_num;
-                    } else {
+                    }
+                    else {
                         digital_handle_num = digital_action_handles[config_key.first];
                     }
 
                     controller_maps[action_handle_num].active_digital[digital_handle_num].insert(digital->second);
-                } else {
+                }
+                else {
                     auto analog = analog_strings.find(button_string);
                     if (analog != analog_strings.end()) {
                         ControllerAnalogActionHandle_t analog_handle_num = current_handle_num;
@@ -139,7 +160,8 @@ void Steam_Controller::set_handles(std::map<std::string, std::map<std::string, s
                         enum EInputSourceMode source_mode;
                         if (analog->second == TRIGGER_LEFT || analog->second == TRIGGER_RIGHT) {
                             source_mode = k_EInputSourceMode_Trigger;
-                        } else {
+                        }
+                        else {
                             source_mode = k_EInputSourceMode_JoystickMove;
                         }
 
@@ -150,26 +172,37 @@ void Steam_Controller::set_handles(std::map<std::string, std::map<std::string, s
 
                         if (analog_action_handles.find(config_key.first) == analog_action_handles.end()) {
                             analog_action_handles[config_key.first] = analog_handle_num;
-                        } else {
+                        }
+                        else {
                             analog_handle_num = analog_action_handles[config_key.first];
                         }
 
                         controller_maps[action_handle_num].active_analog[analog_handle_num].first.insert(analog->second);
                         controller_maps[action_handle_num].active_analog[analog_handle_num].second = source_mode;
 
-                    } else {
+                    }
+                    else {
                         PRINT_DEBUG("Did not recognize controller button %s", button_string.c_str());
                         continue;
                     }
                 }
             }
         }
+    };
+
+    for (auto& set : action_sets) {
+        storeActionSetHandle(set);
+    }
+
+    for (auto& set : action_set_layers) {
+        storeActionSetHandle(set);
     }
 }
 
 
-void Steam_Controller::background_rumble(Rumble_Thread_Data *data)
+void Steam_Controller::background_rumble(Rumble_Thread_Data* data)
 {
+    // TODO Is this needed anymore?
     while (true) {
         unsigned short left, right;
         unsigned int rumble_length_ms;
@@ -201,29 +234,30 @@ void Steam_Controller::background_rumble(Rumble_Thread_Data *data)
             }
         }
 
-        GamepadSetRumble((GAMEPAD_DEVICE)gamepad, ((float)left) / 65535.0f, ((float)right) / 65535.0f, rumble_length_ms);
+        // SDL_Gamepad* gamepadHandle = SDL_GetGamepadFromPlayerIndex(gamepad);
+        // SDL_RumbleGamepad(gamepadHandle, left, right, rumble_length_ms);
     }
 }
 
-void Steam_Controller::steam_run_every_runcb(void *object)
+void Steam_Controller::steam_run_every_runcb(void* object)
 {
     // PRINT_DEBUG_ENTRY();
 
-    Steam_Controller *steam_controller = (Steam_Controller *)object;
+    Steam_Controller* steam_controller = (Steam_Controller*)object;
     steam_controller->RunCallbacks();
 }
 
-Steam_Controller::Steam_Controller(class Settings *settings, class SteamCallResults *callback_results, class SteamCallBacks *callbacks, class RunEveryRunCB *run_every_runcb)
+Steam_Controller::Steam_Controller(class Settings* settings, class SteamCallResults* callback_results, class SteamCallBacks* callbacks, class RunEveryRunCB* run_every_runcb)
 {
     this->settings = settings;
     this->callback_results = callback_results;
     this->callbacks = callbacks;
     this->run_every_runcb = run_every_runcb;
 
-    set_handles(settings->controller_settings.action_sets);
+    set_handles(settings->controller_settings.action_sets, settings->controller_settings.action_set_layers);
     disabled = action_handles.empty();
     initialized = false;
-    
+
     this->run_every_runcb->add(&Steam_Controller::steam_run_every_runcb, this);
 }
 
@@ -244,29 +278,32 @@ bool Steam_Controller::Init(bool bExplicitlyCallRunFrame)
         return true;
     }
 
-    GamepadInit();
+    GamepadInit(settings->combine_joycons);
     GamepadUpdate();
 
-    for (int i = 1; i < 5; ++i) {
-        struct Controller_Action cont_action(i);
+    std::vector<ControllerHandle_t> newHandles{};
+    std::vector<ControllerHandle_t> handles{};
+    DetectGamepads(handles, newHandles);
+
+    for (auto& id : handles) {
+        struct Controller_Action cont_action(id);
         //Activate the first action set.
         //TODO: check exactly what decides which gets activated by default
         if (action_handles.size() >= 1) {
             cont_action.activate_action_set(action_handles.begin()->second, controller_maps);
         }
-
-        controllers.insert(std::pair<ControllerHandle_t, struct Controller_Action>(i, cont_action));
+        controllers.insert(std::pair<ControllerHandle_t, struct Controller_Action>(id, cont_action));
     }
 
-    rumble_thread_data = new Rumble_Thread_Data();
-    background_rumble_thread = std::thread(background_rumble, rumble_thread_data);
+    //rumble_thread_data = new Rumble_Thread_Data();
+    //background_rumble_thread = std::thread(background_rumble, rumble_thread_data);
 
     initialized = true;
     explicitly_call_run_frame = bExplicitlyCallRunFrame;
     return true;
 }
 
-bool Steam_Controller::Init( const char *pchAbsolutePathToControllerConfigVDF )
+bool Steam_Controller::Init(const char* pchAbsolutePathToControllerConfigVDF)
 {
     PRINT_DEBUG("old");
     return Init();
@@ -286,19 +323,22 @@ bool Steam_Controller::Shutdown()
     }
 
     controllers = std::map<ControllerHandle_t, struct Controller_Action>();
-    rumble_thread_data->rumble_mutex.lock();
-    rumble_thread_data->kill_rumble_thread = true;
-    rumble_thread_data->rumble_mutex.unlock();
-    rumble_thread_data->rumble_thread_cv.notify_one();
-    background_rumble_thread.join();
-    delete rumble_thread_data;
-    rumble_thread_data = nullptr;
+
+    // rumble_thread_data->rumble_mutex.lock();
+    // rumble_thread_data->kill_rumble_thread = true;
+    // rumble_thread_data->rumble_mutex.unlock();
+    // rumble_thread_data->rumble_thread_cv.notify_one();
+    // background_rumble_thread.join();
+    // delete rumble_thread_data;
+    // rumble_thread_data = nullptr;
+
     GamepadShutdown();
+
     initialized = false;
     return true;
 }
 
-void Steam_Controller::SetOverrideMode( const char *pchMode )
+void Steam_Controller::SetOverrideMode(const char* pchMode)
 {
     PRINT_DEBUG_TODO();
 }
@@ -306,14 +346,14 @@ void Steam_Controller::SetOverrideMode( const char *pchMode )
 // Set the absolute path to the Input Action Manifest file containing the in-game actions
 // and file paths to the official configurations. Used in games that bundle Steam Input
 // configurations inside of the game depot instead of using the Steam Workshop
-bool Steam_Controller::SetInputActionManifestFilePath( const char *pchInputActionManifestAbsolutePath )
+bool Steam_Controller::SetInputActionManifestFilePath(const char* pchInputActionManifestAbsolutePath)
 {
     PRINT_DEBUG_TODO();
     //TODO SteamInput005
     return false;
 }
 
-bool Steam_Controller::BWaitForData( bool bWaitForever, uint32 unTimeout )
+bool Steam_Controller::BWaitForData(bool bWaitForever, uint32 unTimeout)
 {
     PRINT_DEBUG_TODO();
     //TODO SteamInput005
@@ -343,7 +383,7 @@ void Steam_Controller::EnableDeviceCallbacks()
 // Enable SteamInputActionEvent_t callbacks. Directly calls your callback function
 // for lower latency than standard Steam callbacks. Supports one callback at a time.
 // Note: this is called within either SteamInput()->RunFrame or by SteamAPI_RunCallbacks
-void Steam_Controller::EnableActionEventCallbacks( SteamInputActionEventCallbackPointer pCallback )
+void Steam_Controller::EnableActionEventCallbacks(SteamInputActionEventCallbackPointer pCallback)
 {
     PRINT_DEBUG_TODO();
     //TODO SteamInput005
@@ -368,7 +408,7 @@ void Steam_Controller::RunFrame()
     RunFrame(true);
 }
 
-bool Steam_Controller::GetControllerState( uint32 unControllerIndex, SteamControllerState001_t *pState )
+bool Steam_Controller::GetControllerState(uint32 unControllerIndex, SteamControllerState001_t* pState)
 {
     PRINT_DEBUG_TODO();
     return false;
@@ -377,7 +417,7 @@ bool Steam_Controller::GetControllerState( uint32 unControllerIndex, SteamContro
 // Enumerate currently connected controllers
 // handlesOut should point to a STEAM_CONTROLLER_MAX_COUNT sized array of ControllerHandle_t handles
 // Returns the number of handles written to handlesOut
-int Steam_Controller::GetConnectedControllers( ControllerHandle_t *handlesOut )
+int Steam_Controller::GetConnectedControllers(ControllerHandle_t* handlesOut)
 {
     PRINT_DEBUG_ENTRY();
     if (!handlesOut) return 0;
@@ -385,11 +425,24 @@ int Steam_Controller::GetConnectedControllers( ControllerHandle_t *handlesOut )
         return 0;
     }
 
-    int count = 0;
-    if (GamepadIsConnected(GAMEPAD_0)) {*handlesOut = GAMEPAD_0 + 1; ++handlesOut; ++count;};
-    if (GamepadIsConnected(GAMEPAD_1)) {*handlesOut = GAMEPAD_1 + 1; ++handlesOut; ++count;};
-    if (GamepadIsConnected(GAMEPAD_2)) {*handlesOut = GAMEPAD_2 + 1; ++handlesOut; ++count;};
-    if (GamepadIsConnected(GAMEPAD_3)) {*handlesOut = GAMEPAD_3 + 1; ++handlesOut; ++count;};
+    std::vector<ControllerHandle_t> newHandles{};
+    std::vector<ControllerHandle_t> handles{};
+    int count = DetectGamepads(handles, newHandles);
+
+    for (const auto& id : newHandles) {
+        PRINT_DEBUG("creating new controller with id %i", id);
+        struct Controller_Action cont_action(id);
+        //Activate the first action set.
+        //TODO: check exactly what decides which gets activated by default
+        if (action_handles.size() >= 1) {
+            cont_action.activate_action_set(action_handles.begin()->second, controller_maps);
+        }
+        controllers.insert(std::pair<ControllerHandle_t, struct Controller_Action>(id, cont_action));
+    }
+
+    std::copy(handles.begin(), handles.end(), handlesOut);
+
+    PRINT_DEBUG("first controller handle is %i", handlesOut[0]);
 
     PRINT_DEBUG("returned %i connected controllers", count);
     return count;
@@ -398,7 +451,7 @@ int Steam_Controller::GetConnectedControllers( ControllerHandle_t *handlesOut )
 
 // Invokes the Steam overlay and brings up the binding screen
 // Returns false is overlay is disabled / unavailable, or the user is not in Big Picture mode
-bool Steam_Controller::ShowBindingPanel( ControllerHandle_t controllerHandle )
+bool Steam_Controller::ShowBindingPanel(ControllerHandle_t controllerHandle)
 {
     PRINT_DEBUG_TODO();
     return false;
@@ -407,12 +460,12 @@ bool Steam_Controller::ShowBindingPanel( ControllerHandle_t controllerHandle )
 
 // ACTION SETS
 // Lookup the handle for an Action Set. Best to do this once on startup, and store the handles for all future API calls.
-ControllerActionSetHandle_t Steam_Controller::GetActionSetHandle( const char *pszActionSetName )
+ControllerActionSetHandle_t Steam_Controller::GetActionSetHandle(const char* pszActionSetName)
 {
     PRINT_DEBUG("%s", pszActionSetName);
     if (!pszActionSetName) return 0;
     std::string upper_action_name(pszActionSetName);
-    std::transform(upper_action_name.begin(), upper_action_name.end(), upper_action_name.begin(),[](unsigned char c){ return std::toupper(c); });
+    std::transform(upper_action_name.begin(), upper_action_name.end(), upper_action_name.begin(), [](unsigned char c) { return std::toupper(c); });
 
     auto set_handle = action_handles.find(upper_action_name);
     if (set_handle == action_handles.end()) return 0;
@@ -425,11 +478,11 @@ ControllerActionSetHandle_t Steam_Controller::GetActionSetHandle( const char *ps
 // Reconfigure the controller to use the specified action set (ie 'Menu', 'Walk' or 'Drive')
 // This is cheap, and can be safely called repeatedly. It's often easier to repeatedly call it in
 // your state loops, instead of trying to place it in all of your state transitions.
-void Steam_Controller::ActivateActionSet( ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetHandle )
+void Steam_Controller::ActivateActionSet(ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetHandle)
 {
     PRINT_DEBUG("%llu %llu", controllerHandle, actionSetHandle);
     if (controllerHandle == STEAM_CONTROLLER_HANDLE_ALL_CONTROLLERS) {
-        for (auto & c: controllers) {
+        for (auto& c : controllers) {
             c.second.activate_action_set(actionSetHandle, controller_maps);
         }
     }
@@ -440,7 +493,7 @@ void Steam_Controller::ActivateActionSet( ControllerHandle_t controllerHandle, C
     controller->second.activate_action_set(actionSetHandle, controller_maps);
 }
 
-ControllerActionSetHandle_t Steam_Controller::GetCurrentActionSet( ControllerHandle_t controllerHandle )
+ControllerActionSetHandle_t Steam_Controller::GetCurrentActionSet(ControllerHandle_t controllerHandle)
 {
     //TODO: should return zero if no action set specifically activated with ActivateActionSet
     PRINT_DEBUG("%llu", controllerHandle);
@@ -451,37 +504,54 @@ ControllerActionSetHandle_t Steam_Controller::GetCurrentActionSet( ControllerHan
 }
 
 
-void Steam_Controller::ActivateActionSetLayer( ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetLayerHandle )
+void Steam_Controller::ActivateActionSetLayer(ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetLayerHandle)
 {
-    PRINT_DEBUG_TODO();
+    PRINT_DEBUG_ENTRY();
+    auto controller = controllers.find(controllerHandle);
+    if (controller == controllers.end()) return;
+    controller->second.activate_action_set_layer(actionSetLayerHandle, controller_maps);
 }
 
-void Steam_Controller::DeactivateActionSetLayer( ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetLayerHandle )
+void Steam_Controller::DeactivateActionSetLayer(ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetLayerHandle)
 {
-    PRINT_DEBUG_TODO();
+    PRINT_DEBUG_ENTRY();
+    auto controller = controllers.find(controllerHandle);
+    if (controller == controllers.end()) return;
+    controller->second.deactivate_action_set_layer(actionSetLayerHandle);
 }
 
-void Steam_Controller::DeactivateAllActionSetLayers( ControllerHandle_t controllerHandle )
+void Steam_Controller::DeactivateAllActionSetLayers(ControllerHandle_t controllerHandle)
 {
-    PRINT_DEBUG_TODO();
+    PRINT_DEBUG_ENTRY();
+    auto controller = controllers.find(controllerHandle);
+    if (controller == controllers.end()) return;
+    controller->second.active_layers.clear();
 }
 
-int Steam_Controller::GetActiveActionSetLayers( ControllerHandle_t controllerHandle, ControllerActionSetHandle_t *handlesOut )
+int Steam_Controller::GetActiveActionSetLayers(ControllerHandle_t controllerHandle, ControllerActionSetHandle_t* handlesOut)
 {
-    PRINT_DEBUG_TODO();
-    return 0;
+    PRINT_DEBUG_ENTRY();
+    auto controller = controllers.find(controllerHandle);
+    if (controller == controllers.end()) return 0;
+    int count = 0;
+    for (auto const& handle : controller->second.active_layers) {
+        *handlesOut = handle.first;
+        ++handlesOut;
+        count++;
+    }
+    return count;
 }
 
 
 
 // ACTIONS
 // Lookup the handle for a digital action. Best to do this once on startup, and store the handles for all future API calls.
-ControllerDigitalActionHandle_t Steam_Controller::GetDigitalActionHandle( const char *pszActionName )
+ControllerDigitalActionHandle_t Steam_Controller::GetDigitalActionHandle(const char* pszActionName)
 {
     PRINT_DEBUG("%s", pszActionName);
     if (!pszActionName) return 0;
     std::string upper_action_name(pszActionName);
-    std::transform(upper_action_name.begin(), upper_action_name.end(), upper_action_name.begin(),[](unsigned char c){ return std::toupper(c); });
+    std::transform(upper_action_name.begin(), upper_action_name.end(), upper_action_name.begin(), [](unsigned char c) { return std::toupper(c); });
 
     auto handle = digital_action_handles.find(upper_action_name);
     if (handle == digital_action_handles.end()) {
@@ -496,7 +566,7 @@ ControllerDigitalActionHandle_t Steam_Controller::GetDigitalActionHandle( const 
 
 
 // Returns the current state of the supplied digital game action
-ControllerDigitalActionData_t Steam_Controller::GetDigitalActionData( ControllerHandle_t controllerHandle, ControllerDigitalActionHandle_t digitalActionHandle )
+ControllerDigitalActionData_t Steam_Controller::GetDigitalActionData(ControllerHandle_t controllerHandle, ControllerDigitalActionHandle_t digitalActionHandle)
 {
     PRINT_DEBUG("%llu %llu", controllerHandle, digitalActionHandle);
     ControllerDigitalActionData_t digitalData;
@@ -510,50 +580,36 @@ ControllerDigitalActionData_t Steam_Controller::GetDigitalActionData( Controller
     if (!buttons.size()) return digitalData;
     digitalData.bActive = true;
 
-    GAMEPAD_DEVICE device = (GAMEPAD_DEVICE)(controllerHandle - 1);
 
     for (auto button : buttons) {
         bool pressed = false;
         if (button < BUTTON_COUNT) {
-            pressed = GamepadButtonDown(device, (GAMEPAD_BUTTON)button);
-        } else {
+            pressed = GamepadButtonDown(controllerHandle, (GAMEPAD_BUTTON)button);
+        }
+        else {
             switch (button) {
-                case BUTTON_LTRIGGER:
-                    pressed = GamepadTriggerLength(device, TRIGGER_LEFT) > 0.8;
-                    break;
-                case BUTTON_RTRIGGER:
-                    pressed = GamepadTriggerLength(device, TRIGGER_RIGHT) > 0.8;
-                    break;
-                case BUTTON_STICK_LEFT_UP:
-                case BUTTON_STICK_LEFT_DOWN:
-                case BUTTON_STICK_LEFT_LEFT:
-                case BUTTON_STICK_LEFT_RIGHT: {
-                    float x = 0, y = 0, len = GamepadStickLength(device, STICK_LEFT);
-                    GamepadStickNormXY(device, STICK_LEFT, &x, &y);
-                    x *= len;
-                    y *= len;
-                    if (button == BUTTON_STICK_LEFT_UP) pressed = y > DEADZONE_BUTTON_STICK;
-                    if (button == BUTTON_STICK_LEFT_DOWN) pressed = y < -DEADZONE_BUTTON_STICK;
-                    if (button == BUTTON_STICK_LEFT_RIGHT) pressed = x > DEADZONE_BUTTON_STICK;
-                    if (button == BUTTON_STICK_LEFT_LEFT) pressed = x < -DEADZONE_BUTTON_STICK;
-                    break;
-                }
-                case BUTTON_STICK_RIGHT_UP:
-                case BUTTON_STICK_RIGHT_DOWN:
-                case BUTTON_STICK_RIGHT_LEFT:
-                case BUTTON_STICK_RIGHT_RIGHT: {
-                    float x = 0, y = 0, len = GamepadStickLength(device, STICK_RIGHT);
-                    GamepadStickNormXY(device, STICK_RIGHT, &x, &y);
-                    x *= len;
-                    y *= len;
-                    if (button == BUTTON_STICK_RIGHT_UP) pressed = y > DEADZONE_BUTTON_STICK;
-                    if (button == BUTTON_STICK_RIGHT_DOWN) pressed = y < -DEADZONE_BUTTON_STICK;
-                    if (button == BUTTON_STICK_RIGHT_RIGHT) pressed = x > DEADZONE_BUTTON_STICK;
-                    if (button == BUTTON_STICK_RIGHT_LEFT) pressed = x < -DEADZONE_BUTTON_STICK;
-                    break;
-                }
-                default:
-                    break;
+            case BUTTON_STICK_LEFT_UP:
+            case BUTTON_STICK_LEFT_DOWN:
+            case BUTTON_STICK_LEFT_LEFT:
+            case BUTTON_STICK_LEFT_RIGHT: {
+                float x = 0, y = 0;
+                GamepadStickNormXY(controllerHandle, STICK_LEFT, &x, &y, this->settings->inner_deadzone, this->settings->outer_deadzone);
+                if (button == BUTTON_STICK_LEFT_DOWN || button == BUTTON_STICK_LEFT_UP) pressed = y != 0.0f;
+                if (button == BUTTON_STICK_LEFT_RIGHT || button == BUTTON_STICK_LEFT_LEFT) pressed = x != 0.0f;
+                break;
+            }
+            case BUTTON_STICK_RIGHT_UP:
+            case BUTTON_STICK_RIGHT_DOWN:
+            case BUTTON_STICK_RIGHT_LEFT:
+            case BUTTON_STICK_RIGHT_RIGHT: {
+                float x = 0, y = 0;
+                GamepadStickNormXY(controllerHandle, STICK_LEFT, &x, &y, this->settings->inner_deadzone, this->settings->outer_deadzone);
+                if (button == BUTTON_STICK_RIGHT_DOWN || button == BUTTON_STICK_RIGHT_UP) pressed = y != 0.0f;
+                if (button == BUTTON_STICK_RIGHT_RIGHT || button == BUTTON_STICK_RIGHT_LEFT) pressed = x != 0.0f;
+                break;
+            }
+            default:
+                break;
             }
         }
 
@@ -569,19 +625,39 @@ ControllerDigitalActionData_t Steam_Controller::GetDigitalActionData( Controller
 
 // Get the origin(s) for a digital action within an action set. Returns the number of origins supplied in originsOut. Use this to display the appropriate on-screen prompt for the action.
 // originsOut should point to a STEAM_CONTROLLER_MAX_ORIGINS sized array of EControllerActionOrigin handles
-int Steam_Controller::GetDigitalActionOrigins( ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetHandle, ControllerDigitalActionHandle_t digitalActionHandle, EControllerActionOrigin *originsOut )
+int Steam_Controller::GetDigitalActionOrigins(ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetHandle, ControllerDigitalActionHandle_t digitalActionHandle, EControllerActionOrigin* originsOut)
 {
     PRINT_DEBUG_ENTRY();
     EInputActionOrigin origins[STEAM_CONTROLLER_MAX_ORIGINS];
-    int ret = GetDigitalActionOrigins(controllerHandle, actionSetHandle, digitalActionHandle, origins );
+    int ret = GetDigitalActionOrigins(controllerHandle, actionSetHandle, digitalActionHandle, origins);
     for (int i = 0; i < ret; ++i) {
-        originsOut[i] = (EControllerActionOrigin)(origins[i] - ((long)k_EInputActionOrigin_XBox360_A - (long)k_EControllerActionOrigin_XBox360_A));
+        switch (GamepadGetType(controllerHandle)) {
+        case k_ESteamInputType_PS3Controller:
+        case k_ESteamInputType_PS4Controller:
+            originsOut[i] = (EControllerActionOrigin)(origins[i] - ((long)k_EInputActionOrigin_PS4_X - (long)k_EControllerActionOrigin_PS4_X));
+            break;
+        case k_ESteamInputType_PS5Controller:
+            originsOut[i] = (EControllerActionOrigin)(origins[i] - ((long)k_EInputActionOrigin_PS5_X - (long)k_EControllerActionOrigin_PS5_X));
+            break;
+        case k_ESteamInputType_SwitchJoyConSingle:
+        case k_ESteamInputType_SwitchJoyConPair:
+        case k_ESteamInputType_SwitchProController:
+            originsOut[i] = (EControllerActionOrigin)(origins[i] - ((long)k_EInputActionOrigin_Switch_A - (long)k_EControllerActionOrigin_Switch_A));
+            break;
+        case k_ESteamInputType_XBoxOneController:
+            originsOut[i] = (EControllerActionOrigin)(origins[i] - ((long)k_EInputActionOrigin_XBoxOne_A - (long)k_EControllerActionOrigin_XBoxOne_A));
+            break;
+        case k_ESteamInputType_XBox360Controller:
+        default:
+            originsOut[i] = (EControllerActionOrigin)(origins[i] - ((long)k_EInputActionOrigin_XBox360_A - (long)k_EControllerActionOrigin_XBox360_A));
+            break;
+        }
     }
 
     return ret;
 }
 
-int Steam_Controller::GetDigitalActionOrigins( InputHandle_t inputHandle, InputActionSetHandle_t actionSetHandle, InputDigitalActionHandle_t digitalActionHandle, EInputActionOrigin *originsOut )
+int Steam_Controller::GetDigitalActionOrigins(InputHandle_t inputHandle, InputActionSetHandle_t actionSetHandle, InputDigitalActionHandle_t digitalActionHandle, EInputActionOrigin* originsOut)
 {
     PRINT_DEBUG_ENTRY();
     auto controller = controllers.find(inputHandle);
@@ -593,88 +669,338 @@ int Steam_Controller::GetDigitalActionOrigins( InputHandle_t inputHandle, InputA
     auto a = map->second.active_digital.find(digitalActionHandle);
     if (a == map->second.active_digital.end()) return 0;
 
+    // TODO Different controller layouts
     int count = 0;
-    for (auto button: a->second) {
+    ESteamInputType type = GamepadGetType(controller->first);
+    for (auto button : a->second) {
+        originsOut[count] = k_EInputActionOrigin_None;
         switch (button) {
-            case BUTTON_A:
+        case BUTTON_A:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_X;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_X;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_A;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController) {
+                if (this->settings->flip_nintendo_layout)
+                    originsOut[count] = k_EInputActionOrigin_Switch_B;
+                else
+                    originsOut[count] = k_EInputActionOrigin_Switch_A;
+            }
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_A;
-                break;
-            case BUTTON_B:
+            break;
+
+        case BUTTON_B:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_Circle;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_Circle;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_B;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController) {
+                if (this->settings->flip_nintendo_layout)
+                    originsOut[count] = k_EInputActionOrigin_Switch_A;
+                else
+                    originsOut[count] = k_EInputActionOrigin_Switch_B;
+            }
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_B;
-                break;
-            case BUTTON_X:
+            break;
+
+        case BUTTON_X:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_Square;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_Square;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_X;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController) {
+                if (this->settings->flip_nintendo_layout)
+                    originsOut[count] = k_EInputActionOrigin_Switch_Y;
+                else
+                    originsOut[count] = k_EInputActionOrigin_Switch_X;
+            }
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_X;
-                break;
-            case BUTTON_Y:
+            break;
+
+        case BUTTON_Y:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_Triangle;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_Triangle;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_Y;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController) {
+                if (this->settings->flip_nintendo_layout)
+                    originsOut[count] = k_EInputActionOrigin_Switch_X;
+                else
+                    originsOut[count] = k_EInputActionOrigin_Switch_Y;
+            }
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_Y;
-                break;
-            case BUTTON_LEFT_SHOULDER:
+            break;
+
+        case BUTTON_LEFT_SHOULDER:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_LeftBumper;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_LeftBumper;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_LeftBumper;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_LeftBumper;
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_LeftBumper;
-                break;
-            case BUTTON_RIGHT_SHOULDER:
+            break;
+
+        case BUTTON_RIGHT_SHOULDER:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_RightBumper;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_RightBumper;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_RightBumper;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_RightBumper;
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_RightBumper;
-                break;
-            case BUTTON_START:
+            break;
+
+        case BUTTON_START:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_Options;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_Option;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_Menu;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_Plus;
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_Start;
-                break;
-            case BUTTON_BACK:
+            break;
+
+        case BUTTON_BACK:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_Share;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_Create;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_View;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_Minus;
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_Back;
-                break;
-            case BUTTON_LTRIGGER:
+            break;
+
+        case BUTTON_LTRIGGER:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_LeftTrigger_Click;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_LeftTrigger_Click;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_LeftTrigger_Click;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_LeftTrigger_Click;
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_LeftTrigger_Click;
-                break;
-            case BUTTON_RTRIGGER:
+            break;
+
+        case BUTTON_RTRIGGER:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_RightTrigger_Click;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_RightTrigger_Click;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_RightTrigger_Click;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_RightTrigger_Click;
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_RightTrigger_Click;
-                break;
-            case BUTTON_LEFT_THUMB:
+            break;
+
+        case BUTTON_LEFT_THUMB:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_LeftStick_Click;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_LeftStick_Click;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_LeftStick_Click;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_LeftStick_Click;
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_LeftStick_Click;
-                break;
-            case BUTTON_RIGHT_THUMB:
+            break;
+
+        case BUTTON_RIGHT_THUMB:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_RightStick_Click;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_RightStick_Click;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_RightStick_Click;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_RightStick_Click;
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_RightStick_Click;
-                break;
+            break;
 
-            case BUTTON_STICK_LEFT_UP:
+        case BUTTON_STICK_LEFT_UP:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_LeftStick_DPadNorth;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_LeftStick_DPadNorth;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_LeftStick_DPadNorth;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_LeftStick_DPadNorth;
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_LeftStick_DPadNorth;
-                break;
-            case BUTTON_STICK_LEFT_DOWN:
+            break;
+
+        case BUTTON_STICK_LEFT_DOWN:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_LeftStick_DPadSouth;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_LeftStick_DPadSouth;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_LeftStick_DPadSouth;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_LeftStick_DPadSouth;
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_LeftStick_DPadSouth;
-                break;
-            case BUTTON_STICK_LEFT_LEFT:
+            break;
+
+        case BUTTON_STICK_LEFT_LEFT:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_LeftStick_DPadWest;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_LeftStick_DPadWest;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_LeftStick_DPadWest;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_LeftStick_DPadWest;
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_LeftStick_DPadWest;
-                break;
-            case BUTTON_STICK_LEFT_RIGHT:
+            break;
+
+        case BUTTON_STICK_LEFT_RIGHT:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_LeftStick_DPadEast;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_LeftStick_DPadEast;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_LeftStick_DPadEast;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_LeftStick_DPadEast;
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_LeftStick_DPadEast;
-                break;
+            break;
 
-            case BUTTON_STICK_RIGHT_UP:
+        case BUTTON_STICK_RIGHT_UP:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_RightStick_DPadNorth;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_RightStick_DPadNorth;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_RightStick_DPadNorth;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_RightStick_DPadNorth;
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_RightStick_DPadNorth;
-                break;
-            case BUTTON_STICK_RIGHT_DOWN:
+            break;
+
+        case BUTTON_STICK_RIGHT_DOWN:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_RightStick_DPadSouth;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_RightStick_DPadSouth;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_RightStick_DPadSouth;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_RightStick_DPadSouth;
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_RightStick_DPadSouth;
-                break;
-            case BUTTON_STICK_RIGHT_LEFT:
+            break;
+
+        case BUTTON_STICK_RIGHT_LEFT:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_RightStick_DPadWest;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_RightStick_DPadWest;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_RightStick_DPadWest;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_RightStick_DPadWest;
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_RightStick_DPadWest;
-                break;
-            case BUTTON_STICK_RIGHT_RIGHT:
+            break;
+
+        case BUTTON_STICK_RIGHT_RIGHT:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_RightStick_DPadEast;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_RightStick_DPadEast;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_RightStick_DPadEast;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_RightStick_DPadEast;
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_RightStick_DPadEast;
-                break;
+            break;
 
-            case BUTTON_DPAD_UP:
+        case BUTTON_DPAD_UP:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_DPad_North;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_DPad_North;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_DPad_North;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_DPad_North;
+            else if (type == k_ESteamInputType_XBox360Controller)
                 originsOut[count] = k_EInputActionOrigin_XBox360_DPad_North;
-                break;
-            case BUTTON_DPAD_DOWN:
-                originsOut[count] = k_EInputActionOrigin_XBox360_DPad_South;
-                break;
-            case BUTTON_DPAD_LEFT:
-                originsOut[count] = k_EInputActionOrigin_XBox360_DPad_West;
-                break;
-            case BUTTON_DPAD_RIGHT:
-                originsOut[count] = k_EInputActionOrigin_XBox360_DPad_East;
-                break;
+            break;
 
-            default:
-                originsOut[count] = k_EInputActionOrigin_None;
-                break;
+        case BUTTON_DPAD_DOWN:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_DPad_South;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_DPad_South;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_DPad_South;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_DPad_South;
+            else if (type == k_ESteamInputType_XBox360Controller)
+                originsOut[count] = k_EInputActionOrigin_XBox360_DPad_South;
+            break;
+
+        case BUTTON_DPAD_LEFT:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_DPad_West;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_DPad_West;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_DPad_West;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_DPad_West;
+            else if (type == k_ESteamInputType_XBox360Controller)
+                originsOut[count] = k_EInputActionOrigin_XBox360_DPad_West;
+            break;
+        case BUTTON_DPAD_RIGHT:
+            if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller)
+                originsOut[count] = k_EInputActionOrigin_PS4_DPad_East;
+            else if (type == k_ESteamInputType_PS5Controller)
+                originsOut[count] = k_EInputActionOrigin_PS5_DPad_East;
+            else if (type == k_ESteamInputType_XBoxOneController)
+                originsOut[count] = k_EInputActionOrigin_XBoxOne_DPad_East;
+            else if (type == k_ESteamInputType_SwitchJoyConSingle || type == k_ESteamInputType_SwitchJoyConPair || type == k_ESteamInputType_SwitchProController)
+                originsOut[count] = k_EInputActionOrigin_Switch_DPad_East;
+            else if (type == k_ESteamInputType_XBox360Controller)
+                originsOut[count] = k_EInputActionOrigin_XBox360_DPad_East;
+            break;
         }
 
         ++count;
@@ -687,7 +1013,7 @@ int Steam_Controller::GetDigitalActionOrigins( InputHandle_t inputHandle, InputA
 }
 
 // Returns a localized string (from Steam's language setting) for the user-facing action name corresponding to the specified handle
-const char* Steam_Controller::GetStringForDigitalActionName( InputDigitalActionHandle_t eActionHandle )
+const char* Steam_Controller::GetStringForDigitalActionName(InputDigitalActionHandle_t eActionHandle)
 {
     PRINT_DEBUG_TODO();
     //TODO SteamInput005
@@ -695,12 +1021,12 @@ const char* Steam_Controller::GetStringForDigitalActionName( InputDigitalActionH
 }
 
 // Lookup the handle for an analog action. Best to do this once on startup, and store the handles for all future API calls.
-ControllerAnalogActionHandle_t Steam_Controller::GetAnalogActionHandle( const char *pszActionName )
+ControllerAnalogActionHandle_t Steam_Controller::GetAnalogActionHandle(const char* pszActionName)
 {
     PRINT_DEBUG("%s", pszActionName);
     if (!pszActionName) return 0;
     std::string upper_action_name(pszActionName);
-    std::transform(upper_action_name.begin(), upper_action_name.end(), upper_action_name.begin(),[](unsigned char c){ return std::toupper(c); });
+    std::transform(upper_action_name.begin(), upper_action_name.end(), upper_action_name.begin(), [](unsigned char c) { return std::toupper(c); });
 
     auto handle = analog_action_handles.find(upper_action_name);
     if (handle == analog_action_handles.end()) return 0;
@@ -710,10 +1036,9 @@ ControllerAnalogActionHandle_t Steam_Controller::GetAnalogActionHandle( const ch
 
 
 // Returns the current state of these supplied analog game action
-ControllerAnalogActionData_t Steam_Controller::GetAnalogActionData( ControllerHandle_t controllerHandle, ControllerAnalogActionHandle_t analogActionHandle )
+ControllerAnalogActionData_t Steam_Controller::GetAnalogActionData(ControllerHandle_t controllerHandle, ControllerAnalogActionHandle_t analogActionHandle)
 {
     PRINT_DEBUG("%llu %llu", controllerHandle, analogActionHandle);
-    GAMEPAD_DEVICE device = (GAMEPAD_DEVICE)(controllerHandle - 1);
 
     ControllerAnalogActionData_t data;
     data.eMode = k_EInputSourceMode_None;
@@ -733,8 +1058,8 @@ ControllerAnalogActionData_t Steam_Controller::GetAnalogActionData( ControllerHa
         if (a >= JOY_ID_START) {
             int joystick_id = a - JOY_ID_START;
             if (joystick_id == STICK_DPAD) {
-                int mov_y = (int)GamepadButtonDown(device, BUTTON_DPAD_UP) - (int)GamepadButtonDown(device, BUTTON_DPAD_DOWN);
-                int mov_x = (int)GamepadButtonDown(device, BUTTON_DPAD_RIGHT) - (int)GamepadButtonDown(device, BUTTON_DPAD_LEFT);
+                int mov_y = (int)GamepadButtonDown(controllerHandle, BUTTON_DPAD_UP) - (int)GamepadButtonDown(controllerHandle, BUTTON_DPAD_DOWN);
+                int mov_x = (int)GamepadButtonDown(controllerHandle, BUTTON_DPAD_RIGHT) - (int)GamepadButtonDown(controllerHandle, BUTTON_DPAD_LEFT);
                 if (mov_y || mov_x) {
                     data.x = static_cast<float>(mov_x);
                     data.y = static_cast<float>(mov_y);
@@ -742,14 +1067,13 @@ ControllerAnalogActionData_t Steam_Controller::GetAnalogActionData( ControllerHa
                     data.x = data.x * length;
                     data.y = data.y * length;
                 }
-            } else {
-                GamepadStickNormXY(device, (GAMEPAD_STICK) joystick_id, &data.x, &data.y);
-                float length = GamepadStickLength(device, (GAMEPAD_STICK) joystick_id);
-                data.x = data.x * length;
-                data.y = data.y * length;
             }
-        } else {
-            data.x = GamepadTriggerLength(device, (GAMEPAD_TRIGGER) a);
+            else {
+                GamepadStickNormXY(controllerHandle, (GAMEPAD_STICK)joystick_id, &data.x, &data.y, this->settings->inner_deadzone, this->settings->outer_deadzone);
+            }
+        }
+        else {
+            data.x = GamepadTriggerLength(controllerHandle, (GAMEPAD_TRIGGER)a);
         }
 
         if (data.x || data.y) {
@@ -763,19 +1087,39 @@ ControllerAnalogActionData_t Steam_Controller::GetAnalogActionData( ControllerHa
 
 // Get the origin(s) for an analog action within an action set. Returns the number of origins supplied in originsOut. Use this to display the appropriate on-screen prompt for the action.
 // originsOut should point to a STEAM_CONTROLLER_MAX_ORIGINS sized array of EControllerActionOrigin handles
-int Steam_Controller::GetAnalogActionOrigins( ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetHandle, ControllerAnalogActionHandle_t analogActionHandle, EControllerActionOrigin *originsOut )
+int Steam_Controller::GetAnalogActionOrigins(ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetHandle, ControllerAnalogActionHandle_t analogActionHandle, EControllerActionOrigin* originsOut)
 {
     PRINT_DEBUG_ENTRY();
     EInputActionOrigin origins[STEAM_CONTROLLER_MAX_ORIGINS];
-    int ret = GetAnalogActionOrigins(controllerHandle, actionSetHandle, analogActionHandle, origins );
+    int ret = GetAnalogActionOrigins(controllerHandle, actionSetHandle, analogActionHandle, origins);
     for (int i = 0; i < ret; ++i) {
-        originsOut[i] = (EControllerActionOrigin)(origins[i] - ((long)k_EInputActionOrigin_XBox360_A - (long)k_EControllerActionOrigin_XBox360_A));
+        switch (GamepadGetType(controllerHandle)) {
+        case k_ESteamInputType_PS3Controller:
+        case k_ESteamInputType_PS4Controller:
+            originsOut[i] = (EControllerActionOrigin)(origins[i] - ((long)k_EInputActionOrigin_PS4_X - (long)k_EControllerActionOrigin_PS4_X));
+            break;
+        case k_ESteamInputType_PS5Controller:
+            originsOut[i] = (EControllerActionOrigin)(origins[i] - ((long)k_EInputActionOrigin_PS5_X - (long)k_EControllerActionOrigin_PS5_X));
+            break;
+        case k_ESteamInputType_SwitchJoyConSingle:
+        case k_ESteamInputType_SwitchJoyConPair:
+        case k_ESteamInputType_SwitchProController:
+            originsOut[i] = (EControllerActionOrigin)(origins[i] - ((long)k_EInputActionOrigin_Switch_A - (long)k_EControllerActionOrigin_Switch_A));
+            break;
+        case k_ESteamInputType_XBoxOneController:
+            originsOut[i] = (EControllerActionOrigin)(origins[i] - ((long)k_EInputActionOrigin_XBoxOne_A - (long)k_EControllerActionOrigin_XBoxOne_A));
+            break;
+        case k_ESteamInputType_XBox360Controller:
+        default:
+            originsOut[i] = (EControllerActionOrigin)(origins[i] - ((long)k_EInputActionOrigin_XBox360_A - (long)k_EControllerActionOrigin_XBox360_A));
+            break;
+        }
     }
 
     return ret;
 }
 
-int Steam_Controller::GetAnalogActionOrigins( InputHandle_t inputHandle, InputActionSetHandle_t actionSetHandle, InputAnalogActionHandle_t analogActionHandle, EInputActionOrigin *originsOut )
+int Steam_Controller::GetAnalogActionOrigins(InputHandle_t inputHandle, InputActionSetHandle_t actionSetHandle, InputAnalogActionHandle_t analogActionHandle, EInputActionOrigin* originsOut)
 {
     PRINT_DEBUG_ENTRY();
     auto controller = controllers.find(inputHandle);
@@ -788,26 +1132,52 @@ int Steam_Controller::GetAnalogActionOrigins( InputHandle_t inputHandle, InputAc
     if (a == map->second.active_analog.end()) return 0;
 
     int count = 0;
-    for (auto b: a->second.first) {
+    ESteamInputType type = GamepadGetType(inputHandle);
+    for (auto b : a->second.first) {
+        originsOut[count] = k_EInputActionOrigin_None;
         switch (b) {
-            case TRIGGER_LEFT:
-                originsOut[count] = k_EInputActionOrigin_XBox360_LeftTrigger_Pull;
-                break;
-            case TRIGGER_RIGHT:
-                originsOut[count] = k_EInputActionOrigin_XBox360_RightTrigger_Pull;
-                break;
-            case STICK_LEFT + JOY_ID_START:
-                originsOut[count] = k_EInputActionOrigin_XBox360_LeftStick_Move;
-                break;
-            case STICK_RIGHT + JOY_ID_START:
-                originsOut[count] = k_EInputActionOrigin_XBox360_RightStick_Move;
-                break;
-            case STICK_DPAD + JOY_ID_START:
-                originsOut[count] = k_EInputActionOrigin_XBox360_DPad_Move;
-                break;
-            default:
-                originsOut[count] = k_EInputActionOrigin_None;
-                break;
+        case TRIGGER_LEFT:
+            if (type == k_ESteamInputType_XBox360Controller) originsOut[count] = k_EInputActionOrigin_XBox360_LeftTrigger_Pull;
+            else if (type == k_ESteamInputType_XBoxOneController) originsOut[count] = k_EInputActionOrigin_XBoxOne_LeftTrigger_Pull;
+            else if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller) originsOut[count] = k_EInputActionOrigin_PS4_LeftTrigger_Pull;
+            else if (type == k_ESteamInputType_PS5Controller) originsOut[count] = k_EInputActionOrigin_PS5_LeftTrigger_Pull;
+            else if (type == k_ESteamInputType_SwitchProController || type == k_ESteamInputType_SwitchJoyConPair
+                || type == k_ESteamInputType_SwitchJoyConSingle) originsOut[count] = k_EInputActionOrigin_Switch_LeftTrigger_Pull;
+            break;
+        case TRIGGER_RIGHT:
+            if (type == k_ESteamInputType_XBox360Controller) originsOut[count] = k_EInputActionOrigin_XBox360_RightTrigger_Pull;
+            else if (type == k_ESteamInputType_XBoxOneController) originsOut[count] = k_EInputActionOrigin_XBoxOne_RightTrigger_Pull;
+            else if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller) originsOut[count] = k_EInputActionOrigin_PS4_RightTrigger_Pull;
+            else if (type == k_ESteamInputType_PS5Controller) originsOut[count] = k_EInputActionOrigin_PS5_RightTrigger_Pull;
+            else if (type == k_ESteamInputType_SwitchProController || type == k_ESteamInputType_SwitchJoyConPair
+                || type == k_ESteamInputType_SwitchJoyConSingle) originsOut[count] = k_EInputActionOrigin_Switch_RightTrigger_Pull;
+            break;
+        case STICK_LEFT + JOY_ID_START:
+            if (type == k_ESteamInputType_XBox360Controller) originsOut[count] = k_EInputActionOrigin_XBox360_LeftStick_Move;
+            else if (type == k_ESteamInputType_XBoxOneController) originsOut[count] = k_EInputActionOrigin_XBoxOne_LeftStick_Move;
+            else if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller) originsOut[count] = k_EInputActionOrigin_PS4_LeftStick_Move;
+            else if (type == k_ESteamInputType_PS5Controller) originsOut[count] = k_EInputActionOrigin_PS5_LeftStick_Move;
+            else if (type == k_ESteamInputType_SwitchProController || type == k_ESteamInputType_SwitchJoyConPair
+                || type == k_ESteamInputType_SwitchJoyConSingle) originsOut[count] = k_EInputActionOrigin_Switch_LeftStick_Move;
+            break;
+        case STICK_RIGHT + JOY_ID_START:
+            if (type == k_ESteamInputType_XBox360Controller) originsOut[count] = k_EInputActionOrigin_XBox360_RightStick_Move;
+            else if (type == k_ESteamInputType_XBoxOneController) originsOut[count] = k_EInputActionOrigin_XBoxOne_RightStick_Move;
+            else if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller) originsOut[count] = k_EInputActionOrigin_PS4_RightStick_Move;
+            else if (type == k_ESteamInputType_PS5Controller) originsOut[count] = k_EInputActionOrigin_PS5_RightStick_Move;
+            else if (type == k_ESteamInputType_SwitchProController || type == k_ESteamInputType_SwitchJoyConPair
+                || type == k_ESteamInputType_SwitchJoyConSingle) originsOut[count] = k_EInputActionOrigin_Switch_RightStick_Move;
+            break;
+        case STICK_DPAD + JOY_ID_START:
+            if (type == k_ESteamInputType_XBox360Controller) originsOut[count] = k_EInputActionOrigin_XBox360_DPad_Move;
+            else if (type == k_ESteamInputType_XBoxOneController) originsOut[count] = k_EInputActionOrigin_XBoxOne_DPad_Move;
+            else if (type == k_ESteamInputType_PS3Controller || type == k_ESteamInputType_PS4Controller) originsOut[count] = k_EInputActionOrigin_PS4_DPad_Move;
+            else if (type == k_ESteamInputType_PS5Controller) originsOut[count] = k_EInputActionOrigin_PS5_DPad_Move;
+            else if (type == k_ESteamInputType_SwitchProController || type == k_ESteamInputType_SwitchJoyConPair
+                || type == k_ESteamInputType_SwitchJoyConSingle) originsOut[count] = k_EInputActionOrigin_Switch_DPad_Move;
+            break;
+        default:
+            break;
         }
 
         ++count;
@@ -819,40 +1189,40 @@ int Steam_Controller::GetAnalogActionOrigins( InputHandle_t inputHandle, InputAc
     return count;
 }
 
-    
-void Steam_Controller::StopAnalogActionMomentum( ControllerHandle_t controllerHandle, ControllerAnalogActionHandle_t eAction )
+
+void Steam_Controller::StopAnalogActionMomentum(ControllerHandle_t controllerHandle, ControllerAnalogActionHandle_t eAction)
 {
     PRINT_DEBUG("%llu %llu", controllerHandle, eAction);
 }
 
 
 // Trigger a haptic pulse on a controller
-void Steam_Controller::TriggerHapticPulse( ControllerHandle_t controllerHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec )
+void Steam_Controller::TriggerHapticPulse(ControllerHandle_t controllerHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec)
 {
     PRINT_DEBUG_TODO();
 }
 
 // Trigger a haptic pulse on a controller
-void Steam_Controller::Legacy_TriggerHapticPulse( InputHandle_t inputHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec )
+void Steam_Controller::Legacy_TriggerHapticPulse(InputHandle_t inputHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec)
 {
     PRINT_DEBUG_TODO();
-    TriggerHapticPulse(inputHandle, eTargetPad, usDurationMicroSec );
+    TriggerHapticPulse(inputHandle, eTargetPad, usDurationMicroSec);
 }
 
-void Steam_Controller::TriggerHapticPulse( uint32 unControllerIndex, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec )
+void Steam_Controller::TriggerHapticPulse(uint32 unControllerIndex, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec)
 {
     PRINT_DEBUG("old");
-    TriggerHapticPulse(unControllerIndex, eTargetPad, usDurationMicroSec );
+    TriggerHapticPulse(unControllerIndex, eTargetPad, usDurationMicroSec);
 }
 
 // Trigger a pulse with a duty cycle of usDurationMicroSec / usOffMicroSec, unRepeat times.
 // nFlags is currently unused and reserved for future use.
-void Steam_Controller::TriggerRepeatedHapticPulse( ControllerHandle_t controllerHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec, unsigned short usOffMicroSec, unsigned short unRepeat, unsigned int nFlags )
+void Steam_Controller::TriggerRepeatedHapticPulse(ControllerHandle_t controllerHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec, unsigned short usOffMicroSec, unsigned short unRepeat, unsigned int nFlags)
 {
     PRINT_DEBUG_TODO();
 }
 
-void Steam_Controller::Legacy_TriggerRepeatedHapticPulse( InputHandle_t inputHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec, unsigned short usOffMicroSec, unsigned short unRepeat, unsigned int nFlags )
+void Steam_Controller::Legacy_TriggerRepeatedHapticPulse(InputHandle_t inputHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec, unsigned short usOffMicroSec, unsigned short unRepeat, unsigned int nFlags)
 {
     PRINT_DEBUG_TODO();
     TriggerRepeatedHapticPulse(inputHandle, eTargetPad, usDurationMicroSec, usOffMicroSec, unRepeat, nFlags);
@@ -860,13 +1230,13 @@ void Steam_Controller::Legacy_TriggerRepeatedHapticPulse( InputHandle_t inputHan
 
 
 // Send a haptic pulse, works on Steam Deck and Steam Controller devices
-void Steam_Controller::TriggerSimpleHapticEvent( InputHandle_t inputHandle, EControllerHapticLocation eHapticLocation, uint8 nIntensity, char nGainDB, uint8 nOtherIntensity, char nOtherGainDB )
+void Steam_Controller::TriggerSimpleHapticEvent(InputHandle_t inputHandle, EControllerHapticLocation eHapticLocation, uint8 nIntensity, char nGainDB, uint8 nOtherIntensity, char nOtherGainDB)
 {
     PRINT_DEBUG_TODO();
 }
 
 // Tigger a vibration event on supported controllers.  
-void Steam_Controller::TriggerVibration( ControllerHandle_t controllerHandle, unsigned short usLeftSpeed, unsigned short usRightSpeed )
+void Steam_Controller::TriggerVibration(ControllerHandle_t controllerHandle, unsigned short usLeftSpeed, unsigned short usRightSpeed)
 {
     PRINT_DEBUG("%hu %hu", usLeftSpeed, usRightSpeed);
     auto controller = controllers.find(controllerHandle);
@@ -879,56 +1249,74 @@ void Steam_Controller::TriggerVibration( ControllerHandle_t controllerHandle, un
     rumble_length_ms = 100;
 #endif
 
-    unsigned gamepad_device = static_cast<unsigned int>(controllerHandle - 1);
-    if (gamepad_device > GAMEPAD_COUNT) return;
-    rumble_thread_data->rumble_mutex.lock();
-    rumble_thread_data->data[gamepad_device].new_data = true;
-    rumble_thread_data->data[gamepad_device].left = usLeftSpeed;
-    rumble_thread_data->data[gamepad_device].right = usRightSpeed;
-    rumble_thread_data->data[gamepad_device].rumble_length_ms = rumble_length_ms;
-    rumble_thread_data->rumble_mutex.unlock();
-    rumble_thread_data->rumble_thread_cv.notify_one();
+    GamepadSetRumble(controllerHandle, usLeftSpeed, usRightSpeed, rumble_length_ms);
+
+    //unsigned gamepad_device = static_cast<unsigned int>(controllerHandle - 1);
+    //if (gamepad_device > GAMEPAD_COUNT) return;
+    //rumble_thread_data->rumble_mutex.lock();
+    //rumble_thread_data->data[gamepad_device].new_data = true;
+    //rumble_thread_data->data[gamepad_device].left = usLeftSpeed;
+    //rumble_thread_data->data[gamepad_device].right = usRightSpeed;
+    //rumble_thread_data->data[gamepad_device].rumble_length_ms = rumble_length_ms;
+    //rumble_thread_data->rumble_mutex.unlock();
+    //rumble_thread_data->rumble_thread_cv.notify_one();
 }
 
 // Trigger a vibration event on supported controllers including Xbox trigger impulse rumble - Steam will translate these commands into haptic pulses for Steam Controllers
-void Steam_Controller::TriggerVibrationExtended( InputHandle_t inputHandle, unsigned short usLeftSpeed, unsigned short usRightSpeed, unsigned short usLeftTriggerSpeed, unsigned short usRightTriggerSpeed )
+void Steam_Controller::TriggerVibrationExtended(InputHandle_t inputHandle, unsigned short usLeftSpeed, unsigned short usRightSpeed, unsigned short usLeftTriggerSpeed, unsigned short usRightTriggerSpeed)
 {
-    PRINT_DEBUG_TODO();
-    TriggerVibration(inputHandle, usLeftSpeed, usRightSpeed);
-    //TODO trigger impulse rumbles
+    PRINT_DEBUG("%hu %hu %hu %hu", usLeftSpeed, usRightSpeed, usLeftTriggerSpeed, usRightTriggerSpeed);
+    auto controller = controllers.find(inputHandle);
+    if (controller == controllers.end()) return;
+
+    unsigned int rumble_length_ms = 0;
+
+#if defined(__linux__)
+    //FIXME: shadow of the tomb raider on linux doesn't seem to turn off the rumble so I made it expire after 100ms. Need to check if this is how linux steam actually behaves.
+    rumble_length_ms = 100;
+#endif
+
+    GamepadSetTriggersRumble(inputHandle, usLeftSpeed, usRightSpeed, rumble_length_ms);
 }
 
 // Set the controller LED color on supported controllers.  
-void Steam_Controller::SetLEDColor( ControllerHandle_t controllerHandle, uint8 nColorR, uint8 nColorG, uint8 nColorB, unsigned int nFlags )
+void Steam_Controller::SetLEDColor(ControllerHandle_t controllerHandle, uint8 nColorR, uint8 nColorG, uint8 nColorB, unsigned int nFlags)
 {
     PRINT_DEBUG_TODO();
 }
 
 
 // Returns the associated gamepad index for the specified controller, if emulating a gamepad
-int Steam_Controller::GetGamepadIndexForController( ControllerHandle_t ulControllerHandle )
+int Steam_Controller::GetGamepadIndexForController(ControllerHandle_t ulControllerHandle)
 {
     PRINT_DEBUG_ENTRY();
     auto controller = controllers.find(ulControllerHandle);
     if (controller == controllers.end()) return -1;
 
-    return static_cast<int>(ulControllerHandle) - 1;
+    ESteamInputType type = GamepadGetType(controller->first);
+    if (type == k_ESteamInputType_XBox360Controller || type == k_ESteamInputType_XBoxOneController) return 0; // 0 means Xbox!
+
+    return static_cast<int>(std::distance(controllers.begin(), controller));
 }
 
 
 // Returns the associated controller handle for the specified emulated gamepad
-ControllerHandle_t Steam_Controller::GetControllerForGamepadIndex( int nIndex )
+ControllerHandle_t Steam_Controller::GetControllerForGamepadIndex(int nIndex)
 {
     PRINT_DEBUG("%i", nIndex);
-    ControllerHandle_t out = nIndex + 1;
-    auto controller = controllers.find(out);
-    if (controller == controllers.end()) return 0;
-    return out;
+    if (nIndex > controllers.size())
+        return 0;
+    auto it = controllers.begin();
+    std::advance(it, nIndex);
+    if (it == controllers.end()) return -1; // return some garbage value
+    ESteamInputType type = GamepadGetType(it->first);
+    if (type == k_ESteamInputType_XBox360Controller || type == k_ESteamInputType_XBoxOneController) return 0; // 0 means Xbox!
+    return it->first;
 }
 
 
 // Returns raw motion data from the specified controller
-ControllerMotionData_t Steam_Controller::GetMotionData( ControllerHandle_t controllerHandle )
+ControllerMotionData_t Steam_Controller::GetMotionData(ControllerHandle_t controllerHandle)
 {
     PRINT_DEBUG_TODO();
     ControllerMotionData_t data = {};
@@ -938,13 +1326,13 @@ ControllerMotionData_t Steam_Controller::GetMotionData( ControllerHandle_t contr
 
 // Attempt to display origins of given action in the controller HUD, for the currently active action set
 // Returns false is overlay is disabled / unavailable, or the user is not in Big Picture mode
-bool Steam_Controller::ShowDigitalActionOrigins( ControllerHandle_t controllerHandle, ControllerDigitalActionHandle_t digitalActionHandle, float flScale, float flXPosition, float flYPosition )
+bool Steam_Controller::ShowDigitalActionOrigins(ControllerHandle_t controllerHandle, ControllerDigitalActionHandle_t digitalActionHandle, float flScale, float flXPosition, float flYPosition)
 {
     PRINT_DEBUG_TODO();
     return true;
 }
 
-bool Steam_Controller::ShowAnalogActionOrigins( ControllerHandle_t controllerHandle, ControllerAnalogActionHandle_t analogActionHandle, float flScale, float flXPosition, float flYPosition )
+bool Steam_Controller::ShowAnalogActionOrigins(ControllerHandle_t controllerHandle, ControllerAnalogActionHandle_t analogActionHandle, float flScale, float flXPosition, float flYPosition)
 {
     PRINT_DEBUG_TODO();
     return true;
@@ -952,20 +1340,20 @@ bool Steam_Controller::ShowAnalogActionOrigins( ControllerHandle_t controllerHan
 
 
 // Returns a localized string (from Steam's language setting) for the specified origin
-const char* Steam_Controller::GetStringForActionOrigin( EControllerActionOrigin eOrigin )
+const char* Steam_Controller::GetStringForActionOrigin(EControllerActionOrigin eOrigin)
 {
     PRINT_DEBUG_TODO();
     return "Button String";
 }
 
-const char* Steam_Controller::GetStringForActionOrigin( EInputActionOrigin eOrigin )
+const char* Steam_Controller::GetStringForActionOrigin(EInputActionOrigin eOrigin)
 {
     PRINT_DEBUG_TODO();
     return "Button String";
 }
 
 // Returns a localized string (from Steam's language setting) for the user-facing action name corresponding to the specified handle
-const char* Steam_Controller::GetStringForAnalogActionName( InputAnalogActionHandle_t eActionHandle )
+const char* Steam_Controller::GetStringForAnalogActionName(InputAnalogActionHandle_t eActionHandle)
 {
     PRINT_DEBUG_TODO();
     //TODO SteamInput005
@@ -973,7 +1361,7 @@ const char* Steam_Controller::GetStringForAnalogActionName( InputAnalogActionHan
 }
 
 // Get a local path to art for on-screen glyph for a particular origin 
-const char* Steam_Controller::GetGlyphForActionOrigin( EControllerActionOrigin eOrigin )
+const char* Steam_Controller::GetGlyphForActionOrigin(EControllerActionOrigin eOrigin)
 {
     PRINT_DEBUG("%i", eOrigin);
 
@@ -1015,11 +1403,15 @@ const char* Steam_Controller::GetGlyphForActionOrigin( EControllerActionOrigin e
     return glyph->second.c_str();
 }
 
-const char* Steam_Controller::GetGlyphForActionOrigin( EInputActionOrigin eOrigin )
+
+
+const char* Steam_Controller::GetGlyphForActionOrigin(EInputActionOrigin eOrigin)
 {
     PRINT_DEBUG("steaminput %i", eOrigin);
     if (steaminput_glyphs.empty()) {
+        //std::string base_dir = settings->glyphs_directory;
         std::string dir = settings->glyphs_directory;
+        //dir = base_dir + (PATH_SEPARATOR "XBox360" PATH_SEPARATOR);
         steaminput_glyphs[k_EInputActionOrigin_XBox360_A] = dir + "button_a.png";
         steaminput_glyphs[k_EInputActionOrigin_XBox360_B] = dir + "button_b.png";
         steaminput_glyphs[k_EInputActionOrigin_XBox360_X] = dir + "button_x.png";
@@ -1058,7 +1450,7 @@ const char* Steam_Controller::GetGlyphForActionOrigin( EInputActionOrigin eOrigi
 }
 
 // Get a local path to a PNG file for the provided origin's glyph. 
-const char* Steam_Controller::GetGlyphPNGForActionOrigin( EInputActionOrigin eOrigin, ESteamInputGlyphSize eSize, uint32 unFlags )
+const char* Steam_Controller::GetGlyphPNGForActionOrigin(EInputActionOrigin eOrigin, ESteamInputGlyphSize eSize, uint32 unFlags)
 {
     PRINT_DEBUG_TODO();
     //TODO SteamInput005
@@ -1066,7 +1458,7 @@ const char* Steam_Controller::GetGlyphPNGForActionOrigin( EInputActionOrigin eOr
 }
 
 // Get a local path to a SVG file for the provided origin's glyph. 
-const char* Steam_Controller::GetGlyphSVGForActionOrigin( EInputActionOrigin eOrigin, uint32 unFlags )
+const char* Steam_Controller::GetGlyphSVGForActionOrigin(EInputActionOrigin eOrigin, uint32 unFlags)
 {
     PRINT_DEBUG_TODO();
     //TODO SteamInput005
@@ -1074,74 +1466,394 @@ const char* Steam_Controller::GetGlyphSVGForActionOrigin( EInputActionOrigin eOr
 }
 
 // Get a local path to an older, Big Picture Mode-style PNG file for a particular origin
-const char* Steam_Controller::GetGlyphForActionOrigin_Legacy( EInputActionOrigin eOrigin )
+const char* Steam_Controller::GetGlyphForActionOrigin_Legacy(EInputActionOrigin eOrigin)
 {
     PRINT_DEBUG_ENTRY();
     return GetGlyphForActionOrigin(eOrigin);
 }
 
 // Returns the input type for a particular handle
-ESteamInputType Steam_Controller::GetInputTypeForHandle( ControllerHandle_t controllerHandle )
+ESteamInputType Steam_Controller::GetInputTypeForHandle(ControllerHandle_t controllerHandle)
 {
-    PRINT_DEBUG("%llu", controllerHandle);
     auto controller = controllers.find(controllerHandle);
-    if (controller == controllers.end()) return k_ESteamInputType_Unknown;
-    return k_ESteamInputType_XBox360Controller;
+    if (controller == controllers.end()) {
+        // Hack: Why does Elden Ring query controllerHandle 0? Are we returning empty handles somewhere else?
+        if (controllers.size() != 0 && controllerHandle == 0)
+            controller = controllers.begin();
+        else {
+            PRINT_DEBUG("%llu ret %i", controllerHandle, 0);
+            return k_ESteamInputType_Unknown;
+        }
+    };
+
+    ESteamInputType type = GamepadGetType(controller->first);
+    PRINT_DEBUG("%llu ret %i", controllerHandle, static_cast<int>(type));
+    return type;
 }
 
-const char* Steam_Controller::GetStringForXboxOrigin( EXboxOrigin eOrigin )
+const char* Steam_Controller::GetStringForXboxOrigin(EXboxOrigin eOrigin)
 {
     PRINT_DEBUG_TODO();
     return "";
 }
 
-const char* Steam_Controller::GetGlyphForXboxOrigin( EXboxOrigin eOrigin )
+const char* Steam_Controller::GetGlyphForXboxOrigin(EXboxOrigin eOrigin)
 {
     PRINT_DEBUG_TODO();
     return "";
 }
 
-EControllerActionOrigin Steam_Controller::GetActionOriginFromXboxOrigin_( ControllerHandle_t controllerHandle, EXboxOrigin eOrigin )
+EControllerActionOrigin Steam_Controller::GetActionOriginFromXboxOrigin_(ControllerHandle_t controllerHandle, EXboxOrigin eOrigin)
+{
+    PRINT_DEBUG_ENTRY();
+    EInputActionOrigin ret = GetActionOriginFromXboxOrigin(controllerHandle, eOrigin);
+    switch (GamepadGetType(controllerHandle)) {
+    case k_ESteamInputType_PS3Controller:
+    case k_ESteamInputType_PS4Controller:
+        return (EControllerActionOrigin)(ret - ((long)k_EInputActionOrigin_PS4_X - (long)k_EControllerActionOrigin_PS4_X));
+    case k_ESteamInputType_PS5Controller:
+        return (EControllerActionOrigin)(ret - ((long)k_EInputActionOrigin_PS5_X - (long)k_EControllerActionOrigin_PS5_X));
+    case k_ESteamInputType_SwitchProController:
+        return (EControllerActionOrigin)(ret - ((long)k_EInputActionOrigin_Switch_A - (long)k_EControllerActionOrigin_Switch_A));
+    case k_ESteamInputType_XBoxOneController:
+        return (EControllerActionOrigin)(ret - ((long)k_EInputActionOrigin_XBoxOne_A - (long)k_EControllerActionOrigin_XBoxOne_A));
+    case k_ESteamInputType_XBox360Controller:
+    default:
+        return (EControllerActionOrigin)(ret - ((long)k_EInputActionOrigin_XBox360_A - (long)k_EControllerActionOrigin_XBox360_A));
+    }
+}
+
+EInputActionOrigin Steam_Controller::GetActionOriginFromXboxOrigin(InputHandle_t inputHandle, EXboxOrigin eOrigin)
+{
+    PRINT_DEBUG_ENTRY();
+    auto controller = controllers.find(inputHandle);
+    if (controller == controllers.end()) return k_EInputActionOrigin_None;
+    ESteamInputType controllerType = GamepadGetType(inputHandle);
+    switch (eOrigin) {
+    case k_EXboxOrigin_A:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_X;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_X;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_A;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController) {
+            if (this->settings->flip_nintendo_layout)
+                return k_EInputActionOrigin_Switch_B;
+            else
+                return k_EInputActionOrigin_Switch_A;
+        }
+        return k_EInputActionOrigin_None;
+
+    case k_EXboxOrigin_B:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_Circle;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_Circle;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_B;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController) {
+            if (this->settings->flip_nintendo_layout)
+                return k_EInputActionOrigin_Switch_A;
+            else
+                return k_EInputActionOrigin_Switch_B;
+        }
+        return k_EInputActionOrigin_None;
+
+    case k_EXboxOrigin_X:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_Square;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_Square;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_X;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController) {
+            if (this->settings->flip_nintendo_layout)
+                return k_EInputActionOrigin_Switch_Y;
+            else
+                return k_EInputActionOrigin_Switch_X;
+        }
+        return k_EInputActionOrigin_None;
+
+    case k_EXboxOrigin_Y:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_Triangle;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_Triangle;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_Y;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController) {
+            if (this->settings->flip_nintendo_layout)
+                return k_EInputActionOrigin_Switch_X;
+            else
+                return k_EInputActionOrigin_Switch_Y;
+        }
+        return k_EInputActionOrigin_None;
+
+        // Bumpers
+    case k_EXboxOrigin_LeftBumper:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_LeftBumper;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_LeftBumper;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_LeftBumper;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_LeftBumper;
+        return k_EInputActionOrigin_XBox360_LeftBumper;
+
+    case k_EXboxOrigin_RightBumper:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_RightBumper;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_RightBumper;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_RightBumper;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_RightBumper;
+        return k_EInputActionOrigin_XBox360_RightBumper;
+
+        // Menu buttons
+    case k_EXboxOrigin_Menu:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_Options;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_Option;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_Menu;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_Plus;
+        return k_EInputActionOrigin_XBox360_Start;
+
+    case k_EXboxOrigin_View:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_Share;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_Create;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_View;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_Minus;
+
+        return k_EInputActionOrigin_XBox360_Back;
+
+        // Triggers
+    case k_EXboxOrigin_LeftTrigger_Click:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_LeftTrigger_Click;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_LeftTrigger_Click;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_LeftTrigger_Click;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_LeftTrigger_Click;
+        return k_EInputActionOrigin_XBox360_LeftTrigger_Click;
+
+    case k_EXboxOrigin_RightTrigger_Click:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_RightTrigger_Click;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_RightTrigger_Click;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_RightTrigger_Click;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_RightTrigger_Click;
+        return k_EInputActionOrigin_XBox360_RightTrigger_Click;
+
+        // Stick clicks
+    case k_EXboxOrigin_LeftStick_Click:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_LeftStick_Click;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_LeftStick_Click;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_LeftStick_Click;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_LeftStick_Click;
+        return k_EInputActionOrigin_XBox360_LeftStick_Click;
+
+    case k_EXboxOrigin_RightStick_Click:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_RightStick_Click;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_RightStick_Click;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_RightStick_Click;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_RightStick_Click;
+        return k_EInputActionOrigin_XBox360_RightStick_Click;
+
+        // Left stick directions
+    case k_EXboxOrigin_LeftStick_DPadNorth:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_LeftStick_DPadNorth;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_LeftStick_DPadNorth;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_LeftStick_DPadNorth;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_LeftStick_DPadNorth;
+        return k_EInputActionOrigin_XBox360_LeftStick_DPadNorth;
+
+    case k_EXboxOrigin_LeftStick_DPadSouth:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_LeftStick_DPadSouth;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_LeftStick_DPadSouth;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_LeftStick_DPadSouth;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_LeftStick_DPadSouth;
+        return k_EInputActionOrigin_XBox360_LeftStick_DPadSouth;
+
+    case k_EXboxOrigin_LeftStick_DPadWest:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_LeftStick_DPadWest;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_LeftStick_DPadWest;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_LeftStick_DPadWest;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_LeftStick_DPadWest;
+        return k_EInputActionOrigin_XBox360_LeftStick_DPadWest;
+
+    case k_EXboxOrigin_LeftStick_DPadEast:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_LeftStick_DPadEast;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_LeftStick_DPadEast;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_LeftStick_DPadEast;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_LeftStick_DPadEast;
+        return k_EInputActionOrigin_XBox360_LeftStick_DPadEast;
+
+        // Right stick directions
+    case k_EXboxOrigin_RightStick_DPadNorth:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_RightStick_DPadNorth;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_RightStick_DPadNorth;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_RightStick_DPadNorth;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_RightStick_DPadNorth;
+        return k_EInputActionOrigin_XBox360_RightStick_DPadNorth;
+
+    case k_EXboxOrigin_RightStick_DPadSouth:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_RightStick_DPadSouth;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_RightStick_DPadSouth;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_RightStick_DPadSouth;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_RightStick_DPadSouth;
+
+        return k_EInputActionOrigin_XBox360_RightStick_DPadSouth;
+
+    case k_EXboxOrigin_RightStick_DPadWest:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_RightStick_DPadWest;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_RightStick_DPadWest;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_RightStick_DPadWest;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_RightStick_DPadWest;
+        return k_EInputActionOrigin_XBox360_RightStick_DPadWest;
+
+    case k_EXboxOrigin_RightStick_DPadEast:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_RightStick_DPadEast;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_RightStick_DPadEast;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_RightStick_DPadEast;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_RightStick_DPadEast;
+        return k_EInputActionOrigin_XBox360_RightStick_DPadEast;
+
+        // DPad buttons
+    case k_EXboxOrigin_DPad_North:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_DPad_North;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_DPad_North;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_DPad_North;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_DPad_North;
+        return k_EInputActionOrigin_XBox360_DPad_North;
+
+    case k_EXboxOrigin_DPad_South:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_DPad_South;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_DPad_South;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_DPad_South;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_DPad_South;
+        return k_EInputActionOrigin_XBox360_DPad_South;
+
+    case k_EXboxOrigin_DPad_West:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_DPad_West;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_DPad_West;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_DPad_West;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_DPad_West;
+        return k_EInputActionOrigin_XBox360_DPad_West;
+
+    case k_EXboxOrigin_DPad_East:
+        if (controllerType == k_ESteamInputType_PS3Controller || controllerType == k_ESteamInputType_PS4Controller)
+            return k_EInputActionOrigin_PS4_DPad_East;
+        if (controllerType == k_ESteamInputType_PS5Controller)
+            return k_EInputActionOrigin_PS5_DPad_East;
+        if (controllerType == k_ESteamInputType_XBoxOneController)
+            return k_EInputActionOrigin_XBoxOne_DPad_East;
+        if (controllerType == k_ESteamInputType_SwitchJoyConSingle || controllerType == k_ESteamInputType_SwitchJoyConPair || controllerType == k_ESteamInputType_SwitchProController)
+            return k_EInputActionOrigin_Switch_DPad_East;
+        return k_EInputActionOrigin_XBox360_DPad_East;
+
+    default:
+        return k_EInputActionOrigin_None;
+    }
+
+}
+
+EControllerActionOrigin Steam_Controller::TranslateActionOrigin(ESteamInputType eDestinationInputType, EControllerActionOrigin eSourceOrigin)
 {
     PRINT_DEBUG_TODO();
     return k_EControllerActionOrigin_None;
 }
 
-EInputActionOrigin Steam_Controller::GetActionOriginFromXboxOrigin( InputHandle_t inputHandle, EXboxOrigin eOrigin )
+EInputActionOrigin Steam_Controller::TranslateActionOrigin(ESteamInputType eDestinationInputType, EInputActionOrigin eSourceOrigin)
 {
-    PRINT_DEBUG_TODO();
-    return k_EInputActionOrigin_None;
-}
+    PRINT_DEBUG("steaminput destinationinputtype %d sourceorigin %d", eDestinationInputType, eSourceOrigin);
 
-EControllerActionOrigin Steam_Controller::TranslateActionOrigin( ESteamInputType eDestinationInputType, EControllerActionOrigin eSourceOrigin )
-{
-    PRINT_DEBUG_TODO();
-    return k_EControllerActionOrigin_None;
-}
-
-EInputActionOrigin Steam_Controller::TranslateActionOrigin( ESteamInputType eDestinationInputType, EInputActionOrigin eSourceOrigin )
-{
-    PRINT_DEBUG("steaminput destinationinputtype %d sourceorigin %d", eDestinationInputType, eSourceOrigin );
- 
     if (eDestinationInputType == k_ESteamInputType_XBox360Controller)
         return eSourceOrigin;
- 
+
     return k_EInputActionOrigin_None;
 }
 
-bool Steam_Controller::GetControllerBindingRevision( ControllerHandle_t controllerHandle, int *pMajor, int *pMinor )
+bool Steam_Controller::GetControllerBindingRevision(ControllerHandle_t controllerHandle, int* pMajor, int* pMinor)
 {
     PRINT_DEBUG_TODO();
     return false;
 }
 
-bool Steam_Controller::GetDeviceBindingRevision( InputHandle_t inputHandle, int *pMajor, int *pMinor )
+bool Steam_Controller::GetDeviceBindingRevision(InputHandle_t inputHandle, int* pMajor, int* pMinor)
 {
     PRINT_DEBUG_TODO();
     return false;
 }
 
-uint32 Steam_Controller::GetRemotePlaySessionID( InputHandle_t inputHandle )
+uint32 Steam_Controller::GetRemotePlaySessionID(InputHandle_t inputHandle)
 {
     PRINT_DEBUG_TODO();
     return 0;
@@ -1156,7 +1868,7 @@ uint16 Steam_Controller::GetSessionInputConfigurationSettings()
 }
 
 // Set the trigger effect for a DualSense controller
-void Steam_Controller::SetDualSenseTriggerEffect( InputHandle_t inputHandle, const ScePadTriggerEffectParam *pParam )
+void Steam_Controller::SetDualSenseTriggerEffect(InputHandle_t inputHandle, const ScePadTriggerEffectParam* pParam)
 {
     PRINT_DEBUG_TODO();
 }

--- a/dll/steam_controller.cpp
+++ b/dll/steam_controller.cpp
@@ -129,74 +129,71 @@ void Steam_Controller::set_handles(std::map<std::string, std::map<std::string, s
     // TODO Load action_set_layers properly?
     uint64 handle_num = 1;
 
-    auto storeActionSetHandle = [&](std::pair<std::string, std::map<std::string, std::pair<std::set<std::string>, std::string>>> set) {
-        ControllerActionSetHandle_t action_handle_num = handle_num;
-        ++handle_num;
-
-        action_handles[set.first] = action_handle_num;
-        for (auto& config_key : set.second) {
-            uint64 current_handle_num = handle_num;
+    auto storeActionSetHandle = [&](std::map<std::string, std::map<std::string, std::pair<std::set<std::string>, std::string>>> &sets) {
+        for (auto& set : sets) {
+            ControllerActionSetHandle_t action_handle_num = handle_num;
             ++handle_num;
 
-            for (auto& button_string : config_key.second.first) {
-                auto digital = button_strings.find(button_string);
-                if (digital != button_strings.end()) {
-                    ControllerDigitalActionHandle_t digital_handle_num = current_handle_num;
+            action_handles[set.first] = action_handle_num;
+            for (auto& config_key : set.second) {
+                uint64 current_handle_num = handle_num;
+                ++handle_num;
 
-                    if (digital_action_handles.find(config_key.first) == digital_action_handles.end()) {
-                        digital_action_handles[config_key.first] = digital_handle_num;
-                    }
-                    else {
-                        digital_handle_num = digital_action_handles[config_key.first];
-                    }
+                for (auto& button_string : config_key.second.first) {
+                    auto digital = button_strings.find(button_string);
+                    if (digital != button_strings.end()) {
+                        ControllerDigitalActionHandle_t digital_handle_num = current_handle_num;
 
-                    controller_maps[action_handle_num].active_digital[digital_handle_num].insert(digital->second);
-                }
-                else {
-                    auto analog = analog_strings.find(button_string);
-                    if (analog != analog_strings.end()) {
-                        ControllerAnalogActionHandle_t analog_handle_num = current_handle_num;
-
-                        enum EInputSourceMode source_mode;
-                        if (analog->second == TRIGGER_LEFT || analog->second == TRIGGER_RIGHT) {
-                            source_mode = k_EInputSourceMode_Trigger;
+                        if (digital_action_handles.find(config_key.first) == digital_action_handles.end()) {
+                            digital_action_handles[config_key.first] = digital_handle_num;
                         }
                         else {
-                            source_mode = k_EInputSourceMode_JoystickMove;
+                            digital_handle_num = digital_action_handles[config_key.first];
                         }
 
-                        auto input_mode = analog_input_modes.find(config_key.second.second);
-                        if (input_mode != analog_input_modes.end()) {
-                            source_mode = input_mode->second;
-                        }
-
-                        if (analog_action_handles.find(config_key.first) == analog_action_handles.end()) {
-                            analog_action_handles[config_key.first] = analog_handle_num;
-                        }
-                        else {
-                            analog_handle_num = analog_action_handles[config_key.first];
-                        }
-
-                        controller_maps[action_handle_num].active_analog[analog_handle_num].first.insert(analog->second);
-                        controller_maps[action_handle_num].active_analog[analog_handle_num].second = source_mode;
-
+                        controller_maps[action_handle_num].active_digital[digital_handle_num].insert(digital->second);
                     }
                     else {
-                        PRINT_DEBUG("Did not recognize controller button %s", button_string.c_str());
-                        continue;
+                        auto analog = analog_strings.find(button_string);
+                        if (analog != analog_strings.end()) {
+                            ControllerAnalogActionHandle_t analog_handle_num = current_handle_num;
+
+                            enum EInputSourceMode source_mode;
+                            if (analog->second == TRIGGER_LEFT || analog->second == TRIGGER_RIGHT) {
+                                source_mode = k_EInputSourceMode_Trigger;
+                            }
+                            else {
+                                source_mode = k_EInputSourceMode_JoystickMove;
+                            }
+
+                            auto input_mode = analog_input_modes.find(config_key.second.second);
+                            if (input_mode != analog_input_modes.end()) {
+                                source_mode = input_mode->second;
+                            }
+
+                            if (analog_action_handles.find(config_key.first) == analog_action_handles.end()) {
+                                analog_action_handles[config_key.first] = analog_handle_num;
+                            }
+                            else {
+                                analog_handle_num = analog_action_handles[config_key.first];
+                            }
+
+                            controller_maps[action_handle_num].active_analog[analog_handle_num].first.insert(analog->second);
+                            controller_maps[action_handle_num].active_analog[analog_handle_num].second = source_mode;
+
+                        }
+                        else {
+                            PRINT_DEBUG("Did not recognize controller button %s", button_string.c_str());
+                            continue;
+                        }
                     }
                 }
             }
         }
     };
 
-    for (auto& set : action_sets) {
-        storeActionSetHandle(set);
-    }
-
-    for (auto& set : action_set_layers) {
-        storeActionSetHandle(set);
-    }
+    storeActionSetHandle(action_sets);
+    storeActionSetHandle(action_set_layers);
 }
 
 
@@ -2073,8 +2070,304 @@ EInputActionOrigin Steam_Controller::TranslateActionOrigin(ESteamInputType eDest
 {
     PRINT_DEBUG("steaminput destinationinputtype %d sourceorigin %d", eDestinationInputType, eSourceOrigin);
 
-    if (eDestinationInputType == k_ESteamInputType_XBox360Controller)
-        return eSourceOrigin;
+    //switch (eSourceOrigin) {
+    //case k_EInputActionOrigin_XBox360_A:
+    //case k_EInputActionOrigin_XBoxOne_A:
+    //case k_EInputActionOrigin_PS4_X:
+    //case k_EInputActionOrigin_PS5_X:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_X;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_X;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_A;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController) {
+    //        if (this->settings->flip_nintendo_layout)
+    //            return k_EInputActionOrigin_Switch_B;
+    //        else
+    //            return k_EInputActionOrigin_Switch_A;
+    //    }
+    //    return k_EInputActionOrigin_None;
+
+    //case k_EXboxOrigin_B:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_Circle;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_Circle;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_B;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController) {
+    //        if (this->settings->flip_nintendo_layout)
+    //            return k_EInputActionOrigin_Switch_A;
+    //        else
+    //            return k_EInputActionOrigin_Switch_B;
+    //    }
+    //    return k_EInputActionOrigin_None;
+
+    //case k_EXboxOrigin_X:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_Square;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_Square;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_X;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController) {
+    //        if (this->settings->flip_nintendo_layout)
+    //            return k_EInputActionOrigin_Switch_Y;
+    //        else
+    //            return k_EInputActionOrigin_Switch_X;
+    //    }
+    //    return k_EInputActionOrigin_None;
+
+    //case k_EXboxOrigin_Y:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_Triangle;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_Triangle;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_Y;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController) {
+    //        if (this->settings->flip_nintendo_layout)
+    //            return k_EInputActionOrigin_Switch_X;
+    //        else
+    //            return k_EInputActionOrigin_Switch_Y;
+    //    }
+    //    return k_EInputActionOrigin_None;
+
+    //    // Bumpers
+    //case k_EXboxOrigin_LeftBumper:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_LeftBumper;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_LeftBumper;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_LeftBumper;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_LeftBumper;
+    //    return k_EInputActionOrigin_XBox360_LeftBumper;
+
+    //case k_EXboxOrigin_RightBumper:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_RightBumper;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_RightBumper;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_RightBumper;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_RightBumper;
+    //    return k_EInputActionOrigin_XBox360_RightBumper;
+
+    //    // Menu buttons
+    //case k_EXboxOrigin_Menu:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_Options;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_Option;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_Menu;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_Plus;
+    //    return k_EInputActionOrigin_XBox360_Start;
+
+    //case k_EXboxOrigin_View:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_Share;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_Create;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_View;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_Minus;
+
+    //    return k_EInputActionOrigin_XBox360_Back;
+
+    //    // Triggers
+    //case k_EXboxOrigin_LeftTrigger_Click:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_LeftTrigger_Click;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_LeftTrigger_Click;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_LeftTrigger_Click;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_LeftTrigger_Click;
+    //    return k_EInputActionOrigin_XBox360_LeftTrigger_Click;
+
+    //case k_EXboxOrigin_RightTrigger_Click:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_RightTrigger_Click;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_RightTrigger_Click;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_RightTrigger_Click;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_RightTrigger_Click;
+    //    return k_EInputActionOrigin_XBox360_RightTrigger_Click;
+
+    //    // Stick clicks
+    //case k_EXboxOrigin_LeftStick_Click:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_LeftStick_Click;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_LeftStick_Click;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_LeftStick_Click;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_LeftStick_Click;
+    //    return k_EInputActionOrigin_XBox360_LeftStick_Click;
+
+    //case k_EXboxOrigin_RightStick_Click:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_RightStick_Click;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_RightStick_Click;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_RightStick_Click;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_RightStick_Click;
+    //    return k_EInputActionOrigin_XBox360_RightStick_Click;
+
+    //    // Left stick directions
+    //case k_EXboxOrigin_LeftStick_DPadNorth:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_LeftStick_DPadNorth;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_LeftStick_DPadNorth;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_LeftStick_DPadNorth;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_LeftStick_DPadNorth;
+    //    return k_EInputActionOrigin_XBox360_LeftStick_DPadNorth;
+
+    //case k_EXboxOrigin_LeftStick_DPadSouth:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_LeftStick_DPadSouth;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_LeftStick_DPadSouth;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_LeftStick_DPadSouth;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_LeftStick_DPadSouth;
+    //    return k_EInputActionOrigin_XBox360_LeftStick_DPadSouth;
+
+    //case k_EXboxOrigin_LeftStick_DPadWest:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_LeftStick_DPadWest;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_LeftStick_DPadWest;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_LeftStick_DPadWest;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_LeftStick_DPadWest;
+    //    return k_EInputActionOrigin_XBox360_LeftStick_DPadWest;
+
+    //case k_EXboxOrigin_LeftStick_DPadEast:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_LeftStick_DPadEast;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_LeftStick_DPadEast;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_LeftStick_DPadEast;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_LeftStick_DPadEast;
+    //    return k_EInputActionOrigin_XBox360_LeftStick_DPadEast;
+
+    //    // Right stick directions
+    //case k_EXboxOrigin_RightStick_DPadNorth:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_RightStick_DPadNorth;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_RightStick_DPadNorth;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_RightStick_DPadNorth;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_RightStick_DPadNorth;
+    //    return k_EInputActionOrigin_XBox360_RightStick_DPadNorth;
+
+    //case k_EXboxOrigin_RightStick_DPadSouth:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_RightStick_DPadSouth;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_RightStick_DPadSouth;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_RightStick_DPadSouth;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_RightStick_DPadSouth;
+
+    //    return k_EInputActionOrigin_XBox360_RightStick_DPadSouth;
+
+    //case k_EXboxOrigin_RightStick_DPadWest:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_RightStick_DPadWest;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_RightStick_DPadWest;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_RightStick_DPadWest;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_RightStick_DPadWest;
+    //    return k_EInputActionOrigin_XBox360_RightStick_DPadWest;
+
+    //case k_EXboxOrigin_RightStick_DPadEast:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_RightStick_DPadEast;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_RightStick_DPadEast;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_RightStick_DPadEast;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_RightStick_DPadEast;
+    //    return k_EInputActionOrigin_XBox360_RightStick_DPadEast;
+
+    //    // DPad buttons
+    //case k_EXboxOrigin_DPad_North:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_DPad_North;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_DPad_North;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_DPad_North;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_DPad_North;
+    //    return k_EInputActionOrigin_XBox360_DPad_North;
+
+    //case k_EXboxOrigin_DPad_South:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_DPad_South;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_DPad_South;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_DPad_South;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_DPad_South;
+    //    return k_EInputActionOrigin_XBox360_DPad_South;
+
+    //case k_EXboxOrigin_DPad_West:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_DPad_West;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_DPad_West;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_DPad_West;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_DPad_West;
+    //    return k_EInputActionOrigin_XBox360_DPad_West;
+
+    //case k_EXboxOrigin_DPad_East:
+    //    if (eDestinationInputType == k_ESteamInputType_PS3Controller || eDestinationInputType == k_ESteamInputType_PS4Controller)
+    //        return k_EInputActionOrigin_PS4_DPad_East;
+    //    if (eDestinationInputType == k_ESteamInputType_PS5Controller)
+    //        return k_EInputActionOrigin_PS5_DPad_East;
+    //    if (eDestinationInputType == k_ESteamInputType_XBoxOneController)
+    //        return k_EInputActionOrigin_XBoxOne_DPad_East;
+    //    if (eDestinationInputType == k_ESteamInputType_SwitchJoyConSingle || eDestinationInputType == k_ESteamInputType_SwitchJoyConPair || eDestinationInputType == k_ESteamInputType_SwitchProController)
+    //        return k_EInputActionOrigin_Switch_DPad_East;
+    //    return k_EInputActionOrigin_XBox360_DPad_East;
+
+    //default:
+    //    return k_EInputActionOrigin_None;
+    //}
+
+
 
     return k_EInputActionOrigin_None;
 }

--- a/helpers/gamepad_provider.cpp
+++ b/helpers/gamepad_provider.cpp
@@ -14,6 +14,7 @@ float gamepad_provider::sdl::GamepadTriggerLength(ControllerHandle_t id, GAMEPAD
 void gamepad_provider::sdl::GamepadStickXY(ControllerHandle_t id, GAMEPAD_STICK stick, float* out_x, float* out_y) {};
 void gamepad_provider::sdl::GamepadStickNormXY(ControllerHandle_t id, GAMEPAD_STICK stick, float* out_x, float* out_y, int inner_deadzone, int outer_deadzone) {};
 void gamepad_provider::sdl::GamepadSetRumble(ControllerHandle_t id, unsigned short left, unsigned short right, unsigned int rumble_length_ms) {};
+void gamepad_provider::sdl::GamepadSetTriggersRumble(ControllerHandle_t id, unsigned short left, unsigned short right, unsigned int rumble_length_ms) {};
 ESteamInputType gamepad_provider::sdl::GamepadGetType(ControllerHandle_t id) { return k_ESteamInputType_Unknown; };
 
 #else
@@ -191,8 +192,11 @@ void gamepad_provider::sdl::GamepadStickNormXY(ControllerHandle_t id, GAMEPAD_ST
 
 void gamepad_provider::sdl::GamepadStickXY(ControllerHandle_t id, GAMEPAD_STICK stick, float* out_x, float* out_y) {
     SDL_Gamepad* gamepad = GamepadGetFromHandle(id);
-    if (!gamepad)
+    if (!gamepad) {
+        *out_x = 0.0f;
+        *out_y = 0.0f;
         return;
+    }
 
     if (stick == STICK_LEFT) {
         *out_x = static_cast<float>(SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_LEFTX));

--- a/helpers/gamepad_provider.cpp
+++ b/helpers/gamepad_provider.cpp
@@ -1,0 +1,250 @@
+#include "gamepad_provider/gamepad_provider.hpp"
+#include <array>
+#include <algorithm>
+#include <string>
+#define GAMEPAD_COUNT 16
+
+#if !defined(CONTROLLER_SUPPORT)
+int gamepad_provider::sdl::DetectGamepads(std::vector<ControllerHandle_t>& handlesOut, std::vector<ControllerHandle_t>& newHandlesOut) { return 0; }
+bool gamepad_provider::sdl::GamepadInit(bool combine_joycons) { return false; };
+void gamepad_provider::sdl::GamepadShutdown(void) {};
+void gamepad_provider::sdl::GamepadUpdate(void) {};
+bool gamepad_provider::sdl::GamepadButtonDown(ControllerHandle_t id, GAMEPAD_BUTTON button) { return false; };
+float gamepad_provider::sdl::GamepadTriggerLength(ControllerHandle_t id, GAMEPAD_TRIGGER trigger) { return 0.0f; };
+void gamepad_provider::sdl::GamepadStickXY(ControllerHandle_t id, GAMEPAD_STICK stick, float* out_x, float* out_y) {};
+void gamepad_provider::sdl::GamepadStickNormXY(ControllerHandle_t id, GAMEPAD_STICK stick, float* out_x, float* out_y, int inner_deadzone, int outer_deadzone) {};
+void gamepad_provider::sdl::GamepadSetRumble(ControllerHandle_t id, unsigned short left, unsigned short right, unsigned int rumble_length_ms) {};
+ESteamInputType gamepad_provider::sdl::GamepadGetType(ControllerHandle_t id) { return k_ESteamInputType_Unknown; };
+
+#else
+
+namespace gamepad_provider {
+    namespace sdl {
+        namespace {
+            static std::map<ControllerHandle_t, SDL_JoystickID> sdl_controller_map{};
+            static std::map<std::string, std::vector<ControllerHandle_t>> guid_controller_map{};
+            static ControllerHandle_t current_controller_index = 1; // Must start from 1
+
+            inline SDL_Gamepad* GamepadGetFromHandle(ControllerHandle_t controller) {
+                auto sdl_controller = sdl_controller_map.find(controller);
+                if (sdl_controller == sdl_controller_map.end()) return nullptr;
+                return SDL_GetGamepadFromID(sdl_controller->second);
+            }
+        }
+    }
+}
+
+bool gamepad_provider::sdl::GamepadInit(bool combine_joycons) {
+    SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4, "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5, "1");
+
+    SDL_SetHint(SDL_HINT_JOYSTICK_ENHANCED_REPORTS, "1");
+
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_GAMECUBE, "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_SWITCH, "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_JOY_CONS, "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_COMBINE_JOY_CONS, combine_joycons ? "1" : "0");  // Joycons are combined by default
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_STADIA, "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_STEAM, "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_LUNA, "1");
+
+    if (!SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_GAMEPAD | SDL_INIT_HAPTIC | SDL_INIT_EVENTS))
+        return false;
+
+    SDL_SetGamepadEventsEnabled(false);
+
+    return true;
+}
+
+void gamepad_provider::sdl::GamepadShutdown(void) {
+    for (auto& c : sdl_controller_map) {
+        SDL_Gamepad* gamepad = SDL_GetGamepadFromID(c.second);
+        if (gamepad)
+            SDL_CloseGamepad(gamepad);
+    }
+
+    SDL_QuitSubSystem(SDL_INIT_JOYSTICK | SDL_INIT_GAMEPAD | SDL_INIT_HAPTIC | SDL_INIT_EVENTS);
+}
+
+void gamepad_provider::sdl::GamepadUpdate(void) {
+    SDL_UpdateGamepads();
+}
+
+/* Detects gamepad connect/disconnects. */
+int gamepad_provider::sdl::DetectGamepads(std::vector<ControllerHandle_t> &handlesOut, std::vector<ControllerHandle_t> &newHandlesOut) {
+    SDL_UpdateGamepads();
+    int count = 0;
+    SDL_JoystickID* gamepads = SDL_GetGamepads(&count);
+
+    for (int i = 0; i < count && i < GAMEPAD_COUNT; ++i) {
+        bool newHandleCreated = false;
+        SDL_JoystickID instance_id = gamepads[i];
+        SDL_GUID guid = SDL_GetGamepadGUIDForID(instance_id);
+        char guid_string[33];
+        SDL_GUIDToString(guid, guid_string, 33);
+        auto guid_handles = guid_controller_map.find(guid_string);
+
+        // Always open gamepad, since a disconnected controller could be in the map
+        SDL_Gamepad* gamepadHandle = SDL_OpenGamepad(instance_id);
+        ControllerHandle_t curr_index = 0;
+
+        if (guid_handles == guid_controller_map.end()) {
+            newHandlesOut.push_back(current_controller_index);
+            char guid_string[33];
+            SDL_GUIDToString(guid, guid_string, 33);
+            sdl_controller_map.insert(std::pair<ControllerHandle_t, SDL_JoystickID>(current_controller_index, instance_id));
+            guid_controller_map.insert(std::pair<std::string, std::vector<ControllerHandle_t>>(guid_string, std::vector<ControllerHandle_t>{current_controller_index}));
+            curr_index = current_controller_index;
+            newHandleCreated = true;
+            ++current_controller_index;
+        }
+        else {
+            bool replaced = false;
+            // GUID already exists
+            for (auto& c : guid_handles->second) {
+                SDL_Gamepad* gamepadHandle = GamepadGetFromHandle(c);
+                if (!gamepadHandle || !SDL_GamepadConnected(gamepadHandle)) {
+                    // Gamepad is not connected, replace this index
+                    if (gamepadHandle)
+                        SDL_CloseGamepad(gamepadHandle);
+                    gamepadHandle = SDL_OpenGamepad(instance_id);
+                    sdl_controller_map[c] = instance_id;
+                    replaced = true;
+                    curr_index = c;
+                    break;
+                }
+                if (SDL_GetGamepadID(gamepadHandle) == instance_id) {
+                    // Gamepad is connected and already in controller_map
+                    replaced = true;
+                    curr_index = c;
+                    break;
+                }
+            }
+
+            if (!replaced) {
+                sdl_controller_map.insert(std::pair<ControllerHandle_t, SDL_JoystickID>(current_controller_index, instance_id));
+                guid_handles->second.push_back(current_controller_index);
+                curr_index = current_controller_index;
+                newHandleCreated = true;
+                ++current_controller_index;
+            }
+        }
+
+        handlesOut.push_back(curr_index);
+
+        if (newHandleCreated) {
+            newHandlesOut.push_back(curr_index);
+        }
+    }
+
+    SDL_free(gamepads);
+
+    return count;
+}
+
+bool gamepad_provider::sdl::GamepadButtonDown(ControllerHandle_t id, GAMEPAD_BUTTON button) {
+    SDL_Gamepad* gamepad = GamepadGetFromHandle(id);
+    if (!gamepad)
+        return false;
+    return SDL_GetGamepadButton(gamepad, (SDL_GamepadButton)button);
+}
+
+float gamepad_provider::sdl::GamepadTriggerLength(ControllerHandle_t id, GAMEPAD_TRIGGER trigger) {
+    SDL_Gamepad* gamepad = GamepadGetFromHandle(id);
+    if (!gamepad)
+        return 0.0f;
+    if (trigger == TRIGGER_LEFT)
+        return static_cast<float>(SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_LEFT_TRIGGER));
+    else if (trigger == TRIGGER_RIGHT)
+        return static_cast<float>(SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_RIGHT_TRIGGER));
+    return 0.0f;
+}
+
+void gamepad_provider::sdl::GamepadStickNormXY(ControllerHandle_t id, GAMEPAD_STICK stick, float* out_x, float* out_y, int inner_deadzone, int outer_deadzone) {
+    float x = 0.0f, y = 0.0f;
+    GamepadStickXY(id, stick, &x, &y);
+
+    // normalize X and Y
+    float length = static_cast<float>(sqrt(x * x + y * y));
+    if (length > inner_deadzone) {
+        // clamp length to maximum value
+        length = std::min(length, 32767.f);
+
+        // normalized X and Y values
+        x /= (JOYSTICK_MAX - outer_deadzone);
+        y /= (JOYSTICK_MAX - outer_deadzone);
+
+        //fix special case
+        x = std::clamp(x, -1.0f, 1.0f);
+        y = std::clamp(y, -1.0f, 1.0f);
+    }
+    else {
+        x = 0.0f;
+        y = 0.0f;
+    }
+
+    *out_x = x;
+    *out_y = y;
+}
+
+void gamepad_provider::sdl::GamepadStickXY(ControllerHandle_t id, GAMEPAD_STICK stick, float* out_x, float* out_y) {
+    SDL_Gamepad* gamepad = GamepadGetFromHandle(id);
+    if (!gamepad)
+        return;
+
+    if (stick == STICK_LEFT) {
+        *out_x = static_cast<float>(SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_LEFTX));
+        *out_y = static_cast<float>(-SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_LEFTY));
+    }
+    else if (stick == STICK_RIGHT) {
+        *out_x = static_cast<float>(SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_RIGHTX));
+        *out_y = static_cast<float>(-SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_RIGHTY));
+    }
+}
+
+void gamepad_provider::sdl::GamepadSetRumble(ControllerHandle_t id, unsigned short left, unsigned short right, unsigned int rumble_length_ms) {
+    SDL_Gamepad* gamepad = GamepadGetFromHandle(id);
+    if (!gamepad)
+        return;
+    SDL_RumbleGamepad(gamepad, left, right, rumble_length_ms);
+}
+
+void gamepad_provider::sdl::GamepadSetTriggersRumble(ControllerHandle_t id, unsigned short left, unsigned short right, unsigned int rumble_length_ms) {
+    SDL_Gamepad* gamepad = GamepadGetFromHandle(id);
+    if (!gamepad)
+        return;
+    SDL_RumbleGamepadTriggers(gamepad, left, right, rumble_length_ms);
+}
+
+ESteamInputType gamepad_provider::sdl::GamepadGetType(ControllerHandle_t id) {
+    SDL_Gamepad* gamepad = GamepadGetFromHandle(id);
+    if (!gamepad)
+        return k_ESteamInputType_Unknown;
+    switch (SDL_GetGamepadType(gamepad)) {
+    case SDL_GAMEPAD_TYPE_XBOX360:
+        return k_ESteamInputType_XBox360Controller;
+    case SDL_GAMEPAD_TYPE_XBOXONE:
+        return k_ESteamInputType_XBoxOneController;
+    case SDL_GAMEPAD_TYPE_PS3:
+        return k_ESteamInputType_PS3Controller;
+    case SDL_GAMEPAD_TYPE_PS4:
+        return k_ESteamInputType_PS4Controller;
+    case SDL_GAMEPAD_TYPE_PS5:
+        return k_ESteamInputType_PS5Controller;
+    case SDL_GAMEPAD_TYPE_NINTENDO_SWITCH_JOYCON_LEFT:
+    case SDL_GAMEPAD_TYPE_NINTENDO_SWITCH_JOYCON_RIGHT:
+        return k_ESteamInputType_SwitchJoyConSingle;
+    case SDL_GAMEPAD_TYPE_NINTENDO_SWITCH_JOYCON_PAIR:
+        return k_ESteamInputType_SwitchJoyConPair;
+    case SDL_GAMEPAD_TYPE_NINTENDO_SWITCH_PRO:
+        return k_ESteamInputType_SwitchProController;
+    case SDL_GAMEPAD_TYPE_STANDARD:
+        return k_ESteamInputType_GenericGamepad;
+    default:
+        return k_ESteamInputType_Unknown;
+    }
+}
+
+#endif

--- a/helpers/gamepad_provider/gamepad_provider.hpp
+++ b/helpers/gamepad_provider/gamepad_provider.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <map>
+#include <vector>
+
+#include <steam/steamtypes.h>
+#include <steam/isteamcontroller.h>
+
+#if !defined(CONTROLLER_SUPPORT)
+
+#define JOYSTICK_MAX 32767
+
+enum GAMEPAD_BUTTON {
+  BUTTON_DPAD_UP, /* UP on the direction pad */
+  BUTTON_DPAD_DOWN,	/**< DOWN on the direction pad */
+  BUTTON_DPAD_LEFT,	/**< LEFT on the direction pad */
+  BUTTON_DPAD_RIGHT,	/**< RIGHT on the direction pad */
+  BUTTON_START,	/**< START button */
+  BUTTON_BACK,	/**< BACK button */
+  BUTTON_LEFT_THUMB,	/**< Left analog stick button */
+  BUTTON_RIGHT_THUMB,	/**< Right analog stick button */
+  BUTTON_LEFT_SHOULDER,	/**< Left bumper button */
+  BUTTON_RIGHT_SHOULDER,	/**< Right bumper button */
+  BUTTON_A,	/**< A button */
+  BUTTON_B,	/**< B button */
+  BUTTON_X,	/**< X button */
+  BUTTON_Y,	/**< Y button */
+  BUTTON_COUNT = 16
+};
+#else
+
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_joystick.h>
+
+#define JOYSTICK_MAX SDL_JOYSTICK_AXIS_MAX
+
+enum GAMEPAD_BUTTON {
+  BUTTON_DPAD_UP = SDL_GAMEPAD_BUTTON_DPAD_UP,	/**< UP on the direction pad */
+  BUTTON_DPAD_DOWN = SDL_GAMEPAD_BUTTON_DPAD_DOWN,	/**< DOWN on the direction pad */
+  BUTTON_DPAD_LEFT = SDL_GAMEPAD_BUTTON_DPAD_LEFT,	/**< LEFT on the direction pad */
+  BUTTON_DPAD_RIGHT = SDL_GAMEPAD_BUTTON_DPAD_RIGHT,	/**< RIGHT on the direction pad */
+  BUTTON_START = SDL_GAMEPAD_BUTTON_START,	/**< START button */
+  BUTTON_BACK = SDL_GAMEPAD_BUTTON_BACK,	/**< BACK button */
+  BUTTON_LEFT_THUMB = SDL_GAMEPAD_BUTTON_LEFT_STICK,	/**< Left analog stick button */
+  BUTTON_RIGHT_THUMB = SDL_GAMEPAD_BUTTON_RIGHT_STICK,	/**< Right analog stick button */
+  BUTTON_LEFT_SHOULDER = SDL_GAMEPAD_BUTTON_LEFT_SHOULDER,	/**< Left bumper button */
+  BUTTON_RIGHT_SHOULDER = SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER,	/**< Right bumper button */
+  BUTTON_A = SDL_GAMEPAD_BUTTON_SOUTH,	/**< A button */
+  BUTTON_B = SDL_GAMEPAD_BUTTON_EAST,	/**< B button */
+  BUTTON_X = SDL_GAMEPAD_BUTTON_WEST,	/**< X button */
+  BUTTON_Y = SDL_GAMEPAD_BUTTON_NORTH,	/**< Y button */
+  BUTTON_COUNT = 16
+};
+
+#endif
+
+/**
+ * Enumeration of the possible pressure/trigger buttons.
+ */
+enum GAMEPAD_TRIGGER {
+  TRIGGER_LEFT = 0,	/**< Left trigger */
+  TRIGGER_RIGHT = 1,	/**< Right trigger */
+  TRIGGER_COUNT			/**< Number of triggers */
+};
+
+/**
+ * Enumeration of the analog sticks.
+ */
+enum GAMEPAD_STICK {
+  STICK_LEFT = 0,	/**< Left stick */
+  STICK_RIGHT = 1,	/**< Right stick */
+  STICK_COUNT		/**< Number of analog sticks */
+};
+
+namespace gamepad_provider {
+  namespace sdl
+  {
+      int DetectGamepads(std::vector<ControllerHandle_t> &handlesOut, std::vector<ControllerHandle_t>& newHandlesOut);
+      bool GamepadInit(bool combine_joycons);
+      void GamepadShutdown(void);
+      void GamepadUpdate(void);
+      bool GamepadButtonDown(ControllerHandle_t id, GAMEPAD_BUTTON button);
+      float GamepadTriggerLength(ControllerHandle_t id, GAMEPAD_TRIGGER trigger);
+      void GamepadStickXY(ControllerHandle_t id, GAMEPAD_STICK stick, float* out_x, float* out_y);
+      void GamepadStickNormXY(ControllerHandle_t id, GAMEPAD_STICK stick, float* out_x, float* out_y, int inner_deadzone, int outer_deadzone);
+      void GamepadSetRumble(ControllerHandle_t id, unsigned short left, unsigned short right, unsigned int rumble_length_ms);
+      void GamepadSetTriggersRumble(ControllerHandle_t id, unsigned short left, unsigned short right, unsigned int rumble_length_ms);
+      ESteamInputType GamepadGetType(ControllerHandle_t id);
+  }
+}

--- a/premake5-deps.lua
+++ b/premake5-deps.lua
@@ -93,6 +93,11 @@ newoption {
     trigger = "ext-ingame_overlay",
     description = "Extract ingame_overlay",
 }
+newoption {
+    category = "extract",
+    trigger = "ext-sdl3",
+    description = "Extract sdl3",
+}
 
 -- build
 newoption {
@@ -146,6 +151,11 @@ newoption {
     trigger = "build-ingame_overlay",
     description = "Build ingame_overlay",
 }
+newoption {
+    category = "build",
+    trigger = "build-sdl3",
+    description = "Build sdl3",
+}
 
 
 local function merge_list(src, dest)
@@ -185,7 +195,9 @@ else
         mycmake = mycmake .. '.exe'
     end
     if not os.isfile(mycmake) then
-        error('cmake is missing from third-party dir, you can specify custom cmake location, run the script with --help. cmake: ' .. mycmake)
+        error(
+            'cmake is missing from third-party dir, you can specify custom cmake location, run the script with --help. cmake: ' ..
+            mycmake)
     end
 end
 
@@ -226,10 +238,10 @@ local function cmake_build(dep_folder, is_32, extra_cmd_defs, c_flags_init, cxx_
     end
 
     print('\n\nbuilding dep: "' .. dep_base .. '"')
-    
+
     local build_dir = path.getabsolute(path.join(dep_base, 'build' .. arch_iden))
     local install_dir = path.join(dep_base, 'install' .. arch_iden)
-    
+
     -- clean if required
     if _OPTIONS["clean"] then
         print('cleaning dir: ' .. build_dir)
@@ -243,7 +255,8 @@ local function cmake_build(dep_folder, is_32, extra_cmd_defs, c_flags_init, cxx_
         return
     end
 
-    local cmake_common_defs_str = '-D' .. table.concat(cmake_common_defs, ' -D') .. ' -DCMAKE_INSTALL_PREFIX="' .. install_dir .. '"'
+    local cmake_common_defs_str = '-D' ..
+        table.concat(cmake_common_defs, ' -D') .. ' -DCMAKE_INSTALL_PREFIX="' .. install_dir .. '"'
     local cmd_gen = mycmake .. ' -S "' .. dep_base .. '" -B "' .. build_dir .. '" ' .. cmake_common_defs_str
 
     local all_cflags_init = {}
@@ -275,7 +288,7 @@ local function cmake_build(dep_folder, is_32, extra_cmd_defs, c_flags_init, cxx_
         error("unsupported action for cmake build: " .. _ACTION)
         return
     end
-    
+
     -- add c/cxx extra init flags
     if c_flags_init then
         if type(c_flags_init) ~= 'table' then
@@ -308,7 +321,7 @@ local function cmake_build(dep_folder, is_32, extra_cmd_defs, c_flags_init, cxx_
     -- write toolchain file
     local toolchain_file_content = ''
     if _OPTIONS["cmake-toolchain"] then
-        toolchain_file_content='include(' .. _OPTIONS["cmake-toolchain"] .. ')\n\n'
+        toolchain_file_content = 'include(' .. _OPTIONS["cmake-toolchain"] .. ')\n\n'
     end
     if #cflags_init_str > 0 then
         toolchain_file_content = toolchain_file_content .. 'set(CMAKE_C_FLAGS_INIT "' .. cflags_init_str .. '" )\n'
@@ -317,12 +330,15 @@ local function cmake_build(dep_folder, is_32, extra_cmd_defs, c_flags_init, cxx_
         toolchain_file_content = toolchain_file_content .. 'set(CMAKE_CXX_FLAGS_INIT "' .. cxxflags_init_str .. '" )\n'
     end
     if string.match(_ACTION, 'vs.+') then -- because libssq doesn't care about CMAKE_C/XX_FLAGS_INIT
-        toolchain_file_content = toolchain_file_content .. 'set(CMAKE_C_FLAGS_RELEASE  "${CMAKE_C_FLAGS_RELEASE} /MT /D_MT" ) \n'
-        toolchain_file_content = toolchain_file_content .. 'set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT /D_MT" ) \n'
+        toolchain_file_content = toolchain_file_content ..
+            'set(CMAKE_C_FLAGS_RELEASE  "${CMAKE_C_FLAGS_RELEASE} /MT /D_MT" ) \n'
+        toolchain_file_content = toolchain_file_content ..
+            'set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT /D_MT" ) \n'
     end
-    
+
     if #toolchain_file_content > 0 then
-        local toolchain_file = path.join(dep_base, 'toolchain_' .. tostring(is_32) .. '_' .. _ACTION .. '_' .. os_iden .. '.precmt')
+        local toolchain_file = path.join(dep_base,
+            'toolchain_' .. tostring(is_32) .. '_' .. _ACTION .. '_' .. os_iden .. '.precmt')
         if not io.writefile(toolchain_file, toolchain_file_content) then
             error("failed to write cmake toolchain")
             return
@@ -365,7 +381,8 @@ local function cmake_build(dep_folder, is_32, extra_cmd_defs, c_flags_init, cxx_
     if _OPTIONS['j'] then
         parallel_str = parallel_str .. ' ' .. _OPTIONS['j']
     end
-    local ok = os.execute(mycmake .. ' --build "' .. build_dir .. '" --config Release' .. parallel_str .. verbose_build_str)
+    local ok = os.execute(mycmake ..
+        ' --build "' .. build_dir .. '" --config Release' .. parallel_str .. verbose_build_str)
     if not ok then
         error("failed to build")
         return
@@ -377,7 +394,7 @@ local function cmake_build(dep_folder, is_32, extra_cmd_defs, c_flags_init, cxx_
         return
     end
 
-    local cmd_install = mycmake.. ' --install "' .. build_dir .. '" --prefix "' .. install_dir .. '"'
+    local cmd_install = mycmake .. ' --install "' .. build_dir .. '" --prefix "' .. install_dir .. '"'
     print(cmd_install)
     local ok = os.execute(cmd_install)
     if not ok then
@@ -427,6 +444,9 @@ end
 if _OPTIONS["ext-ingame_overlay"] or _OPTIONS["all-ext"] then
     table.insert(deps_to_extract, { 'ingame_overlay/ingame_overlay.tar.gz', 'ingame_overlay' })
 end
+if _OPTIONS["ext-sdl3"] or _OPTIONS["all-ext"] then
+    table.insert(deps_to_extract, { 'sdl3/sdl3.tar.gz', 'sdl3' })
+end
 
 -- start extraction
 for _, dep in pairs(deps_to_extract) do
@@ -460,7 +480,9 @@ for _, dep in pairs(deps_to_extract) do
     local ext = string.lower(string.sub(archive_file, -7)) -- ".tar.gz"
     local ok_cmd = false
     if ext == ".tar.gz" then
-        ok_cmd = os.execute(extractor .. ' -bso0 -bse2 x "' .. archive_file .. '" -so | "' .. extractor .. '" -bso0 -bse2 x -si -ttar -y -aoa -o"' .. deps_dir .. '"')
+        ok_cmd = os.execute(extractor ..
+            ' -bso0 -bse2 x "' ..
+            archive_file .. '" -so | "' .. extractor .. '" -bso0 -bse2 x -si -ttar -y -aoa -o"' .. deps_dir .. '"')
     else
         ok_cmd = os.execute(extractor .. ' -bso0 -bse2 x "' .. archive_file .. '" -y -aoa -o"' .. out_folder .. '"')
     end
@@ -479,7 +501,6 @@ for _, dep in pairs(deps_to_extract) do
     --     end
     --     os.rmdir(inner_folder)
     -- end
-
 end
 
 
@@ -509,7 +530,7 @@ end
 --     if(ZLIB_FOUND)
 --       set(HAVE_LIBZ ON)
 --       set(USE_ZLIB ON)
---     
+--
 --       # Depend on ZLIB via imported targets if supported by the running
 --       # version of CMake.  This allows our dependents to get our dependencies
 --       # transitively.
@@ -622,7 +643,7 @@ if _OPTIONS["build-curl"] or _OPTIONS["all-build"] then
 
         "CURL_USE_OPENSSL=OFF",
         "CURL_ZLIB=ON",
-        
+
         "CURL_USE_MBEDTLS=ON",
         -- "CURL_USE_SCHANNEL=ON",
         "CURL_CA_FALLBACK=ON",
@@ -735,5 +756,17 @@ if _OPTIONS["build-ingame_overlay"] or _OPTIONS["all-build"] then
             'MINIDETOUR_DYNAMIC_RUNTIME=OFF',
         })
         cmake_build('ingame_overlay', false, ingame_overlay_common_defs, nil, ingame_overlay_fixes)
+    end
+end
+
+if _OPTIONS["build-sdl3"] or _OPTIONS["all-build"] then
+    local sdl3_common_defs = {
+    }
+
+    if _OPTIONS["32-build"] then
+        cmake_build('sdl3', true, sdl3_common_defs)
+    end
+    if _OPTIONS["64-build"] then
+        cmake_build('sdl3', false, sdl3_common_defs)
     end
 end

--- a/premake5.lua
+++ b/premake5.lua
@@ -10,8 +10,8 @@ premake.override(premake.tools.gcc, "getlinks", function(originalFn, cfg, system
     -- https://github.com/premake/premake-core/blob/d842e671c7bc7e09f2eeaafd199fd01e48b87ee7/src/tools/gcc.lua#L568C15-L568C22
 
     local result = originalFn(cfg, systemonly, nogroups)
-    local whole_syslibs = {"-Wl,--whole-archive"}
-    local static_whole_syslibs = {"-Wl,--whole-archive -Wl,-Bstatic"}
+    local whole_syslibs = { "-Wl,--whole-archive" }
+    local static_whole_syslibs = { "-Wl,--whole-archive -Wl,-Bstatic" }
 
     local endswith = function(s, ptrn)
         return ptrn == string.sub(s, -string.len(ptrn))
@@ -157,25 +157,23 @@ newoption {
 
 -- windows options
 if os.target() == 'windows' then
+    newoption {
+        category = "build",
+        trigger = "dosstub",
+        description = "Change the DOS stub of the Windows builds",
+    }
 
-newoption {
-    category = "build",
-    trigger = "dosstub",
-    description = "Change the DOS stub of the Windows builds",
-}
+    newoption {
+        category = "build",
+        trigger = "winsign",
+        description = "Sign Windows builds with a fake certificate",
+    }
 
-newoption {
-    category = "build",
-    trigger = "winsign",
-    description = "Sign Windows builds with a fake certificate",
-}
-
-newoption {
-    category = "build",
-    trigger = "winrsrc",
-    description = "Add resources to Windows builds",
-}
-
+    newoption {
+        category = "build",
+        trigger = "winrsrc",
+        description = "Add resources to Windows builds",
+    }
 end
 -- End windows options
 
@@ -205,6 +203,7 @@ local x32_deps_include = {
     path.join(deps_dir, "protobuf/install32/include"),
     path.join(deps_dir, "zlib/install32/include"),
     path.join(deps_dir, "mbedtls/install32/include"),
+    path.join(deps_dir, "sdl3/install32/include"),
 }
 
 local x32_deps_overlay_include = {
@@ -219,6 +218,7 @@ local x64_deps_include = {
     path.join(deps_dir, "protobuf/install64/include"),
     path.join(deps_dir, "zlib/install64/include"),
     path.join(deps_dir, "mbedtls/install64/include"),
+    path.join(deps_dir, "sdl3/install64/include"),
 }
 
 local x64_deps_overlay_include = {
@@ -243,6 +243,8 @@ local common_files = {
     "helpers/common_helpers.cpp", "helpers/common_helpers/**",
     -- helpers/dbg_log
     "helpers/dbg_log.cpp", "helpers/dbg_log/**",
+    -- helpers/gamepad_provider
+    "helpers/gamepad_provider.cpp", "helpers/gamepad_provider/**",
 }
 
 local overlay_files = {
@@ -273,119 +275,133 @@ if os.target() == 'windows' then
 end
 
 local deps_link = {
-    "ssq"                .. static_postfix,
-    zlib_archive_name    .. static_postfix,
+    "ssq" .. static_postfix,
+    zlib_archive_name .. static_postfix,
     lib_prefix .. "curl" .. static_postfix,
-    "mbedcrypto"         .. static_postfix,
-    "mbedtls"            .. static_postfix,
-    "mbedx509"           .. static_postfix,
+    "mbedcrypto" .. static_postfix,
+    "mbedtls" .. static_postfix,
+    "mbedx509" .. static_postfix,
+    "SDL3-static" .. static_postfix,
 }
 -- add protobuf libs
 table_append(deps_link, {
-    lib_prefix .. "protobuf-lite"                 .. static_postfix,
-    "absl_bad_any_cast_impl"                      .. static_postfix,
-    "absl_bad_optional_access"                    .. static_postfix,
-    "absl_bad_variant_access"                     .. static_postfix,
-    "absl_base"                                   .. static_postfix,
-    "absl_city"                                   .. static_postfix,
-    "absl_civil_time"                             .. static_postfix,
-    "absl_cord"                                   .. static_postfix,
-    "absl_cordz_functions"                        .. static_postfix,
-    "absl_cordz_handle"                           .. static_postfix,
-    "absl_cordz_info"                             .. static_postfix,
-    "absl_cordz_sample_token"                     .. static_postfix,
-    "absl_cord_internal"                          .. static_postfix,
-    "absl_crc32c"                                 .. static_postfix,
-    "absl_crc_cord_state"                         .. static_postfix,
-    "absl_crc_cpu_detect"                         .. static_postfix,
-    "absl_crc_internal"                           .. static_postfix,
-    "absl_debugging_internal"                     .. static_postfix,
-    "absl_demangle_internal"                      .. static_postfix,
-    "absl_die_if_null"                            .. static_postfix,
-    "absl_examine_stack"                          .. static_postfix,
-    "absl_exponential_biased"                     .. static_postfix,
-    "absl_failure_signal_handler"                 .. static_postfix,
-    "absl_flags_commandlineflag"                  .. static_postfix,
-    "absl_flags_commandlineflag_internal"         .. static_postfix,
-    "absl_flags_config"                           .. static_postfix,
-    "absl_flags_internal"                         .. static_postfix,
-    "absl_flags_marshalling"                      .. static_postfix,
-    "absl_flags_parse"                            .. static_postfix,
-    "absl_flags_private_handle_accessor"          .. static_postfix,
-    "absl_flags_program_name"                     .. static_postfix,
-    "absl_flags_reflection"                       .. static_postfix,
-    "absl_flags_usage"                            .. static_postfix,
-    "absl_flags_usage_internal"                   .. static_postfix,
-    "absl_graphcycles_internal"                   .. static_postfix,
-    "absl_hash"                                   .. static_postfix,
-    "absl_hashtablez_sampler"                     .. static_postfix,
-    "absl_int128"                                 .. static_postfix,
-    "absl_kernel_timeout_internal"                .. static_postfix,
-    "absl_leak_check"                             .. static_postfix,
-    "absl_log_entry"                              .. static_postfix,
-    "absl_log_flags"                              .. static_postfix,
-    "absl_log_globals"                            .. static_postfix,
-    "absl_log_initialize"                         .. static_postfix,
-    "absl_log_internal_check_op"                  .. static_postfix,
-    "absl_log_internal_conditions"                .. static_postfix,
-    "absl_log_internal_fnmatch"                   .. static_postfix,
-    "absl_log_internal_format"                    .. static_postfix,
-    "absl_log_internal_globals"                   .. static_postfix,
-    "absl_log_internal_log_sink_set"              .. static_postfix,
-    "absl_log_internal_message"                   .. static_postfix,
-    "absl_log_internal_nullguard"                 .. static_postfix,
-    "absl_log_internal_proto"                     .. static_postfix,
-    "absl_log_severity"                           .. static_postfix,
-    "absl_log_sink"                               .. static_postfix,
-    "absl_low_level_hash"                         .. static_postfix,
-    "absl_malloc_internal"                        .. static_postfix,
-    "absl_periodic_sampler"                       .. static_postfix,
-    "absl_random_distributions"                   .. static_postfix,
+    lib_prefix .. "protobuf-lite" .. static_postfix,
+    "absl_bad_any_cast_impl" .. static_postfix,
+    "absl_bad_optional_access" .. static_postfix,
+    "absl_bad_variant_access" .. static_postfix,
+    "absl_base" .. static_postfix,
+    "absl_city" .. static_postfix,
+    "absl_civil_time" .. static_postfix,
+    "absl_cord" .. static_postfix,
+    "absl_cordz_functions" .. static_postfix,
+    "absl_cordz_handle" .. static_postfix,
+    "absl_cordz_info" .. static_postfix,
+    "absl_cordz_sample_token" .. static_postfix,
+    "absl_cord_internal" .. static_postfix,
+    "absl_crc32c" .. static_postfix,
+    "absl_crc_cord_state" .. static_postfix,
+    "absl_crc_cpu_detect" .. static_postfix,
+    "absl_crc_internal" .. static_postfix,
+    "absl_debugging_internal" .. static_postfix,
+    "absl_demangle_internal" .. static_postfix,
+    "absl_die_if_null" .. static_postfix,
+    "absl_examine_stack" .. static_postfix,
+    "absl_exponential_biased" .. static_postfix,
+    "absl_failure_signal_handler" .. static_postfix,
+    "absl_flags_commandlineflag" .. static_postfix,
+    "absl_flags_commandlineflag_internal" .. static_postfix,
+    "absl_flags_config" .. static_postfix,
+    "absl_flags_internal" .. static_postfix,
+    "absl_flags_marshalling" .. static_postfix,
+    "absl_flags_parse" .. static_postfix,
+    "absl_flags_private_handle_accessor" .. static_postfix,
+    "absl_flags_program_name" .. static_postfix,
+    "absl_flags_reflection" .. static_postfix,
+    "absl_flags_usage" .. static_postfix,
+    "absl_flags_usage_internal" .. static_postfix,
+    "absl_graphcycles_internal" .. static_postfix,
+    "absl_hash" .. static_postfix,
+    "absl_hashtablez_sampler" .. static_postfix,
+    "absl_int128" .. static_postfix,
+    "absl_kernel_timeout_internal" .. static_postfix,
+    "absl_leak_check" .. static_postfix,
+    "absl_log_entry" .. static_postfix,
+    "absl_log_flags" .. static_postfix,
+    "absl_log_globals" .. static_postfix,
+    "absl_log_initialize" .. static_postfix,
+    "absl_log_internal_check_op" .. static_postfix,
+    "absl_log_internal_conditions" .. static_postfix,
+    "absl_log_internal_fnmatch" .. static_postfix,
+    "absl_log_internal_format" .. static_postfix,
+    "absl_log_internal_globals" .. static_postfix,
+    "absl_log_internal_log_sink_set" .. static_postfix,
+    "absl_log_internal_message" .. static_postfix,
+    "absl_log_internal_nullguard" .. static_postfix,
+    "absl_log_internal_proto" .. static_postfix,
+    "absl_log_severity" .. static_postfix,
+    "absl_log_sink" .. static_postfix,
+    "absl_low_level_hash" .. static_postfix,
+    "absl_malloc_internal" .. static_postfix,
+    "absl_periodic_sampler" .. static_postfix,
+    "absl_random_distributions" .. static_postfix,
     "absl_random_internal_distribution_test_util" .. static_postfix,
-    "absl_random_internal_platform"               .. static_postfix,
-    "absl_random_internal_pool_urbg"              .. static_postfix,
-    "absl_random_internal_randen"                 .. static_postfix,
-    "absl_random_internal_randen_hwaes"           .. static_postfix,
-    "absl_random_internal_randen_hwaes_impl"      .. static_postfix,
-    "absl_random_internal_randen_slow"            .. static_postfix,
-    "absl_random_internal_seed_material"          .. static_postfix,
-    "absl_random_seed_gen_exception"              .. static_postfix,
-    "absl_random_seed_sequences"                  .. static_postfix,
-    "absl_raw_hash_set"                           .. static_postfix,
-    "absl_raw_logging_internal"                   .. static_postfix,
-    "absl_scoped_set_env"                         .. static_postfix,
-    "absl_spinlock_wait"                          .. static_postfix,
-    "absl_stacktrace"                             .. static_postfix,
-    "absl_status"                                 .. static_postfix,
-    "absl_statusor"                               .. static_postfix,
-    "absl_strerror"                               .. static_postfix,
-    "absl_strings"                                .. static_postfix,
-    "absl_strings_internal"                       .. static_postfix,
-    "absl_string_view"                            .. static_postfix,
-    "absl_str_format_internal"                    .. static_postfix,
-    "absl_symbolize"                              .. static_postfix,
-    "absl_synchronization"                        .. static_postfix,
-    "absl_throw_delegate"                         .. static_postfix,
-    "absl_time"                                   .. static_postfix,
-    "absl_time_zone"                              .. static_postfix,
-    "absl_vlog_config_internal"                   .. static_postfix,
-    "utf8_range"                                  .. static_postfix,
-    "utf8_validity"                               .. static_postfix,
+    "absl_random_internal_platform" .. static_postfix,
+    "absl_random_internal_pool_urbg" .. static_postfix,
+    "absl_random_internal_randen" .. static_postfix,
+    "absl_random_internal_randen_hwaes" .. static_postfix,
+    "absl_random_internal_randen_hwaes_impl" .. static_postfix,
+    "absl_random_internal_randen_slow" .. static_postfix,
+    "absl_random_internal_seed_material" .. static_postfix,
+    "absl_random_seed_gen_exception" .. static_postfix,
+    "absl_random_seed_sequences" .. static_postfix,
+    "absl_raw_hash_set" .. static_postfix,
+    "absl_raw_logging_internal" .. static_postfix,
+    "absl_scoped_set_env" .. static_postfix,
+    "absl_spinlock_wait" .. static_postfix,
+    "absl_stacktrace" .. static_postfix,
+    "absl_status" .. static_postfix,
+    "absl_statusor" .. static_postfix,
+    "absl_strerror" .. static_postfix,
+    "absl_strings" .. static_postfix,
+    "absl_strings_internal" .. static_postfix,
+    "absl_string_view" .. static_postfix,
+    "absl_str_format_internal" .. static_postfix,
+    "absl_symbolize" .. static_postfix,
+    "absl_synchronization" .. static_postfix,
+    "absl_throw_delegate" .. static_postfix,
+    "absl_time" .. static_postfix,
+    "absl_time_zone" .. static_postfix,
+    "absl_vlog_config_internal" .. static_postfix,
+    "utf8_range" .. static_postfix,
+    "utf8_validity" .. static_postfix,
 })
 
 local common_link_win = {
     -- os specific
-    "Ws2_32"   .. static_postfix,
+    "Ws2_32" .. static_postfix,
     "Iphlpapi" .. static_postfix,
-    "Wldap32"  .. static_postfix,
-    "Winmm"    .. static_postfix,
-    "Bcrypt"   .. static_postfix,
-    "Dbghelp"  .. static_postfix,
+    "Wldap32" .. static_postfix,
+    "Winmm" .. static_postfix,
+    "Bcrypt" .. static_postfix,
+    "Dbghelp" .. static_postfix,
     -- gamepad
-    "Xinput"   .. static_postfix,
+    "Xinput" .. static_postfix,
+    -- sdl3
+    "imagehlp" .. static_postfix,
+    "kernel32" .. static_postfix,
+    "user32" .. static_postfix,
+    "gdi32" .. static_postfix,
+    "imm32" .. static_postfix,
+    "ole32" .. static_postfix,
+    "oleaut32" .. static_postfix,
+    "shell32" .. static_postfix,
+    "version" .. static_postfix,
+    "uuid" .. static_postfix,
+    "advapi32" .. static_postfix,
+    "setupapi" .. static_postfix,
     -- imgui / overlay
-    "Gdi32"    .. static_postfix,
-    "Dwmapi"   .. static_postfix,
+    "Gdi32" .. static_postfix,
+    "Dwmapi" .. static_postfix,
 }
 -- add deps to win
 table_append(common_link_win, deps_link)
@@ -400,7 +416,7 @@ table_append(common_link_linux, deps_link)
 -- overlay libs
 local overlay_link = {
     "ingame_overlay",
-    "system", -- ingame_overlay dependency
+    "system",      -- ingame_overlay dependency
     "mini_detour", -- ingame_overlay dependency
 }
 -- we add them later when needed
@@ -423,6 +439,7 @@ local x32_deps_libdir = {
     path.join(deps_dir, "protobuf/install32/lib"),
     path.join(deps_dir, "zlib/install32/lib"),
     path.join(deps_dir, "mbedtls/install32/lib"),
+    path.join(deps_dir, "sdl3/install32/lib"),
 }
 
 local x32_deps_overlay_libdir = {
@@ -438,6 +455,7 @@ local x64_deps_libdir = {
     path.join(deps_dir, "zlib/install64/lib"),
     path.join(deps_dir, "mbedtls/install64/lib"),
     path.join(deps_dir, "ingame_overlay/install64/lib"),
+    path.join(deps_dir, "sdl3/install64/lib"),
 }
 
 local x64_deps_overlay_libdir = {
@@ -481,23 +499,23 @@ platforms { "x64", "x32", }
 language "C++"
 cppdialect "C++17"
 cdialect "C17"
-filter { "system:not windows", "action:gmake*" , }
-    cdialect("gnu17") -- gamepad.c relies on some linux-specific functions like strdup() and MAX_PATH
-filter {} -- reset the filter and remove all active keywords
+filter { "system:not windows", "action:gmake*", }
+cdialect("gnu17")            -- gamepad.c relies on some linux-specific functions like strdup() and MAX_PATH
+filter {}                    -- reset the filter and remove all active keywords
 characterset "Unicode"
-staticruntime "on" -- /MT or /MTd
-runtime "Release" -- ensure we never link with /MTd, otherwise deps linking will fail
+staticruntime "on"           -- /MT or /MTd
+runtime "Release"            -- ensure we never link with /MTd, otherwise deps linking will fail
 flags {
-    "NoPCH", -- no precompiled header on Windows
+    "NoPCH",                 -- no precompiled header on Windows
     "MultiProcessorCompile", -- /MP "Enable Visual Studio to use multiple compiler processes when building"
     "RelativeLinks",
 }
-targetprefix "" -- prevent adding the prefix libxxx on linux
-visibility "Hidden" -- hide all symbols by default on GCC (unless they are marked visible)
-linkgroups "On" -- turn off the awful order dependent linking on gcc/clang, causes the linker to go back and forth to find missing symbols
+targetprefix ""        -- prevent adding the prefix libxxx on linux
+visibility "Hidden"    -- hide all symbols by default on GCC (unless they are marked visible)
+linkgroups "On"        -- turn off the awful order dependent linking on gcc/clang, causes the linker to go back and forth to find missing symbols
 exceptionhandling "On" -- "Enable exception handling. ... although it does not affect execution."
-stringpooling "On" -- cache similar strings
-vpaths { -- just for visual niceness, see: https://premake.github.io/docs/vpaths/
+stringpooling "On"     -- cache similar strings
+vpaths {               -- just for visual niceness, see: https://premake.github.io/docs/vpaths/
     ["headers/*"] = {
         "**.h", "**.hxx", "**.hpp",
     },
@@ -523,9 +541,9 @@ vpaths { -- just for visual niceness, see: https://premake.github.io/docs/vpaths
 -- arch
 ---------
 filter { "platforms:x32", }
-    architecture "x86" 
+architecture "x86"
 filter { "platforms:x64", }
-    architecture "x86_64"
+architecture "x86_64"
 
 
 -- debug/optimization flags
@@ -533,40 +551,40 @@ filter { "platforms:x64", }
 filter {} -- reset the filter and remove all active keywords
 intrinsics "On"
 filter { "configurations:*debug", }
-    symbols "On"
-    optimize "Off"
+symbols "On"
+optimize "Off"
 filter { "configurations:*release", }
-    symbols "Off"
-    optimize "On"
+symbols "Off"
+optimize "On"
 
 
 --- common compiler/linker options
 ---------
 -- Visual Studio common compiler/linker options
 filter { "action:vs*", }
-    buildoptions  {
-        "/permissive-", "/DYNAMICBASE", "/bigobj",
-        "/utf-8", "/Zc:char8_t-", "/EHsc", "/GL-"
-    }
-    linkoptions  {
-        -- source of emittoolversioninfo: https://developercommunity.visualstudio.com/t/add-linker-option-to-strip-rich-stamp-from-exe-hea/740443
-        "/NOLOGO", "/emittoolversioninfo:no"
-    }
+buildoptions {
+    "/permissive-", "/DYNAMICBASE", "/bigobj",
+    "/utf-8", "/Zc:char8_t-", "/EHsc", "/GL-"
+}
+linkoptions {
+    -- source of emittoolversioninfo: https://developercommunity.visualstudio.com/t/add-linker-option-to-strip-rich-stamp-from-exe-hea/740443
+    "/NOLOGO", "/emittoolversioninfo:no"
+}
 -- GNU make common compiler/linker options
 filter { "action:gmake*", }
-    buildoptions  {
-        -- https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html
-        "-fno-jump-tables" , "-Wno-switch",
-    }
-    linkoptions {
-        "-Wl,--exclude-libs,ALL",
-    }
+buildoptions {
+    -- https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html
+    "-fno-jump-tables", "-Wno-switch",
+}
+linkoptions {
+    "-Wl,--exclude-libs,ALL",
+}
 -- this is made separate because GCC complains but not CLANG
-filter { "action:gmake*" , "files:*.cpp or *.cxx or *.cc or *.hpp or *.hxx", }
-    buildoptions  {
-        "-fno-char8_t", -- GCC gives a warning when a .c file is compiled with this
-    }
-filter {} -- reset the filter and remove all active keywords
+filter { "action:gmake*", "files:*.cpp or *.cxx or *.cc or *.hpp or *.hxx", }
+buildoptions {
+    "-fno-char8_t", -- GCC gives a warning when a .c file is compiled with this
+}
+filter {}           -- reset the filter and remove all active keywords
 
 
 -- defines
@@ -577,79 +595,79 @@ defines { -- added to all filters, later defines will be appended
 }
 -- release mode defines
 filter { "configurations:*release" }
-    defines {
-        "NDEBUG", "EMU_RELEASE_BUILD"
-    }
+defines {
+    "NDEBUG", "EMU_RELEASE_BUILD"
+}
 -- debug mode defines
 filter { "configurations:*debug" }
-    defines {
-        "DEBUG",
-    }
+defines {
+    "DEBUG",
+}
 -- Windows defines
 filter { "system:windows", }
-    defines {
-        "_CRT_SECURE_NO_WARNINGS",
-    }
+defines {
+    "_CRT_SECURE_NO_WARNINGS",
+}
 -- Linux defines
 filter { "system:not windows" }
-    defines {
-        "GNUC",
-    }
+defines {
+    "GNUC",
+}
 
 
 -- MinGw on Windows
 -- common compiler/linker options: source: https://gcc.gnu.org/onlinedocs/gcc/Cygwin-and-MinGW-Options.html
 ---------
 filter { "system:windows", "action:gmake*", }
-    -- MinGw on Windows common defines
-    -- MinGw on Windows doesn't have a definition for '_S_IFDIR' which is microsoft specific: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/stat-functions
-    -- this is used in 'base.cpp' -> if ( buffer.st_mode & _S_IFDIR)
-    -- instead microsoft has an alternative but only enabled when _CRT_DECLARE_NONSTDC_NAMES is defined
-    -- https://learn.microsoft.com/en-us/cpp/c-runtime-library/compatibility
-    defines {
-        -- '_CRT_NONSTDC_NO_WARNINGS',
-        '_CRT_DECLARE_NONSTDC_NAMES',
-    }
-    linkoptions {
-        -- I don't know why but if libgcc/libstdc++ as well as pthreads are not statically linked
-        -- none of the output binary .dlls will reach their DllMain() in x64dbg
-        -- even when they're force-loaded in any process they immediately unload
-        -- '-static-libgcc' ,'-static-libstdc++',
-        '-static',
-    }
+-- MinGw on Windows common defines
+-- MinGw on Windows doesn't have a definition for '_S_IFDIR' which is microsoft specific: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/stat-functions
+-- this is used in 'base.cpp' -> if ( buffer.st_mode & _S_IFDIR)
+-- instead microsoft has an alternative but only enabled when _CRT_DECLARE_NONSTDC_NAMES is defined
+-- https://learn.microsoft.com/en-us/cpp/c-runtime-library/compatibility
+defines {
+    -- '_CRT_NONSTDC_NO_WARNINGS',
+    '_CRT_DECLARE_NONSTDC_NAMES',
+}
+linkoptions {
+    -- I don't know why but if libgcc/libstdc++ as well as pthreads are not statically linked
+    -- none of the output binary .dlls will reach their DllMain() in x64dbg
+    -- even when they're force-loaded in any process they immediately unload
+    -- '-static-libgcc' ,'-static-libstdc++',
+    '-static',
+}
 -- MinGw on Windows cannot compile 'creatwth.cpp' from Detours lib (error: 'DWordMult' was not declared in this scope)
 -- because intsafe.h isn't included by default
 filter { "system:windows", "action:gmake*", "files:**/detours/creatwth.cpp" }
-    buildoptions  {
-        "-include intsafe.h",
-    }
+buildoptions {
+    "-include intsafe.h",
+}
 
 
 -- add extra files for clearance
 filter {} -- reset the filter and remove all active keywords
 -- post build docs
 filter { 'options:incexamples', }
-    files {
-        'post_build/**',
-    }
+files {
+    'post_build/**',
+}
 filter { 'options:incexamples', 'system:not windows', }
-    removefiles {
-        'post_build/win/**'
-    }
+removefiles {
+    'post_build/win/**'
+}
 
 -- deps
 filter { 'options:incdeps', "platforms:x32", }
-    files {
-        table_postfix_items(x32_deps_include, '/**.h'),
-        table_postfix_items(x32_deps_include, '/**.hxx'),
-        table_postfix_items(x32_deps_include, '/**.hpp'),
-    }
+files {
+    table_postfix_items(x32_deps_include, '/**.h'),
+    table_postfix_items(x32_deps_include, '/**.hxx'),
+    table_postfix_items(x32_deps_include, '/**.hpp'),
+}
 filter { 'options:incdeps', "platforms:x64", }
-    files {
-        table_postfix_items(x64_deps_include, '/**.h'),
-        table_postfix_items(x64_deps_include, '/**.hxx'),
-        table_postfix_items(x64_deps_include, '/**.hpp'),
-    }
+files {
+    table_postfix_items(x64_deps_include, '/**.h'),
+    table_postfix_items(x64_deps_include, '/**.hxx'),
+    table_postfix_items(x64_deps_include, '/**.hpp'),
+}
 filter {} -- reset the filter and remove all active keywords
 
 
@@ -664,7 +682,7 @@ includedirs {
 
 -- disable warnings for external libraries/deps
 filter { 'files:proto_gen/** or libs/** or build/deps/**' }
-    warnings 'Off'
+warnings 'Off'
 filter {} -- reset the filter and remove all active keywords
 
 
@@ -672,501 +690,502 @@ filter {} -- reset the filter and remove all active keywords
 -- post build change DOS stub + sign
 ---------
 if os.target() == "windows" then
-
--- token expansion like '%{cfg.platform}' happens later during project build
-local dos_stub_exe = path.translate(path.getabsolute('resources/win/file_dos_stub/file_dos_stub_%{cfg.platform}.exe', _MAIN_SCRIPT_DIR), '\\')
-local signer_tool = path.translate(path.getabsolute('third-party/build/win/cert/sign_helper.bat', _MAIN_SCRIPT_DIR), '\\')
--- change dos stub
-filter { "system:windows", "options:dosstub", }
+    -- token expansion like '%{cfg.platform}' happens later during project build
+    local dos_stub_exe = path.translate(
+        path.getabsolute('resources/win/file_dos_stub/file_dos_stub_%{cfg.platform}.exe', _MAIN_SCRIPT_DIR), '\\')
+    local signer_tool = path.translate(path.getabsolute('third-party/build/win/cert/sign_helper.bat', _MAIN_SCRIPT_DIR),
+        '\\')
+    -- change dos stub
+    filter { "system:windows", "options:dosstub", }
     postbuildcommands {
         '"' .. dos_stub_exe .. '" %[%{!cfg.buildtarget.abspath}]',
     }
--- sign
-filter { "system:windows", "options:winsign", }
+    -- sign
+    filter { "system:windows", "options:winsign", }
     postbuildcommands {
         '"' .. signer_tool .. '" %[%{!cfg.buildtarget.abspath}]',
     }
-filter {} -- reset the filter and remove all active keywords
+    filter {} -- reset the filter and remove all active keywords
 end
 
 
 
 workspace "gbe"
-    location("build/project/%{_ACTION}/" .. os_iden)
+location("build/project/%{_ACTION}/" .. os_iden)
 
 
 -- Project api_regular
 ---------
 project "api_regular"
-    kind "SharedLib"
-    location "%{wks.location}/%{prj.name}"
-    targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/regular/%{cfg.platform}")
+kind "SharedLib"
+location "%{wks.location}/%{prj.name}"
+targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/regular/%{cfg.platform}")
 
 
-    -- name
-    ---------
-    filter { "system:windows", "platforms:x32", }
-        targetname "steam_api"
-    filter { "system:windows", "platforms:x64", }
-        targetname "steam_api64"
-    filter { "system:not windows", }
-        targetname "libsteam_api"
+-- name
+---------
+filter { "system:windows", "platforms:x32", }
+targetname "steam_api"
+filter { "system:windows", "platforms:x64", }
+targetname "steam_api64"
+filter { "system:not windows", }
+targetname "libsteam_api"
 
 
-    -- x32 include dir
-    filter { "platforms:x32", }
-        includedirs {
-            x32_deps_include,
-        }
+-- x32 include dir
+filter { "platforms:x32", }
+includedirs {
+    x32_deps_include,
+}
 
-    -- x64 include dir
-    filter { "platforms:x64", }
-        includedirs {
-            x64_deps_include,
-        }
-
-
-    -- common source & header files
-    ---------
-    filter {} -- reset the filter and remove all active keywords
-    files { -- added to all filters, later defines will be appended
-        common_files,
-    }
-    removefiles {
-        detours_files,
-    }
-    -- Windows common source files
-    filter { "system:windows", }
-        removefiles {
-            "dll/wrap.cpp"
-        }
-    -- Windows x32 common source files
-    filter { "system:windows", "platforms:x32", "options:winrsrc", }
-        files {
-            "resources/win/api/32/resources.rc"
-        }
-    -- Windows x64 common source files
-    filter { "system:windows", "platforms:x64", "options:winrsrc", }
-        files {
-            "resources/win/api/64/resources.rc"
-        }
+-- x64 include dir
+filter { "platforms:x64", }
+includedirs {
+    x64_deps_include,
+}
 
 
-    -- libs to link
-    ---------
-    -- Windows libs to link
-    filter { "system:windows", }
-        links {
-            common_link_win,
-        }
+-- common source & header files
+---------
+filter {} -- reset the filter and remove all active keywords
+files {   -- added to all filters, later defines will be appended
+    common_files,
+}
+removefiles {
+    detours_files,
+}
+-- Windows common source files
+filter { "system:windows", }
+removefiles {
+    "dll/wrap.cpp"
+}
+-- Windows x32 common source files
+filter { "system:windows", "platforms:x32", "options:winrsrc", }
+files {
+    "resources/win/api/32/resources.rc"
+}
+-- Windows x64 common source files
+filter { "system:windows", "platforms:x64", "options:winrsrc", }
+files {
+    "resources/win/api/64/resources.rc"
+}
 
-    -- Linux libs to link
-    filter { "system:not windows", }
-        links {
-            common_link_linux,
-        }
+
+-- libs to link
+---------
+-- Windows libs to link
+filter { "system:windows", }
+links {
+    common_link_win,
+}
+
+-- Linux libs to link
+filter { "system:not windows", }
+links {
+    common_link_linux,
+}
 
 
-    -- libs search dir
-    ---------
-    -- x32 libs search dir
-    filter { "platforms:x32", }
-        libdirs {
-            x32_deps_libdir,
-        }
-    -- x64 libs search dir
-    filter { "platforms:x64", }
-        libdirs {
-            x64_deps_libdir,
-        }
+-- libs search dir
+---------
+-- x32 libs search dir
+filter { "platforms:x32", }
+libdirs {
+    x32_deps_libdir,
+}
+-- x64 libs search dir
+filter { "platforms:x64", }
+libdirs {
+    x64_deps_libdir,
+}
 -- End api_regular
 
 
 -- Project api_experimental
 ---------
 project "api_experimental"
-    kind "SharedLib"
-    location "%{wks.location}/%{prj.name}"
-    targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/experimental/%{cfg.platform}")
+kind "SharedLib"
+location "%{wks.location}/%{prj.name}"
+targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/experimental/%{cfg.platform}")
 
 
-    -- name
-    ---------
-    filter { "system:windows", "platforms:x32", }
-        targetname "steam_api"
-    filter { "system:windows", "platforms:x64", }
-        targetname "steam_api64"
-    filter { "system:not windows", }
-        targetname "libsteam_api"
+-- name
+---------
+filter { "system:windows", "platforms:x32", }
+targetname "steam_api"
+filter { "system:windows", "platforms:x64", }
+targetname "steam_api64"
+filter { "system:not windows", }
+targetname "libsteam_api"
 
 
-    -- defines
-    ---------
-    filter {} -- reset the filter and remove all active keywords
-    defines { -- added to all filters, later defines will be appended
-        "EMU_OVERLAY", "ImTextureID=ImU64",
-    }
-    -- Windows defines
-    filter { "system:windows" }
-        defines {
-            "EMU_EXPERIMENTAL_BUILD",
-        }
+-- defines
+---------
+filter {} -- reset the filter and remove all active keywords
+defines { -- added to all filters, later defines will be appended
+    "EMU_OVERLAY", "ImTextureID=ImU64",
+}
+-- Windows defines
+filter { "system:windows" }
+defines {
+    "EMU_EXPERIMENTAL_BUILD",
+}
 
 
-    -- include dir
-    ---------
-    -- x32 include dir
-    filter { "platforms:x32", }
-        includedirs {
-            x32_deps_include,
-            x32_deps_overlay_include,
-        }
-    -- x64 include dir
-    filter { "platforms:x64", }
-        includedirs {
-            x64_deps_include,
-            x64_deps_overlay_include,
-        }
+-- include dir
+---------
+-- x32 include dir
+filter { "platforms:x32", }
+includedirs {
+    x32_deps_include,
+    x32_deps_overlay_include,
+}
+-- x64 include dir
+filter { "platforms:x64", }
+includedirs {
+    x64_deps_include,
+    x64_deps_overlay_include,
+}
 
 
-    -- common source & header files
-    ---------
-    filter {} -- reset the filter and remove all active keywords
-    files { -- added to all filters, later defines will be appended
-        common_files,
-        overlay_files,
-    }
-    removefiles {
-        'libs/detours/uimports.cc',
-    }
-    -- deps
-    filter { 'options:incdeps', "platforms:x32", }
-        files {
-            table_postfix_items(x32_deps_overlay_include, '/**.h'),
-            table_postfix_items(x32_deps_overlay_include, '/**.hxx'),
-            table_postfix_items(x32_deps_overlay_include, '/**.hpp'),
-        }
-    filter { 'options:incdeps', "platforms:x64", }
-        files {
-            table_postfix_items(x64_deps_overlay_include, '/**.h'),
-            table_postfix_items(x64_deps_overlay_include, '/**.hxx'),
-            table_postfix_items(x64_deps_overlay_include, '/**.hpp'),
-        }
-    -- Windows common source files
-    filter { "system:windows", }
-        removefiles {
-            "dll/wrap.cpp"
-        }
-    -- Windows x32 common source files
-    filter { "system:windows", "platforms:x32", "options:winrsrc", }
-        files {
-            "resources/win/api/32/resources.rc"
-        }
-    -- Windows x64 common source files
-    filter { "system:windows", "platforms:x64", "options:winrsrc", }
-        files {
-            "resources/win/api/64/resources.rc"
-        }
-    -- Linux common source files
-    filter { "system:not windows", }
-        removefiles {
-            detours_files,
-        }
+-- common source & header files
+---------
+filter {} -- reset the filter and remove all active keywords
+files {   -- added to all filters, later defines will be appended
+    common_files,
+    overlay_files,
+}
+removefiles {
+    'libs/detours/uimports.cc',
+}
+-- deps
+filter { 'options:incdeps', "platforms:x32", }
+files {
+    table_postfix_items(x32_deps_overlay_include, '/**.h'),
+    table_postfix_items(x32_deps_overlay_include, '/**.hxx'),
+    table_postfix_items(x32_deps_overlay_include, '/**.hpp'),
+}
+filter { 'options:incdeps', "platforms:x64", }
+files {
+    table_postfix_items(x64_deps_overlay_include, '/**.h'),
+    table_postfix_items(x64_deps_overlay_include, '/**.hxx'),
+    table_postfix_items(x64_deps_overlay_include, '/**.hpp'),
+}
+-- Windows common source files
+filter { "system:windows", }
+removefiles {
+    "dll/wrap.cpp"
+}
+-- Windows x32 common source files
+filter { "system:windows", "platforms:x32", "options:winrsrc", }
+files {
+    "resources/win/api/32/resources.rc"
+}
+-- Windows x64 common source files
+filter { "system:windows", "platforms:x64", "options:winrsrc", }
+files {
+    "resources/win/api/64/resources.rc"
+}
+-- Linux common source files
+filter { "system:not windows", }
+removefiles {
+    detours_files,
+}
 
 
-    -- libs to link
-    ---------
-    filter {} -- reset the filter and remove all active keywords
-        links {
-            overlay_link,
-        }
-    -- Windows libs to link
-    filter { "system:windows", }
-        links {
-            common_link_win,
-        }
+-- libs to link
+---------
+filter {} -- reset the filter and remove all active keywords
+links {
+    overlay_link,
+}
+-- Windows libs to link
+filter { "system:windows", }
+links {
+    common_link_win,
+}
 
-    -- Linux libs to link
-    filter { "system:not windows", }
-        links {
-            common_link_linux,
-            "X11"
-        }
+-- Linux libs to link
+filter { "system:not windows", }
+links {
+    common_link_linux,
+    "X11"
+}
 
 
-    -- libs search dir
-    ---------
-    -- x32 libs search dir
-    filter { "platforms:x32", }
-        libdirs {
-            x32_deps_libdir,
-            x32_deps_overlay_libdir,
-        }
-    -- x64 libs search dir
-    filter { "platforms:x64", }
-        libdirs {
-            x64_deps_libdir,
-            x64_deps_overlay_libdir,
-        }
+-- libs search dir
+---------
+-- x32 libs search dir
+filter { "platforms:x32", }
+libdirs {
+    x32_deps_libdir,
+    x32_deps_overlay_libdir,
+}
+-- x64 libs search dir
+filter { "platforms:x64", }
+libdirs {
+    x64_deps_libdir,
+    x64_deps_overlay_libdir,
+}
 -- End api_experimental
 
 
 -- Project steamclient_experimental
 ---------
 project "steamclient_experimental"
-    kind "SharedLib"
-    location "%{wks.location}/%{prj.name}"
-    
-    -- targetdir
-    ---------
-    filter { "system:windows", }
-        targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/steamclient_experimental")
-    filter { "system:not windows", }
-        targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/experimental/%{cfg.platform}")
+kind "SharedLib"
+location "%{wks.location}/%{prj.name}"
+
+-- targetdir
+---------
+filter { "system:windows", }
+targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/steamclient_experimental")
+filter { "system:not windows", }
+targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/experimental/%{cfg.platform}")
 
 
-    -- name
-    ---------
-    filter { "system:windows", "platforms:x32", }
-        targetname "steamclient"
-    filter { "system:windows", "platforms:x64", }
-        targetname "steamclient64"
-    filter { "system:not windows", }
-        targetname "steamclient"
-    
-
-    -- defines
-    ---------
-    filter {} -- reset the filter and remove all active keywords
-    defines { -- added to all filters, later defines will be appended
-        "STEAMCLIENT_DLL", "EMU_OVERLAY", "ImTextureID=ImU64",
-    }
-    -- Windows defines
-    filter { "system:windows" }
-        defines {
-            "EMU_EXPERIMENTAL_BUILD",
-        }
+-- name
+---------
+filter { "system:windows", "platforms:x32", }
+targetname "steamclient"
+filter { "system:windows", "platforms:x64", }
+targetname "steamclient64"
+filter { "system:not windows", }
+targetname "steamclient"
 
 
-    -- include dir
-    ---------
-    -- x32 include dir
-    filter { "platforms:x32", }
-        includedirs {
-            x32_deps_include,
-            x32_deps_overlay_include,
-        }
-
-    -- x64 include dir
-    filter { "platforms:x64", }
-        includedirs {
-            x64_deps_include,
-            x64_deps_overlay_include,
-        }
+-- defines
+---------
+filter {} -- reset the filter and remove all active keywords
+defines { -- added to all filters, later defines will be appended
+    "STEAMCLIENT_DLL", "EMU_OVERLAY", "ImTextureID=ImU64",
+}
+-- Windows defines
+filter { "system:windows" }
+defines {
+    "EMU_EXPERIMENTAL_BUILD",
+}
 
 
-    -- common source & header files
-    ---------
-    filter {} -- reset the filter and remove all active keywords
-    files { -- added to all filters, later defines will be appended
-        common_files,
-        overlay_files,
-    }
-    removefiles {
-        'libs/detours/uimports.cc',
-    }
-    -- deps
-    filter { 'options:incdeps', "platforms:x32", }
-        files {
-            table_postfix_items(x32_deps_overlay_include, '/**.h'),
-            table_postfix_items(x32_deps_overlay_include, '/**.hxx'),
-            table_postfix_items(x32_deps_overlay_include, '/**.hpp'),
-        }
-    filter { 'options:incdeps', "platforms:x64", }
-        files {
-            table_postfix_items(x64_deps_overlay_include, '/**.h'),
-            table_postfix_items(x64_deps_overlay_include, '/**.hxx'),
-            table_postfix_items(x64_deps_overlay_include, '/**.hpp'),
-        }
-    -- Windows common source files
-    filter { "system:windows", }
-        removefiles {
-            "dll/wrap.cpp"
-        }
-    -- Windows x32 common source files
-    filter { "system:windows", "platforms:x32", "options:winrsrc", }
-        files {
-            "resources/win/client/32/resources.rc"
-        }
-    -- Windows x64 common source files
-    filter { "system:windows", "platforms:x64", "options:winrsrc", }
-        files {
-            "resources/win/client/64/resources.rc"
-        }
-    -- Linux common source files
-    filter { "system:not windows", }
-        removefiles {
-            detours_files,
-        }
+-- include dir
+---------
+-- x32 include dir
+filter { "platforms:x32", }
+includedirs {
+    x32_deps_include,
+    x32_deps_overlay_include,
+}
+
+-- x64 include dir
+filter { "platforms:x64", }
+includedirs {
+    x64_deps_include,
+    x64_deps_overlay_include,
+}
 
 
-    -- libs to link
-    ---------
-    filter {} -- reset the filter and remove all active keywords
-        links {
-            overlay_link,
-        }
-    -- Windows libs to link
-    filter { "system:windows", }
-        links {
-            common_link_win,
-        }
+-- common source & header files
+---------
+filter {} -- reset the filter and remove all active keywords
+files {   -- added to all filters, later defines will be appended
+    common_files,
+    overlay_files,
+}
+removefiles {
+    'libs/detours/uimports.cc',
+}
+-- deps
+filter { 'options:incdeps', "platforms:x32", }
+files {
+    table_postfix_items(x32_deps_overlay_include, '/**.h'),
+    table_postfix_items(x32_deps_overlay_include, '/**.hxx'),
+    table_postfix_items(x32_deps_overlay_include, '/**.hpp'),
+}
+filter { 'options:incdeps', "platforms:x64", }
+files {
+    table_postfix_items(x64_deps_overlay_include, '/**.h'),
+    table_postfix_items(x64_deps_overlay_include, '/**.hxx'),
+    table_postfix_items(x64_deps_overlay_include, '/**.hpp'),
+}
+-- Windows common source files
+filter { "system:windows", }
+removefiles {
+    "dll/wrap.cpp"
+}
+-- Windows x32 common source files
+filter { "system:windows", "platforms:x32", "options:winrsrc", }
+files {
+    "resources/win/client/32/resources.rc"
+}
+-- Windows x64 common source files
+filter { "system:windows", "platforms:x64", "options:winrsrc", }
+files {
+    "resources/win/client/64/resources.rc"
+}
+-- Linux common source files
+filter { "system:not windows", }
+removefiles {
+    detours_files,
+}
 
-    -- Linux libs to link
-    filter { "system:not windows", }
-        links {
-            common_link_linux,
-        }
+
+-- libs to link
+---------
+filter {} -- reset the filter and remove all active keywords
+links {
+    overlay_link,
+}
+-- Windows libs to link
+filter { "system:windows", }
+links {
+    common_link_win,
+}
+
+-- Linux libs to link
+filter { "system:not windows", }
+links {
+    common_link_linux,
+}
 
 
-    -- libs search dir
-    ---------
-    -- x32 libs search dir
-    filter { "platforms:x32", }
-        libdirs {
-            x32_deps_libdir,
-            x32_deps_overlay_libdir,
-        }
-    -- x64 libs search dir
-    filter { "platforms:x64", }
-        libdirs {
-            x64_deps_libdir,
-            x64_deps_overlay_libdir,
-        }
+-- libs search dir
+---------
+-- x32 libs search dir
+filter { "platforms:x32", }
+libdirs {
+    x32_deps_libdir,
+    x32_deps_overlay_libdir,
+}
+-- x64 libs search dir
+filter { "platforms:x64", }
+libdirs {
+    x64_deps_libdir,
+    x64_deps_overlay_libdir,
+}
 -- End steamclient_experimental
 
 
 -- Project tool_lobby_connect
 ---------
 project "tool_lobby_connect"
-    kind "ConsoleApp"
-    location "%{wks.location}/%{prj.name}"
-    targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/tools/lobby_connect")
-    targetname "lobby_connect_%{cfg.platform}"
+kind "ConsoleApp"
+location "%{wks.location}/%{prj.name}"
+targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/tools/lobby_connect")
+targetname "lobby_connect_%{cfg.platform}"
 
 
-    -- defines
-    ---------
-    filter {} -- reset the filter and remove all active keywords
-    defines { -- added to all filters, later defines will be appended
-        "NO_DISK_WRITES", "LOBBY_CONNECT",
-    }
-    removedefines {
-        "CONTROLLER_SUPPORT",
-    }
+-- defines
+---------
+filter {} -- reset the filter and remove all active keywords
+defines { -- added to all filters, later defines will be appended
+    "NO_DISK_WRITES", "LOBBY_CONNECT",
+}
+removedefines {
+    "CONTROLLER_SUPPORT",
+}
 
 
-    -- include dir
-    ---------
-    -- common include dir
-    -- x32 include dir
-    filter { "platforms:x32", }
-        includedirs {
-            x32_deps_include,
-        }
+-- include dir
+---------
+-- common include dir
+-- x32 include dir
+filter { "platforms:x32", }
+includedirs {
+    x32_deps_include,
+}
 
-    -- x64 include dir
-    filter { "platforms:x64", }
-        includedirs {
-            x64_deps_include,
-        }
-
-
-    -- common source & header files
-    ---------
-    filter {} -- reset the filter and remove all active keywords
-    files { -- added to all filters, later defines will be appended
-        common_files,
-        'tools/lobby_connect/lobby_connect.cpp'
-    }
-    removefiles {
-        "libs/gamepad/**",
-        detours_files,
-    }
-    -- Windows x32 common source files
-    filter { "system:windows", "platforms:x32", "options:winrsrc", }
-        files {
-            "resources/win/launcher/32/resources.rc"
-        }
-    -- Windows x64 common source files
-    filter { "system:windows", "platforms:x64", "options:winrsrc", }
-        files {
-            "resources/win/launcher/64/resources.rc"
-        }
+-- x64 include dir
+filter { "platforms:x64", }
+includedirs {
+    x64_deps_include,
+}
 
 
-    -- libs to link
-    ---------
-    -- Windows libs to link
-    filter { "system:windows", }
-        links {
-            common_link_win,
-            'Comdlg32',
-        }
+-- common source & header files
+---------
+filter {} -- reset the filter and remove all active keywords
+files {   -- added to all filters, later defines will be appended
+    common_files,
+    'tools/lobby_connect/lobby_connect.cpp'
+}
+removefiles {
+    "libs/gamepad/**",
+    detours_files,
+}
+-- Windows x32 common source files
+filter { "system:windows", "platforms:x32", "options:winrsrc", }
+files {
+    "resources/win/launcher/32/resources.rc"
+}
+-- Windows x64 common source files
+filter { "system:windows", "platforms:x64", "options:winrsrc", }
+files {
+    "resources/win/launcher/64/resources.rc"
+}
 
-    -- Linux libs to link
-    filter { "system:not windows", }
-        links {
-            common_link_linux,
-        }
+
+-- libs to link
+---------
+-- Windows libs to link
+filter { "system:windows", }
+links {
+    common_link_win,
+    'Comdlg32',
+}
+
+-- Linux libs to link
+filter { "system:not windows", }
+links {
+    common_link_linux,
+}
 
 
-    -- libs search dir
-    ---------
-    -- x32 libs search dir
-    filter { "platforms:x32", }
-        libdirs {
-            x32_deps_libdir,
-        }
-    -- x64 libs search dir
-    filter { "platforms:x64", }
-        libdirs {
-            x64_deps_libdir,
-        }
+-- libs search dir
+---------
+-- x32 libs search dir
+filter { "platforms:x32", }
+libdirs {
+    x32_deps_libdir,
+}
+-- x64 libs search dir
+filter { "platforms:x64", }
+libdirs {
+    x64_deps_libdir,
+}
 -- End tool_lobby_connect
 
 
 -- Project tool_generate_interfaces
 project "tool_generate_interfaces"
-    kind "ConsoleApp"
-    location "%{wks.location}/%{prj.name}"
-    targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/tools/generate_interfaces")
-    targetname "generate_interfaces_%{cfg.platform}"
+kind "ConsoleApp"
+location "%{wks.location}/%{prj.name}"
+targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/tools/generate_interfaces")
+targetname "generate_interfaces_%{cfg.platform}"
 
 
-    -- common source & header files
-    ---------
-    files {
-        "tools/generate_interfaces/generate_interfaces.cpp"
-    }
+-- common source & header files
+---------
+files {
+    "tools/generate_interfaces/generate_interfaces.cpp"
+}
 -- End tool_generate_interfaces
 
 
 -- Project lib_steamnetworkingsockets START
 project "lib_steamnetworkingsockets"
-    kind "SharedLib"
-    location "%{wks.location}/%{prj.name}"
-    targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/steamnetworkingsockets/%{cfg.platform}")
-    targetname "steamnetworkingsockets"
+kind "SharedLib"
+location "%{wks.location}/%{prj.name}"
+targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/steamnetworkingsockets/%{cfg.platform}")
+targetname "steamnetworkingsockets"
 
 
-    -- common source & header files
-    ---------
-    files {
-        "networking_sockets_lib/**",
-        "helpers/dbg_log.cpp", "helpers/dbg_log/**",
-        'helpers/common_helpers.cpp', 'helpers/common_helpers/**',
-    }
+-- common source & header files
+---------
+files {
+    "networking_sockets_lib/**",
+    "helpers/dbg_log.cpp", "helpers/dbg_log/**",
+    'helpers/common_helpers.cpp', 'helpers/common_helpers/**',
+}
 
 
 -- End lib_steamnetworkingsockets
@@ -1174,70 +1193,68 @@ project "lib_steamnetworkingsockets"
 
 -- Project lib_game_overlay_renderer
 project "lib_game_overlay_renderer"
-    kind "SharedLib"
-    location "%{wks.location}/%{prj.name}"
+kind "SharedLib"
+location "%{wks.location}/%{prj.name}"
 
 
-    -- targetdir
-    ---------
-    filter { "system:windows", }
-        targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/steamclient_experimental")
-    filter { "system:not windows", }
-        targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/gameoverlayrenderer/%{cfg.platform}")
+-- targetdir
+---------
+filter { "system:windows", }
+targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/steamclient_experimental")
+filter { "system:not windows", }
+targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/gameoverlayrenderer/%{cfg.platform}")
 
 
-    -- name
-    ---------
-    filter { "system:windows", "platforms:x32", }
-        targetname "GameOverlayRenderer"
-    filter { "system:windows", "platforms:x64", }
-        targetname "GameOverlayRenderer64"
-    filter { "system:not windows", }
-        targetname "gameoverlayrenderer"
-
-    
-    -- include dir
-    ---------
-    -- x32 include dir
-    filter { "platforms:x32", }
-        includedirs {
-            x32_deps_include,
-        }
-
-    -- x64 include dir
-    filter { "platforms:x64", }
-        includedirs {
-            x64_deps_include,
-        }
+-- name
+---------
+filter { "system:windows", "platforms:x32", }
+targetname "GameOverlayRenderer"
+filter { "system:windows", "platforms:x64", }
+targetname "GameOverlayRenderer64"
+filter { "system:not windows", }
+targetname "gameoverlayrenderer"
 
 
-    -- common source & header files
-    ---------
-    filter {} -- reset the filter and remove all active keywords
-    files {
-        "game_overlay_renderer_lib/**"
-    }
-    -- x32 common source files
-    filter { "system:windows", "platforms:x32", "options:winrsrc", }
-        files {
-            "resources/win/game_overlay_renderer/32/resources.rc"
-        }
-    -- x64 common source files
-    filter { "system:windows", "platforms:x64", "options:winrsrc", }
-        files {
-            "resources/win/game_overlay_renderer/64/resources.rc"
-        }
+-- include dir
+---------
+-- x32 include dir
+filter { "platforms:x32", }
+includedirs {
+    x32_deps_include,
+}
+
+-- x64 include dir
+filter { "platforms:x64", }
+includedirs {
+    x64_deps_include,
+}
+
+
+-- common source & header files
+---------
+filter {} -- reset the filter and remove all active keywords
+files {
+    "game_overlay_renderer_lib/**"
+}
+-- x32 common source files
+filter { "system:windows", "platforms:x32", "options:winrsrc", }
+files {
+    "resources/win/game_overlay_renderer/32/resources.rc"
+}
+-- x64 common source files
+filter { "system:windows", "platforms:x64", "options:winrsrc", }
+files {
+    "resources/win/game_overlay_renderer/64/resources.rc"
+}
 -- End lib_game_overlay_renderer
 
 
 
 -- WINDOWS ONLY TARGETS START
 if os.target() == "windows" then
-
-
--- Project steamclient_experimental_stub
----------
-project "steamclient_experimental_stub"
+    -- Project steamclient_experimental_stub
+    ---------
+    project "steamclient_experimental_stub"
     -- https://stackoverflow.com/a/63228027
     kind "SharedLib"
     location "%{wks.location}/%{prj.name}"
@@ -1247,32 +1264,32 @@ project "steamclient_experimental_stub"
     -- name
     ---------
     filter { "platforms:x32", }
-        targetname "steamclient"
+    targetname "steamclient"
     filter { "platforms:x64", }
-        targetname "steamclient64"
+    targetname "steamclient64"
 
 
     -- common source & header files
     ---------
     filter {} -- reset the filter and remove all active keywords
-    files { -- added to all filters, later defines will be appended
+    files {   -- added to all filters, later defines will be appended
         "steamclient/steamclient.cpp",
     }
     -- x32 common source files
     filter { "platforms:x32", "options:winrsrc", }
-        files {
-            "resources/win/client/32/resources.rc"
-        }
+    files {
+        "resources/win/client/32/resources.rc"
+    }
     -- x64 common source files
     filter { "platforms:x64", "options:winrsrc", }
-        files {
-            "resources/win/client/64/resources.rc"
-        }
--- End steamclient_experimental_stub
+    files {
+        "resources/win/client/64/resources.rc"
+    }
+    -- End steamclient_experimental_stub
 
 
--- Project steamclient_experimental_extra
-project "steamclient_experimental_extra"
+    -- Project steamclient_experimental_extra
+    project "steamclient_experimental_extra"
     kind "SharedLib"
     location "%{wks.location}/%{prj.name}"
     targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/steamclient_experimental/extra_dlls")
@@ -1283,14 +1300,14 @@ project "steamclient_experimental_extra"
     ---------
     -- x32 include dir
     filter { "platforms:x32", }
-        includedirs {
-            x32_deps_include,
-        }
+    includedirs {
+        x32_deps_include,
+    }
     -- x64 include dir
     filter { "platforms:x64", }
-        includedirs {
-            x64_deps_include,
-        }
+    includedirs {
+        x64_deps_include,
+    }
 
 
     -- common source & header files
@@ -1308,19 +1325,19 @@ project "steamclient_experimental_extra"
     }
     -- x32 common source files
     filter { "platforms:x32", "options:winrsrc", }
-        files {
-            "resources/win/client/32/resources.rc"
-        }
+    files {
+        "resources/win/client/32/resources.rc"
+    }
     -- x64 common source files
     filter { "platforms:x64", "options:winrsrc", }
-        files {
-            "resources/win/client/64/resources.rc"
-        }
--- End steamclient_experimental_extra
+    files {
+        "resources/win/client/64/resources.rc"
+    }
+    -- End steamclient_experimental_extra
 
 
--- Project steamclient_experimental_loader
-project "steamclient_experimental_loader"
+    -- Project steamclient_experimental_loader
+    project "steamclient_experimental_loader"
     kind "WindowedApp"
     location "%{wks.location}/%{prj.name}"
     targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/steamclient_experimental")
@@ -1331,16 +1348,16 @@ project "steamclient_experimental_loader"
     ---------
     -- MinGW on Windows
     filter { "action:gmake*", }
-        -- source: https://gcc.gnu.org/onlinedocs/gcc/Cygwin-and-MinGW-Options.html
-        linkoptions {
-            -- MinGW on Windows cannot link wWinMain by default
-            "-municode",
-        }
+    -- source: https://gcc.gnu.org/onlinedocs/gcc/Cygwin-and-MinGW-Options.html
+    linkoptions {
+        -- MinGW on Windows cannot link wWinMain by default
+        "-municode",
+    }
 
 
     -- common source & header files
     ---------
-    filter {} -- reset the filter and remove all active keywords
+    filter {}                             -- reset the filter and remove all active keywords
     files {
         "tools/steamclient_loader/win/*", -- we want the .ini too
         "helpers/pe_helpers.cpp", "helpers/pe_helpers/**",
@@ -1350,14 +1367,14 @@ project "steamclient_experimental_loader"
     }
     -- x32 common source files
     filter { "platforms:x32", "options:winrsrc", }
-        files {
-            "resources/win/launcher/32/resources.rc"
-        }
+    files {
+        "resources/win/launcher/32/resources.rc"
+    }
     -- x64 common source files
     filter { "platforms:x64", "options:winrsrc", }
-        files {
-            "resources/win/launcher/64/resources.rc"
-        }
+    files {
+        "resources/win/launcher/64/resources.rc"
+    }
 
 
     -- libs to link
@@ -1367,11 +1384,11 @@ project "steamclient_experimental_loader"
         -- common_link_win,
         'user32',
     }
--- End steamclient_experimental_loader
+    -- End steamclient_experimental_loader
 
 
--- Project tool_file_dos_stub_changer
-project "tool_file_dos_stub_changer"
+    -- Project tool_file_dos_stub_changer
+    project "tool_file_dos_stub_changer"
     kind "ConsoleApp"
     location "%{wks.location}/%{prj.name}"
     targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/file_dos_stub_changer")
@@ -1386,12 +1403,12 @@ project "tool_file_dos_stub_changer"
         "helpers/pe_helpers.cpp", "helpers/pe_helpers/**",
         "helpers/common_helpers.cpp", "helpers/common_helpers/**",
     }
--- End tool_file_dos_stub_changer
+    -- End tool_file_dos_stub_changer
 
 
--- Project test_crash_printer
----------
-project "test_crash_printer"
+    -- Project test_crash_printer
+    ---------
+    project "test_crash_printer"
     kind "ConsoleApp"
     location "%{wks.location}/%{prj.name}"
     targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/tests/crash_printer")
@@ -1401,7 +1418,7 @@ project "test_crash_printer"
     -- common source & header files
     ---------
     filter {} -- reset the filter and remove all active keywords
-    files { -- added to all filters, later defines will be appended
+    files {   -- added to all filters, later defines will be appended
         'crash_printer/' .. os_iden .. '.cpp', 'crash_printer/crash_printer/' .. os_iden .. '.hpp',
         -- helpers
         'helpers/common_helpers.cpp', 'helpers/common_helpers/**',
@@ -1429,8 +1446,7 @@ project "test_crash_printer"
     postbuildcommands {
         '%[%{!cfg.buildtarget.abspath}]',
     }
--- End test_crash_printer
-
+    -- End test_crash_printer
 end
 -- End WINDOWS ONLY TARGETS
 
@@ -1438,10 +1454,9 @@ end
 
 -- LINUX ONLY TARGETS START
 if os.target() == "linux" then
-
--- Project steamclient_regular
----------
-project "steamclient_regular"
+    -- Project steamclient_regular
+    ---------
+    project "steamclient_regular"
     kind "SharedLib"
     location "%{wks.location}/%{prj.name}"
     targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/regular/%{cfg.platform}")
@@ -1460,20 +1475,20 @@ project "steamclient_regular"
     ---------
     -- x32 include dir
     filter { "platforms:x32", }
-        includedirs {
-            x32_deps_include,
-        }
+    includedirs {
+        x32_deps_include,
+    }
     -- x64 include dir
     filter { "platforms:x64", }
-        includedirs {
-            x64_deps_include,
-        }
+    includedirs {
+        x64_deps_include,
+    }
 
 
     -- common source & header files
     ---------
     filter {} -- reset the filter and remove all active keywords
-    files { -- added to all filters, later defines will be appended
+    files {   -- added to all filters, later defines will be appended
         common_files,
     }
     removefiles {
@@ -1484,7 +1499,7 @@ project "steamclient_regular"
     -- libs to link
     ---------
     filter {} -- reset the filter and remove all active keywords
-    links { -- added to all filters, later defines will be appended
+    links {   -- added to all filters, later defines will be appended
         common_link_linux,
     }
 
@@ -1492,20 +1507,20 @@ project "steamclient_regular"
     ---------
     -- x32 libs search dir
     filter { "platforms:x32", }
-        libdirs {
-            x32_deps_libdir,
-        }
+    libdirs {
+        x32_deps_libdir,
+    }
     -- x64 libs search dir
     filter { "platforms:x64", }
-        libdirs {
-            x64_deps_libdir,
-        }
--- End steamclient_regular
+    libdirs {
+        x64_deps_libdir,
+    }
+    -- End steamclient_regular
 
 
--- Project test_crash_printer_sa_handler
----------
-project "test_crash_printer_sa_handler"
+    -- Project test_crash_printer_sa_handler
+    ---------
+    project "test_crash_printer_sa_handler"
     kind "ConsoleApp"
     location "%{wks.location}/%{prj.name}"
     targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/tests/crash_printer")
@@ -1515,7 +1530,7 @@ project "test_crash_printer_sa_handler"
     -- common source & header files
     ---------
     filter {} -- reset the filter and remove all active keywords
-    files { -- added to all filters, later defines will be appended
+    files {   -- added to all filters, later defines will be appended
         'crash_printer/' .. os_iden .. '.cpp', 'crash_printer/crash_printer/' .. os_iden .. '.hpp',
         -- helpers
         'helpers/common_helpers.cpp', 'helpers/common_helpers/**',
@@ -1535,12 +1550,12 @@ project "test_crash_printer_sa_handler"
         '%[%{!cfg.buildtarget.abspath}]',
     }
 
--- End test_crash_printer_sa_handler
+    -- End test_crash_printer_sa_handler
 
 
--- Project test_crash_printer_sa_sigaction
----------
-project "test_crash_printer_sa_sigaction"
+    -- Project test_crash_printer_sa_sigaction
+    ---------
+    project "test_crash_printer_sa_sigaction"
     kind "ConsoleApp"
     location "%{wks.location}/%{prj.name}"
     targetdir("build/" .. os_iden .. "/%{_ACTION}/%{cfg.buildcfg}/tests/crash_printer")
@@ -1550,7 +1565,7 @@ project "test_crash_printer_sa_sigaction"
     -- common source & header files
     ---------
     filter {} -- reset the filter and remove all active keywords
-    files { -- added to all filters, later defines will be appended
+    files {   -- added to all filters, later defines will be appended
         'crash_printer/' .. os_iden .. '.cpp', 'crash_printer/crash_printer/' .. os_iden .. '.hpp',
         -- helpers
         'helpers/common_helpers.cpp', 'helpers/common_helpers/**',
@@ -1569,8 +1584,7 @@ project "test_crash_printer_sa_sigaction"
     postbuildcommands {
         '%[%{!cfg.buildtarget.abspath}]',
     }
--- End test_crash_printer_sa_sigaction
-
+    -- End test_crash_printer_sa_sigaction
 end
 -- End LINUX ONLY TARGETS
 


### PR DESCRIPTION
~~Very~~ WIP PR, currently handles most of the major controller types. Tested to work on Elden Ring Nightreign with a stock Dualsense.

### Implements
- Querying controller types and connected controllers
- Rumble
- Action set layers
- GetActionOrigins, GetGlyphForActionOrigin, GetActionOriginFromXboxOrigin....

### Note on XInput Emulation
Real steam emulates Xinput for non-Xinput gamepads on windows. We could attempt to do the same by hooking Xinput same way that Steam does, but it's tricky and would only work well on experimental builds most likely 

### TODO
- [x] Fix reconnecting controllers
- [x] Implement action layers -> fixes gamepad detection
- [ ] Loading action set layers
- [ ] Test rumble
- [x] Customizable deadzone, layers, etc.
 