### PR TITLE
Clamp callback result output instead of failing

### DIFF
--- a/dll/callsystem.cpp
+++ b/dll/callsystem.cpp
@@ -121,9 +121,25 @@ bool SteamCallResults::callback_result(SteamAPICall_t api_call, void *copy_to, u
     });
     if (cb_result != callresults.end()) {
         if (!cb_result->call_completed()) return false;
-        if (cb_result->result.size() > size) return false;
 
-        memcpy(copy_to, &(cb_result->result[0]), cb_result->result.size());
+        // Real Steam just does nothing and returns true if nullptr is passed.
+        if (!copy_to) return true;
+
+        memset(copy_to, 0, size);
+
+        size_t resultsize = cb_result->result.size();
+        if (size > resultsize) {
+            PRINT_DEBUG("provided buffer is larger than callback data (%u > %u), code should possibly be updated to new sdk",
+                size,
+                resultsize);
+        }
+
+        // Output buffer being too small is not a failure condition.
+        // This behavior is needed for RemoteStorageFileShareResult_t which was made larger in sdk v1.28x
+        // without even the interface version being bumped.
+        size_t outsize = std::min(resultsize, static_cast<size_t>(size));
+
+        memcpy(copy_to, cb_result->result.data(), outsize);
         cb_result->to_delete = true;
         return true;
     } else {

--- a/sdk/steam/isteamremotestorage003.h
+++ b/sdk/steam/isteamremotestorage003.h
@@ -54,4 +54,13 @@ public:
 	virtual	UGCHandle_t GetCachedUGCHandle( int32 iCachedContent ) = 0;
 };
 
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to FileShare()
+//-----------------------------------------------------------------------------
+struct RemoteStorageFileShareResult001_t {
+    enum { k_iCallback = k_iSteamRemoteStorageCallbacks + 7 };
+    EResult m_eResult;			// The result of the operation
+    UGCHandle_t m_hFile;		// The handle that can be shared with users and features
+};
+
 #endif // ISTEAMREMOTESTORAGE003_H


### PR DESCRIPTION
This changes `SteamCallResults::callback_result` behavior so that the buffer being too small is no longer a failure condition but the output is clamped instead. This is necessary for older games using `Steam_Remote_Storage::FileShare` since `RemoteStorageFileShareResult_t` struct was expanded in sdk v1.28x.

Partially fixes 30 second trial in Sonic Generations (that game still needs `Steam_User_Stats::AttachLeaderboardUGC` to be implemented).

From looking at old Linux Steam binaries in IDA, I _think_ this is how the real Steam works as well.