### PR TITLE
Some fixes to `Steam_UGC` functions

### DIFF
--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -58,6 +58,7 @@ struct Mod_entry {
     uint64 total_files_sizes{}; // added in sdk 1.60, "Total size of all files (non-legacy), excluding the preview file"
     std::string min_game_branch{}; // added in sdk 1.60
     std::string max_game_branch{}; // added in sdk 1.60
+    std::string metadata{};
 
     std::string workshopItemURL{};
 

--- a/dll/settings.cpp
+++ b/dll/settings.cpp
@@ -222,6 +222,7 @@ void Settings::addModDetails(PublishedFileId_t id, const Mod_entry &details)
         f->total_files_sizes = details.total_files_sizes;
         f->min_game_branch = details.min_game_branch;
         f->max_game_branch = details.max_game_branch;
+        f->metadata = details.metadata;
     }
 }
 

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -1078,6 +1078,7 @@ static void try_parse_mods_file(class Settings *settings_client, Settings *setti
             newMod.total_files_sizes = mod.value().value("total_files_sizes", newMod.primaryFileSize);
             newMod.min_game_branch = mod.value().value("min_game_branch", "");
             newMod.max_game_branch = mod.value().value("max_game_branch", "");
+            newMod.metadata = mod.value().value("metadata", "");
             
             newMod.workshopItemURL = mod.value().value("workshop_item_url", "https://steamcommunity.com/sharedfiles/filedetails/?id=" + std::string(mod.key()));
             newMod.votesUp = mod.value().value("upvotes", (uint32)500);
@@ -1110,6 +1111,7 @@ static void try_parse_mods_file(class Settings *settings_client, Settings *setti
             PRINT_DEBUG("    total_files_sizes: %llu", settings_client->getMod(newMod.id).total_files_sizes);
             PRINT_DEBUG("    min_game_branch: '%s'", settings_client->getMod(newMod.id).min_game_branch.c_str());
             PRINT_DEBUG("    max_game_branch: '%s'", settings_client->getMod(newMod.id).max_game_branch.c_str());
+            PRINT_DEBUG("    metadata: '%s'", settings_client->getMod(newMod.id).metadata.c_str());
             PRINT_DEBUG("    workshop_item_url: '%s'", newMod.workshopItemURL.c_str());
             PRINT_DEBUG("    preview_url: '%s'", newMod.previewURL.c_str());
         } catch (std::exception& e) {
@@ -1178,6 +1180,7 @@ static void try_detect_mods_folder(class Settings *settings_client, Settings *se
             PRINT_DEBUG("    total_files_sizes: '%llu'", newMod.total_files_sizes);
             PRINT_DEBUG("    min_game_branch: '%s'", newMod.min_game_branch.c_str());
             PRINT_DEBUG("    max_game_branch: '%s'", newMod.max_game_branch.c_str());
+            PRINT_DEBUG("    metadata: '%s'", newMod.metadata.c_str());
             PRINT_DEBUG("    workshop_item_url: '%s'", newMod.workshopItemURL.c_str());
             PRINT_DEBUG("    preview_url: '%s'", newMod.previewURL.c_str());
         } catch (...) {}

--- a/dll/steam_ugc.cpp
+++ b/dll/steam_ugc.cpp
@@ -247,7 +247,8 @@ UGCQueryHandle_t Steam_UGC::CreateQueryUserUGCRequest( AccountID_t unAccountID, 
     PRINT_DEBUG("%u %i %i %i %u %u %u", unAccountID, eListType, eMatchingUGCType, eSortOrder, nCreatorAppID, nConsumerAppID, unPage);
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
-    if (nCreatorAppID != settings->get_local_game_id().AppID() || nConsumerAppID != settings->get_local_game_id().AppID()) return k_UGCQueryHandleInvalid;
+    // TODO: more info needed to decide which UGCs will be returned
+    // if (nCreatorAppID != settings->get_local_game_id().AppID() || nConsumerAppID != settings->get_local_game_id().AppID()) return k_UGCQueryHandleInvalid;
     if (unPage < 1) return k_UGCQueryHandleInvalid;
     if (eListType < 0) return k_UGCQueryHandleInvalid;
     if (unAccountID != settings->get_local_steam_id().GetAccountID()) return k_UGCQueryHandleInvalid;

--- a/dll/steam_ugc.cpp
+++ b/dll/steam_ugc.cpp
@@ -535,11 +535,16 @@ bool Steam_UGC::GetQueryUGCMetadata( UGCQueryHandle_t handle, uint32 index, STEA
     PRINT_DEBUG_TODO();
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
     if (handle == k_UGCQueryHandleInvalid) return false;
+    if (!pchMetadata || !cchMetadatasize) return false;
 
-    auto request = std::find_if(ugc_queries.begin(), ugc_queries.end(), [&handle](struct UGC_query const& item) { return item.handle == handle; });
-    if (ugc_queries.end() == request) return false;
+    auto res = get_query_ugc(handle, index);
+    if (!res.has_value()) return false;
 
-    return false;
+    auto &mod = res.value();
+    PRINT_DEBUG("Steam_UGC:GetQueryUGCMetadata: '%s'", mod.metadata.c_str());
+    memset(pchMetadata, 0, cchMetadatasize);
+    mod.metadata.copy(pchMetadata, cchMetadatasize - 1);
+    return true;
 }
 
 

--- a/post_build/steam_settings.EXAMPLE/mods.EXAMPLE.json
+++ b/post_build/steam_settings.EXAMPLE/mods.EXAMPLE.json
@@ -27,7 +27,8 @@
         "num_children": 0,
         "path": "C:\\games\\my_game\\steam_settings\\mods_data\\mod_111111111_data_folder",
         "preview_url": "file:///C:/games/my_game/steam_settings/mod_images/my_preview.jpg",
-        "score": 0.7
+        "score": 0.7,
+        "metadata": "some needed metadata"
     },
     
     "222222222": {


### PR DESCRIPTION
Some apps may request UGCs by calling `CreateQueryUserUGCRequest()` with appids corresponding to the item creation tool and the app itself respectively, which may be different. Contradictory to the [doc](https://partner.steamgames.com/doc/api/ISteamUGC#CreateQueryUserUGCRequest), real steam actually does return a valid handle and correct results by further calling `SendQueryUGCRequest()`. However it seems that the appids indeed somehow affect the returned UGCs, and thus more info is needed to emu it. Currently I choose to just remove the too strict check only.

Some apps require metadata for UGCs to work, so a new option is added to support such behavior.