### PR TITLE
Various bug fixes

### DIFF
--- a/dll/dll/steam_gameserver.h
+++ b/dll/dll/steam_gameserver.h
@@ -73,6 +73,8 @@ public ISteamGameServer
     std::vector<struct Gameserver_Outgoing_Packet> outgoing_packets{};
 
     void set_version(const char *pchVersionString);
+    void add_player(CSteamID steamID);
+    void remove_player(CSteamID steamID);
 
 
 public:

--- a/dll/dll/steam_matchmaking_servers.h
+++ b/dll/dll/steam_matchmaking_servers.h
@@ -79,6 +79,7 @@ public ISteamMatchmakingServers
     void server_details(Gameserver *g, gameserveritem_t *server);
     void server_details_players(Gameserver *g, Steam_Matchmaking_Servers_Direct_IP_Request *r);
     void server_details_rules(Gameserver *g, Steam_Matchmaking_Servers_Direct_IP_Request *r);
+    HServerListRequest get_server_list_request(EMatchMakingType type);
     void Callback(Common_Message *msg);
 
 public:

--- a/dll/steam_gameserver.cpp
+++ b/dll/steam_gameserver.cpp
@@ -83,6 +83,7 @@ bool Steam_GameServer::InitGameServer( uint32 unIP, uint16 usGamePort, uint16 us
 
     if (logged_in) return false; // may not be changed after logged in.
 
+    server_data.set_appid(nGameAppId);
     set_version(pchVersionString);
     server_data.set_ip(unIP);
     server_data.set_port(usGamePort);
@@ -499,7 +500,7 @@ bool Steam_GameServer::BUpdateUserData( CSteamID steamIDUser, const char *pchPla
 bool Steam_GameServer::BSetServerType( uint32 unServerFlags, uint32 unGameIP, uint16 unGamePort, 
                             uint16 unSpectatorPort, uint16 usQueryPort, const char *pchGameDir, const char *pchVersion, bool bLANMode )
 {
-    PRINT_DEBUG("'%s' '%s'", pchVersion, pchGameDir);
+    PRINT_DEBUG("%u %u '%s' '%s'", unGameIP, unGamePort, pchVersion, pchGameDir);
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
     // Note: appid 55100 doesn't call InitGameServer(), it immediately calls this function
@@ -522,7 +523,9 @@ bool Steam_GameServer::BSetServerType( uint32 unServerFlags, uint32 unGameIP, ui
 bool Steam_GameServer::BSetServerType( int32 nGameAppId, uint32 unServerFlags, uint32 unGameIP, uint16 unGamePort, 
                                     uint16 unSpectatorPort, uint16 usQueryPort, const char *pchGameDir, const char *pchVersion, bool bLANMode )
 {
-    return BSetServerType(unServerFlags, unGameIP, unGamePort, unSpectatorPort, usQueryPort, pchGameDir, pchVersion, bLANMode);
+    bool ret = BSetServerType(unServerFlags, unGameIP, unGamePort, unSpectatorPort, usQueryPort, pchGameDir, pchVersion, bLANMode);
+    server_data.set_appid(nGameAppId);
+    return ret;
 }
 
 // Updates server status values which shows up in the server browser and matchmaking APIs
@@ -855,7 +858,8 @@ void Steam_GameServer::RunCallbacks()
         PRINT_DEBUG("Sending Gameserver");
         Common_Message msg{};
         msg.set_source_id(settings->get_local_steam_id().ConvertToUint64());
-        server_data.set_appid(settings->get_local_game_id().AppID());
+        if (server_data.appid() == 0)
+            server_data.set_appid(settings->get_local_game_id().AppID());
         msg.set_allocated_gameserver(new Gameserver(server_data));
         msg.mutable_gameserver()->set_num_players(auth_manager->countInboundAuth());
         network->sendToAllIndividuals(&msg, true);
@@ -986,7 +990,9 @@ bool Steam_GameServer::GSSetServerType( int32 nGameAppId, uint32 unServerFlags, 
     PRINT_DEBUG_ENTRY();
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
-    return BSetServerType(unServerFlags, unGameIP, unGamePort, 0, 0, pchGameDir, pchVersion, false);
+    bool ret = BSetServerType(unServerFlags, unGameIP, unGamePort, 0, 0, pchGameDir, pchVersion, false);
+    server_data.set_appid(nGameAppId);
+    return ret;
 }
 
 bool Steam_GameServer::GSSetServerType2( int32 nGameAppId, uint32 unServerFlags, uint32 unGameIP, uint16 unGamePort, uint16 unSpectatorPort, uint16 usQueryPort, const char *pchGameDir, const char *pchVersion, bool bLANMode )
@@ -995,7 +1001,9 @@ bool Steam_GameServer::GSSetServerType2( int32 nGameAppId, uint32 unServerFlags,
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
     SetSpectatorPort(unSpectatorPort);
-    return BSetServerType(unServerFlags, unGameIP, unGamePort, unSpectatorPort, usQueryPort, pchGameDir, pchVersion, bLANMode);
+    bool ret = BSetServerType(unServerFlags, unGameIP, unGamePort, unSpectatorPort, usQueryPort, pchGameDir, pchVersion, bLANMode);
+    server_data.set_appid(nGameAppId);
+    return ret;
 }
 
 bool Steam_GameServer::GSUpdateStatus2( int cPlayers, int cPlayersMax, int cBotPlayers, const char *pchServerName, const char *pSpectatorServerName, const char *pchMapName )
@@ -1068,7 +1076,9 @@ bool Steam_GameServer::GSSetServerType( int32 nGameAppId, uint32 unServerFlags, 
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
     SetSpectatorPort(unSpectatorPort);
-    return BSetServerType(unServerFlags, unGameIP, unGamePort, unSpectatorPort, usQueryPort, pchGameDir, pchVersion, bLANMode);
+    bool ret = BSetServerType(unServerFlags, unGameIP, unGamePort, unSpectatorPort, usQueryPort, pchGameDir, pchVersion, bLANMode);
+    server_data.set_appid(nGameAppId);
+    return ret;
 }
 
 bool Steam_GameServer::GSUpdateStatus( int cPlayers, int cPlayersMax, int cBotPlayers, const char *pchServerName, const char *pSpectatorServerName, const char *pchMapName )

--- a/dll/steam_gameserver.cpp
+++ b/dll/steam_gameserver.cpp
@@ -562,9 +562,15 @@ void Steam_GameServer::SetGameType( const char *pchGameType )
 // Ask if a user has a specific achievement for this game, will get a callback on reply
 bool Steam_GameServer::BGetUserAchievementStatus( CSteamID steamID, const char *pchAchievementName )
 {
-    PRINT_DEBUG_ENTRY();
+    PRINT_DEBUG("%llu %s", steamID.ConvertToUint64(), pchAchievementName);
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
-    return false;
+
+    GSClientAchievementStatus_t data = {};
+    data.m_bUnlocked = true;
+    data.m_SteamID = steamID.ConvertToUint64();
+    strncpy(data.m_pchAchievement, pchAchievementName, sizeof(data.m_pchAchievement) - 1);
+    callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
+    return true;
 }
 
 // New auth system APIs - do not mix with the old auth system APIs.

--- a/dll/steam_gameserver.cpp
+++ b/dll/steam_gameserver.cpp
@@ -846,6 +846,8 @@ void Steam_GameServer::RunCallbacks()
         msg.set_source_id(settings->get_local_steam_id().ConvertToUint64());
         if (server_data.appid() == 0)
             server_data.set_appid(settings->get_local_game_id().AppID());
+        if (server_data.mod_dir().empty())
+            server_data.set_mod_dir(server_data.game_dir());
         msg.set_allocated_gameserver(new Gameserver(server_data));
         msg.mutable_gameserver()->set_num_players(auth_manager->countInboundAuth());
         network->sendToAllIndividuals(&msg, true);

--- a/dll/steam_gameserver.cpp
+++ b/dll/steam_gameserver.cpp
@@ -47,6 +47,27 @@ void Steam_GameServer::set_version(const char *pchVersionString)
 
 }
 
+void Steam_GameServer::add_player(CSteamID steamID)
+{
+    std::pair<CSteamID, Gameserver_Player_Info_t> infos;
+    infos.first = steamID;
+    infos.second.join_time = std::chrono::steady_clock::now();
+    infos.second.score = 0;
+    infos.second.name = "unnamed";
+    players.emplace_back(std::move(infos));
+}
+
+void Steam_GameServer::remove_player(CSteamID steamID)
+{
+    auto player_it = std::find_if(players.begin(), players.end(), [&steamID](std::pair<CSteamID, Gameserver_Player_Info_t> &player) {
+        return player.first == steamID;
+        });
+
+    if (player_it != players.end()) {
+        players.erase(player_it);
+    }
+}
+
 
 Steam_GameServer::Steam_GameServer(class Settings *settings, class Networking *network, class SteamCallBacks *callbacks)
 {
@@ -395,12 +416,7 @@ bool Steam_GameServer::SendUserConnectAndAuthenticate( uint32 unIPClient, const 
     bool res = auth_manager->SendUserConnectAndAuthenticate(unIPClient, pvAuthBlob, cubAuthBlobSize, pSteamIDUser);
 
     if (res) {
-        std::pair<CSteamID, Gameserver_Player_Info_t> infos;
-        infos.first = *pSteamIDUser;
-        infos.second.join_time = std::chrono::steady_clock::now();
-        infos.second.score = 0;
-        infos.second.name = "unnamed";
-        players.emplace_back(std::move(infos));
+        add_player(*pSteamIDUser);
     }
 
     return res;
@@ -422,13 +438,7 @@ CSteamID Steam_GameServer::CreateUnauthenticatedUserConnection()
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
     CSteamID bot_id = auth_manager->fakeUser();
-    std::pair<CSteamID, Gameserver_Player_Info_t> infos;
-    infos.first = bot_id;
-    infos.second.join_time = std::chrono::steady_clock::now();
-    infos.second.score = 0;
-    infos.second.name = "unnamed";
-    players.emplace_back(std::move(infos));
-
+    add_player(bot_id);
     return bot_id;
 }
 
@@ -441,16 +451,7 @@ void Steam_GameServer::SendUserDisconnect( CSteamID steamIDUser )
     PRINT_DEBUG_ENTRY();
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
-    auto player_it = std::find_if(players.begin(), players.end(), [&steamIDUser](std::pair<CSteamID, Gameserver_Player_Info_t>& player)
-    {
-        return player.first == steamIDUser;
-    });
-
-    if (player_it != players.end())
-    {
-        players.erase(player_it);
-    }
-
+    remove_player(steamIDUser);
     auth_manager->endAuth(steamIDUser);
 }
 
@@ -597,13 +598,7 @@ EBeginAuthSessionResult Steam_GameServer::BeginAuthSession( const void *pAuthTic
     PRINT_DEBUG("%i %llu", cbAuthTicket, steamID.ConvertToUint64());
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
-    std::pair<CSteamID, Gameserver_Player_Info_t> infos;
-    infos.first = steamID;
-    infos.second.join_time = std::chrono::steady_clock::now();
-    infos.second.score = 0;
-    infos.second.name = "unnamed";
-    players.emplace_back(std::move(infos));
-
+    add_player(steamID);
     return auth_manager->beginAuth(pAuthTicket, cbAuthTicket, steamID );
 }
 
@@ -614,16 +609,7 @@ void Steam_GameServer::EndAuthSession( CSteamID steamID )
     PRINT_DEBUG("%llu", steamID.ConvertToUint64());
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
-    auto player_it = std::find_if(players.begin(), players.end(), [&steamID](std::pair<CSteamID, Gameserver_Player_Info_t>& player)
-    {
-        return player.first == steamID;
-    });
-
-    if (player_it != players.end())
-    {
-        players.erase(player_it);
-    }
-
+    remove_player(steamID);
     auth_manager->endAuth(steamID);
 }
 
@@ -918,12 +904,7 @@ bool Steam_GameServer::GSSendSteam2UserConnect( uint32 unUserID, const void *pvR
     bool res = auth_manager->SendSteam2UserConnect(unUserID, pvRawKey, unKeyLen, unIPPublic, usPort, pvCookie, cubCookie, &steam_id);
 
     if (res) {
-        std::pair<CSteamID, Gameserver_Player_Info_t> infos;
-        infos.first = steam_id;
-        infos.second.join_time = std::chrono::steady_clock::now();
-        infos.second.score = 0;
-        infos.second.name = "unnamed";
-        players.emplace_back(std::move(infos));
+        add_player(steam_id);
     }
 
     return res;
@@ -934,8 +915,8 @@ bool Steam_GameServer::GSSendSteam3UserConnect( CSteamID steamID, uint32 unIPPub
     PRINT_DEBUG_ENTRY();
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
-    CSteamID steam_id;
-    return SendUserConnectAndAuthenticate(unIPPublic, pvCookie, cubCookie, &steam_id);
+    CSteamID ticket_steam_id;
+    return SendUserConnectAndAuthenticate(unIPPublic, pvCookie, cubCookie, &ticket_steam_id);
 }
 
 bool Steam_GameServer::GSRemoveUserConnect( uint32 unUserID )
@@ -1059,12 +1040,7 @@ bool Steam_GameServer::GSSendUserConnect( uint32 unUserID, uint32 unIPPublic, ui
     bool res = auth_manager->SendSteam2UserConnect(unUserID, nullptr, 0, unIPPublic, usPort, pvCookie, cubCookie, &steam_id);
 
     if (res) {
-        std::pair<CSteamID, Gameserver_Player_Info_t> infos;
-        infos.first = steam_id;
-        infos.second.join_time = std::chrono::steady_clock::now();
-        infos.second.score = 0;
-        infos.second.name = "unnamed";
-        players.emplace_back(std::move(infos));
+        add_player(steam_id);
     }
 
     return res;

--- a/dll/steam_matchmaking_servers.cpp
+++ b/dll/steam_matchmaking_servers.cpp
@@ -20,6 +20,14 @@
 #define SERVER_TIMEOUT 10.0
 #define DIRECT_IP_DELAY 0.05
 
+static HServerListRequest new_server_list_request()
+{
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    static uintptr_t a = 0;
+    ++a;
+    if (!a) ++a;
+    return reinterpret_cast<HServerListRequest>(a);
+}
 
 static HServerQuery new_server_query()
 {
@@ -60,11 +68,7 @@ HServerListRequest Steam_Matchmaking_Servers::RequestServerList(AppId_t iApp, IS
     PRINT_DEBUG("%u %p, %i", iApp, pRequestServersResponse, (int)type);
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
-    static unsigned server_list_request = 0;
-
-    ++server_list_request;
-    if (!server_list_request) server_list_request = 1;
-    HServerListRequest id = (char *)0 + server_list_request; // (char *)0 silences the compiler warning
+    HServerListRequest id = new_server_list_request();
 
     if (settings->matchmaking_server_list_always_lan_type) {
         PRINT_DEBUG("forcing request type to LAN");
@@ -215,7 +219,15 @@ void Steam_Matchmaking_Servers::RequestOldServerList(AppId_t iApp, ISteamMatchma
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
     auto g = std::begin(requests);
     while (g != std::end(requests)) {
-        if (g->id == (void *)type) {
+        if (g->old_callbacks && g->type == type) {
+            g->appid = iApp;
+            g->callbacks = NULL;
+            g->old_callbacks = pRequestServersResponse;
+            g->cancelled = false;
+            g->completed = false;
+            g->released = false;
+            g->type = type;
+            g->gameservers_filtered.clear();
             return;
         }
 
@@ -229,7 +241,7 @@ void Steam_Matchmaking_Servers::RequestOldServerList(AppId_t iApp, ISteamMatchma
     request.cancelled = false;
     request.completed = false;
     request.type = type;
-    request.id = (void *)type;
+    request.id = new_server_list_request();
     requests.push_back(request);
     PRINT_DEBUG("pushed new request with id: %p", request.id);
 }
@@ -377,24 +389,26 @@ gameserveritem_t *Steam_Matchmaking_Servers::GetServerDetails( HServerListReques
     PRINT_DEBUG("%p %i", hRequest, iServer);
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
-    std::vector <struct Steam_Matchmaking_Servers_Gameserver> gameservers_filtered;
     auto g = std::begin(requests);
     while (g != std::end(requests)) {
         PRINT_DEBUG("  equal? %p %p", hRequest, g->id);
         if (g->id == hRequest) {
-            gameservers_filtered = g->gameservers_filtered;
-            PRINT_DEBUG("  found %zu", gameservers_filtered.size());
+            PRINT_DEBUG("  found %zu", g->gameservers_filtered.size());
             break;
         }
 
         ++g;
     }
 
-    if (iServer < 0 || static_cast<size_t>(iServer) >= gameservers_filtered.size()) {
+    if (g == std::end(requests)) {
         return NULL;
     }
 
-    Gameserver *gs = &gameservers_filtered[iServer].server;
+    if (iServer < 0 || static_cast<size_t>(iServer) >= g->gameservers_filtered.size()) {
+        return NULL;
+    }
+
+    Gameserver *gs = &g->gameservers_filtered[iServer].server;
     auto &server = requests_from_GetServerDetails.create(std::chrono::hours(1));
     server_details(gs, &server);
     PRINT_DEBUG("  Returned server details");
@@ -478,7 +492,7 @@ void Steam_Matchmaking_Servers::RefreshServer( HServerListRequest hRequest, int 
 gameserveritem_t* Steam_Matchmaking_Servers::GetServerDetails( EMatchMakingType eType, int iServer )
 {
     PRINT_DEBUG_ENTRY();
-    return GetServerDetails((HServerListRequest) eType , iServer );
+    return GetServerDetails(get_server_list_request(eType), iServer);
 }
 
 // Cancel an request which is operation on the given list type.  You should call this to cancel
@@ -488,34 +502,34 @@ gameserveritem_t* Steam_Matchmaking_Servers::GetServerDetails( EMatchMakingType 
 void Steam_Matchmaking_Servers::CancelQuery( EMatchMakingType eType )
 {
     PRINT_DEBUG_ENTRY();
-    return CancelQuery((HServerListRequest) eType);
+    return CancelQuery(get_server_list_request(eType));
 }
 
 // Ping every server in your list again but don't update the list of servers
 void Steam_Matchmaking_Servers::RefreshQuery( EMatchMakingType eType )
 {
     PRINT_DEBUG_ENTRY();
-    return RefreshQuery((HServerListRequest) eType);
+    return RefreshQuery(get_server_list_request(eType));
 }
 
 // Returns true if the list is currently refreshing its server list
 bool Steam_Matchmaking_Servers::IsRefreshing( EMatchMakingType eType )
 {
-    return IsRefreshing((HServerListRequest) eType);
+    return IsRefreshing(get_server_list_request(eType));
 }
 
 // How many servers in the given list, GetServerDetails above takes 0... GetServerCount() - 1
 int Steam_Matchmaking_Servers::GetServerCount( EMatchMakingType eType )
 {
     PRINT_DEBUG_ENTRY();
-    return GetServerCount((HServerListRequest) eType);
+    return GetServerCount(get_server_list_request(eType));
 }
 
 // Refresh a single server inside of a query (rather than all the servers )
 void Steam_Matchmaking_Servers::RefreshServer( EMatchMakingType eType, int iServer )
 {
     PRINT_DEBUG_ENTRY();
-    return RefreshServer((HServerListRequest) eType, iServer);
+    return RefreshServer(get_server_list_request(eType), iServer);
 }
 
 
@@ -591,7 +605,12 @@ void Steam_Matchmaking_Servers::server_details(Gameserver *g, gameserveritem_t *
 
     int latency = MIN_LATENCY;
 
-    if (settings->matchmaking_server_details_via_source_query && !(g->ip() < 0) && !(g->query_port() < 0)) {
+    uint16 query_port = g->query_port();
+    if (g->query_port() == 0xFFFF) {
+        query_port = g->port();
+    }
+
+    if (settings->matchmaking_server_details_via_source_query) {
         unsigned char ip[4]{};
         char newip[24]{};
         ip[0] = g->ip() & 0xFF;
@@ -600,8 +619,8 @@ void Steam_Matchmaking_Servers::server_details(Gameserver *g, gameserveritem_t *
         ip[3] = (g->ip() >> 24) & 0xFF;
         snprintf(newip, sizeof(newip), "%d.%d.%d.%d", ip[3], ip[2], ip[1], ip[0]);
 
-        PRINT_DEBUG("  connecting to ssq server on %s:%u", newip, g->query_port());
-        SSQ_SERVER *ssq = ssq_server_new(newip, g->query_port());
+        PRINT_DEBUG("  connecting to ssq server on %s:%u", newip, query_port);
+        SSQ_SERVER *ssq = ssq_server_new(newip, query_port);
         if (ssq != NULL && ssq_server_eok(ssq)) {
             PRINT_DEBUG("  ssq server connection ok");
             ssq_server_timeout(ssq, (SSQ_TIMEOUT_SELECTOR)(SSQ_TIMEOUT_RECV | SSQ_TIMEOUT_SEND), 1200);
@@ -658,11 +677,6 @@ void Steam_Matchmaking_Servers::server_details(Gameserver *g, gameserveritem_t *
         if (ssq != NULL) ssq_server_free(ssq);
     }
 
-    uint16 query_port = g->query_port();
-    if (g->query_port() == 0xFFFF) {
-        query_port = g->port();
-    }
-
     server->m_NetAdr.Init(g->ip(), query_port, g->port());
     server->m_nPing = latency;
     server->m_bHadSuccessfulResponse = true;
@@ -696,7 +710,12 @@ void Steam_Matchmaking_Servers::server_details(Gameserver *g, gameserveritem_t *
 
 void Steam_Matchmaking_Servers::server_details_players(Gameserver *g, Steam_Matchmaking_Servers_Direct_IP_Request *r)
 {
-    if (settings->matchmaking_server_details_via_source_query && !(g->ip() < 0) && !(g->query_port() < 0)) {
+    uint16 query_port = g->query_port();
+    if (g->query_port() == 0xFFFF) {
+        query_port = g->port();
+    }
+
+    if (settings->matchmaking_server_details_via_source_query) {
         unsigned char ip[4]{};
         char newip[24];
         ip[0] = g->ip() & 0xFF;
@@ -705,8 +724,8 @@ void Steam_Matchmaking_Servers::server_details_players(Gameserver *g, Steam_Matc
         ip[3] = (g->ip() >> 24) & 0xFF;
         snprintf(newip, sizeof(newip), "%d.%d.%d.%d", ip[3], ip[2], ip[1], ip[0]);
 
-        PRINT_DEBUG("  connecting to ssq server on  %s:%u", newip, g->query_port());
-        SSQ_SERVER *ssq = ssq_server_new(newip, g->query_port());
+        PRINT_DEBUG("  connecting to ssq server on  %s:%u", newip, query_port);
+        SSQ_SERVER *ssq = ssq_server_new(newip, query_port);
         if (ssq != NULL && ssq_server_eok(ssq)) {
             PRINT_DEBUG("  ssq server connection ok");
             ssq_server_timeout(ssq, (SSQ_TIMEOUT_SELECTOR)(SSQ_TIMEOUT_RECV | SSQ_TIMEOUT_SEND), 1200);
@@ -747,7 +766,12 @@ void Steam_Matchmaking_Servers::server_details_players(Gameserver *g, Steam_Matc
 
 void Steam_Matchmaking_Servers::server_details_rules(Gameserver *g, Steam_Matchmaking_Servers_Direct_IP_Request *r)
 {
-    if (settings->matchmaking_server_details_via_source_query && !(g->ip() < 0) && !(g->query_port() < 0)) {
+    uint16 query_port = g->query_port();
+    if (g->query_port() == 0xFFFF) {
+        query_port = g->port();
+    }
+
+    if (settings->matchmaking_server_details_via_source_query) {
         unsigned char ip[4]{};
         char newip[24];
         ip[0] = g->ip() & 0xFF;
@@ -756,8 +780,8 @@ void Steam_Matchmaking_Servers::server_details_rules(Gameserver *g, Steam_Matchm
         ip[3] = (g->ip() >> 24) & 0xFF;
         snprintf(newip, sizeof(newip), "%d.%d.%d.%d", ip[3], ip[2], ip[1], ip[0]);
 
-        PRINT_DEBUG("  connecting to ssq server on %s:%u", newip, g->query_port());
-        SSQ_SERVER *ssq = ssq_server_new(newip, g->query_port());
+        PRINT_DEBUG("  connecting to ssq server on %s:%u", newip, query_port);
+        SSQ_SERVER *ssq = ssq_server_new(newip, query_port);
         if (ssq != NULL && ssq_server_eok(ssq)) {
             ssq_server_timeout(ssq, (SSQ_TIMEOUT_SELECTOR)(SSQ_TIMEOUT_RECV | SSQ_TIMEOUT_SEND), 1200);
 
@@ -791,6 +815,17 @@ void Steam_Matchmaking_Servers::server_details_rules(Gameserver *g, Steam_Matchm
     }
 
     PRINT_DEBUG("  " "%" PRIu64 "", g->id());
+}
+
+HServerListRequest Steam_Matchmaking_Servers::get_server_list_request(EMatchMakingType type)
+{
+    for (auto &r : requests) {
+        if (r.old_callbacks && r.type == type) {
+            return r.id;
+        }
+    }
+
+    return 0;
 }
 
 void Steam_Matchmaking_Servers::RunCallbacks()

--- a/dll/steam_user_stats_leaderboard.cpp
+++ b/dll/steam_user_stats_leaderboard.cpp
@@ -491,6 +491,8 @@ bool Steam_User_Stats::GetDownloadedLeaderboardEntry( SteamLeaderboardEntries_t 
         entry.m_steamIDUser = target_entry.steam_id;
         entry.m_nGlobalRank = 1 + (int)(&target_entry - &board.entries[0]);
         entry.m_nScore = target_entry.score;
+        entry.m_cDetails = target_entry.score_details.size();
+        entry.m_hUGC = k_UGCHandleInvalid; // TODO
         
         *pLeaderboardEntry = entry;
     }


### PR DESCRIPTION
* Fixed Steam_User_Stats::GetDownloadedLeaderboardEntry not setting m_cDetails in the callback. Fixes leaderboards in Super Meat Boy.
* Fixed the implementation of SteamMatchmakingServers001.
* Adjusted SteamGameServer to actually store app id passed by the game and only fall back to config if the game doesn't provide one. This is required for dedicated servers since they have their own separate app id but need to announce to the actual game app id.
* Set mod dir to game dir if the game didn't provide one.
* Basic implementation for Steam_GameServer::BGetUserAchievementStatus (always returns true). Fixes unlockable items in Team Fortress 2 2008 builds.