### PR TITLE
Rewrite P2P networking code to allow sharing connections pool beween gameserver/client

### DIFF
--- a/dll/base.cpp
+++ b/dll/base.cpp
@@ -25,8 +25,8 @@
 
 std::recursive_mutex global_mutex{};
 // some arbitrary counter/time for reference
-const std::chrono::time_point<std::chrono::high_resolution_clock> startup_counter = std::chrono::high_resolution_clock::now();
-const std::chrono::time_point<std::chrono::system_clock> startup_time = std::chrono::system_clock::now();
+extern const std::chrono::time_point<std::chrono::high_resolution_clock> startup_counter = std::chrono::high_resolution_clock::now();
+extern const std::chrono::time_point<std::chrono::system_clock> startup_time = std::chrono::system_clock::now();
 
 #ifndef EMU_RELEASE_BUILD
 dbg_log dbg_logger(get_full_program_path() + "STEAM_LOG_" + std::to_string(common_helpers::rand_number(UINT32_MAX)) + ".log");
@@ -68,7 +68,7 @@ static int fd = -1;
 
 void randombytes(char *buf, size_t size)
 {
-  int i;
+  int i{};
 
   if (fd == -1) {
     for (;;) {
@@ -112,7 +112,7 @@ bool set_env_variable(const std::string &name, const std::string &value)
 
 unsigned generate_account_id()
 {
-    int a;
+    int a = 0;
     randombytes((char *)&a, sizeof(a));
     a = abs(a);
     if (!a) ++a;
@@ -154,11 +154,10 @@ CSteamID generate_steam_id_lobby()
     return CSteamID(generate_account_id(), k_EChatInstanceFlagLobby | k_EChatInstanceFlagMMSLobby, k_EUniversePublic, k_EAccountTypeChat);
 }
 
-bool check_timedout(std::chrono::high_resolution_clock::time_point old, double timeout)
+bool check_timedout(std::chrono::high_resolution_clock::time_point old, double timeout, std::chrono::high_resolution_clock::time_point now) // in seconds
 {
     if (timeout == 0.0) return true;
 
-    std::chrono::high_resolution_clock::time_point now = std::chrono::high_resolution_clock::now();
     if (std::chrono::duration_cast<std::chrono::duration<double>>(now - old).count() > timeout) {
         return true;
     }

--- a/dll/dll/base.h
+++ b/dll/dll/base.h
@@ -35,8 +35,9 @@ bool set_env_variable(const std::string &name, const std::string &value);
 /// @brief Check for a timeout given some initial timepoint and a timeout in sec.
 /// @param old The initial timepoint which will be compared against current time
 /// @param timeout The max allowed time in seconds
+/// @param now Optional comparison time point, useful when called in a loop to maintain a consistent reference
 /// @return true if the timepoint has exceeded the max allowed timeout, false otherwise
-bool check_timedout(std::chrono::high_resolution_clock::time_point old, double timeout);
+bool check_timedout(std::chrono::high_resolution_clock::time_point old, double timeout, std::chrono::high_resolution_clock::time_point now = std::chrono::high_resolution_clock::now());
 
 unsigned generate_account_id();
 CSteamID generate_steam_anon_user();

--- a/dll/dll/network.h
+++ b/dll/dll/network.h
@@ -163,6 +163,7 @@ public:
     void rmCallback(Callback_Ids id, CSteamID steam_id, void (*message_callback)(void *object, Common_Message *msg), void *object);
 
     uint32 getIP(CSteamID id);
+    uint16 getPort(CSteamID id);
     uint32 getOwnIP();
 
     void startQuery(IP_PORT ip_port);

--- a/dll/dll/p2p_manager.hpp
+++ b/dll/dll/p2p_manager.hpp
@@ -1,0 +1,101 @@
+/* Copyright (C) 2019 Mr Goldberg
+   This file is part of the Goldberg Emulator
+
+   The Goldberg Emulator is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
+
+   The Goldberg Emulator is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the Goldberg Emulator; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#pragma once
+
+#include "base.h"
+
+
+class P2p_Manager
+{
+private:
+    struct Peer_Src_t
+    {
+        CSteamID remote_id{};
+        CSteamID my_dest_id{};
+    };
+
+    struct Packet_t
+    {
+        bool is_processed = false;
+        std::vector<char> data{};
+    };
+
+    struct Channel_t
+    {
+        std::list<Packet_t> packets{};
+    };
+
+    struct Connection_t
+    {
+        Peer_Src_t peer_conn{};
+        std::chrono::high_resolution_clock::time_point time_added = std::chrono::high_resolution_clock::now();
+        bool is_accepted = false;
+        std::unordered_map<int, Channel_t> channels{};
+    };
+
+    std::recursive_mutex p2p_mtx{};
+    std::list<Connection_t> connections{};
+
+    class Settings *settings_client{};
+    class Settings *settings_server{};
+    class SteamCallBacks *callbacks_client{};
+    class SteamCallBacks *callbacks_server{};
+    class Networking *network{};
+    class RunEveryRunCB *run_every_runcb{};
+
+    SteamCallBacks* get_my_callbacks(const CSteamID &my_id) const;
+    bool is_same_peer(const CSteamID &id, const CSteamID &peer_id) const;
+    void send_peer_session_failure(const Peer_Src_t &peer_conn);
+    void trigger_session_request(const CSteamID &remote_id, const CSteamID &my_id);
+
+    bool remove_connection(const CSteamID &remote_id, const CSteamID &my_id);
+    Connection_t* create_connection(const CSteamID &remote_id, const CSteamID &my_id);
+    Connection_t* get_connection(const CSteamID &remote_id, const CSteamID &my_id);
+
+    void store_packet(CSteamID my_id, CSteamID steamIDRemote, const void *pubData, uint32 cubData, int nChannel);
+
+    void periodic_handle_connections(const std::chrono::high_resolution_clock::time_point &now);
+    void periodic_handle_channels(const std::chrono::high_resolution_clock::time_point &now);
+    void periodic_handle_packets(const std::chrono::high_resolution_clock::time_point &now);
+    void periodic_callback();
+
+    void network_data_packets(Common_Message *msg);
+    void network_low_level(Common_Message *msg);
+    void network_callback(Common_Message *msg);
+
+    static void steam_networking_callback(void *object, Common_Message *msg);
+    static void steam_run_every_runcb(void *object);
+
+
+public:
+    P2p_Manager(
+        class Settings *settings_client, class Settings *settings_server,
+        class SteamCallBacks *callbacks_client, class SteamCallBacks *callbacks_server,
+        class Networking *network, class RunEveryRunCB *run_every_runcb
+    );
+    ~P2p_Manager();
+
+    bool send_packet(CSteamID my_id, CSteamID steamIDRemote, const void *pubData, uint32 cubData, EP2PSend eP2PSendType, int nChannel);
+    bool is_packet_available(CSteamID my_id, uint32 *pcubMsgSize, int nChannel);
+    bool read_packet(CSteamID my_id, void *pubDest, uint32 cubDest, uint32 *pcubMsgSize, CSteamID *psteamIDRemote, int nChannel);
+    bool close_channel(CSteamID my_id, CSteamID steamIDRemote, int nChannel);
+    bool close_session(CSteamID my_id, CSteamID steamIDRemote);
+    bool get_session_state(CSteamID my_id, CSteamID steamIDRemote, P2PSessionState_t *pConnectionState);
+    bool accept_session(CSteamID my_id, CSteamID steamIDRemote);
+
+};

--- a/dll/dll/steam_client.h
+++ b/dll/dll/steam_client.h
@@ -171,6 +171,7 @@ public:
     Steam_AppTicket *steam_app_ticket{};
 
     Steam_Overlay* steam_overlay{};
+    P2p_Manager *p2p_manager{};
 
     PlaytimeCounter* playtime_counter{};
 

--- a/dll/dll/steam_networking.h
+++ b/dll/dll/steam_networking.h
@@ -19,11 +19,7 @@
 #define __INCLUDED_STEAM_NETWORKING_H__
 
 #include "base.h"
-
-struct Steam_Networking_Connection {
-    CSteamID remote{};
-    std::set<int> open_channels{};
-};
+#include "p2p_manager.hpp"
 
 struct steam_listen_socket {
     SNetListenSocket_t id{};
@@ -61,36 +57,25 @@ public ISteamNetworking
 {
     class Settings *settings{};
     class Networking *network{};
+    class P2p_Manager *p2p_manager{};
     class SteamCallBacks *callbacks{};
     class RunEveryRunCB *run_every_runcb{};
 
-    std::recursive_mutex messages_mutex{};
-    std::list<Common_Message> messages{};
-    std::list<Common_Message> unprocessed_messages{};
-
-    std::recursive_mutex connections_edit_mutex{};
-    std::vector<struct Steam_Networking_Connection> connections{};
 
     std::vector<struct steam_listen_socket> listen_sockets{};
     std::vector<struct steam_connection_socket> connection_sockets{};
 
-    std::map<CSteamID, std::chrono::high_resolution_clock::time_point> new_connection_times{};
-    std::queue<CSteamID> new_connections_to_call_cb{};
-    
     SNetListenSocket_t socket_number = 0;
 
-    bool connection_exists(CSteamID id);
-    struct Steam_Networking_Connection *get_or_create_connection(CSteamID id);
-    void remove_connection(CSteamID id);
     SNetSocket_t create_connection_socket(CSteamID target, int nVirtualPort, uint32 nIP, uint16 nPort, SNetListenSocket_t id=0, enum steam_socket_connection_status status=SOCKET_CONNECTING, SNetSocket_t other_id=0);
     struct steam_connection_socket *get_connection_socket(SNetSocket_t id);
     void remove_killed_connection_sockets();
 
     static void steam_networking_callback(void *object, Common_Message *msg);
-    static void steam_networking_run_every_runcp(void *object);
+    static void steam_run_every_runcb(void *object);
 
 public:
-    Steam_Networking(class Settings *settings, class Networking *network, class SteamCallBacks *callbacks, class RunEveryRunCB *run_every_runcb);
+    Steam_Networking(class Settings *settings, class Networking *network, class P2p_Manager *p2p_manager, class SteamCallBacks *callbacks, class RunEveryRunCB *run_every_runcb);
     ~Steam_Networking();
 
     ////////////////////////////////////////////////////////////////////////////////////////////

--- a/dll/net.proto
+++ b/dll/net.proto
@@ -81,18 +81,15 @@ message Low_Level {
 }
 
 message Network_pb {
-    uint32 channel = 1;
+    int32 channel = 1;
     bytes data = 2;
 
     enum Types {
         DATA = 0;
-        NEW_CONNECTION = 1;
+        FAILED_CONNECT = 1;
     }
 
     Types type = 3;
-
-    bool processed = 128;
-    uint64 time_processed = 129;
 }
 
 message Network_Old {

--- a/dll/network.cpp
+++ b/dll/network.cpp
@@ -660,7 +660,7 @@ bool Networking::add_id_connection(struct Connection *connection, CSteamID steam
     if (id != connection->ids.end())
         return false;
 
-    PRINT_DEBUG("ADDED ID %llu", (uint64)steam_id.ConvertToUint64());
+    PRINT_DEBUG("ADDED NEW USER ID %llu", (uint64)steam_id.ConvertToUint64());
     connection->ids.push_back(steam_id);
     if (connection->connected) {
         run_callback_user(steam_id, true, connection->appid);
@@ -715,34 +715,33 @@ bool Networking::handle_announce(Common_Message *msg, IP_PORT ip_port)
             Common_Message msg_ = create_announce(true);
 
             size_t size = msg_.ByteSizeLong();
-            char *buffer = new char[size];
-            msg_.SerializeToArray(buffer, static_cast<int>(size));
+            std::vector<char> buffer(size);
+            msg_.SerializeToArray(buffer.data(), static_cast<int>(size));
             IP_PORT ipp;
             ipp.ip = msg->announce().peers(i).ip();
             ipp.port = htons(msg->announce().peers(i).udp_port());
-            send_packet_to(udp_socket, ipp, buffer, static_cast<unsigned long>(size));
-            delete[] buffer;
+            send_packet_to(udp_socket, ipp, buffer.data(), static_cast<unsigned long>(size));
         }
     }
 
     conn->last_received = std::chrono::high_resolution_clock::now();
 
     if (msg->announce().type() == Announce::PING) {
-        Common_Message msg = create_announce(false);
-        size_t size = msg.ByteSizeLong(); 
-        char *buffer = new char[size];
-        msg.SerializeToArray(buffer, static_cast<int>(size));
-        send_packet_to(udp_socket, ip_port, buffer, static_cast<unsigned long>(size));
-        delete[] buffer;
+        {
+            Common_Message msg = create_announce(false);
+            size_t size = msg.ByteSizeLong();
+            std::vector<char> buffer(size);
+            msg.SerializeToArray(buffer.data(), static_cast<int>(size));
+            send_packet_to(udp_socket, ip_port, buffer.data(), static_cast<unsigned long>(size));
+        }
 
         //send ping packet if not pinged
         if (!conn->udp_pinged) {
             Common_Message msg = create_announce(true);
-            size_t size = msg.ByteSizeLong(); 
-            char *buffer = new char[size];
-            msg.SerializeToArray(buffer, static_cast<int>(size));
-            send_packet_to(udp_socket, ip_port, buffer, static_cast<unsigned long>(size));
-            delete[] buffer;
+            size_t size = msg.ByteSizeLong();
+            std::vector<char> buffer(size);
+            msg.SerializeToArray(buffer.data(), static_cast<int>(size));
+            send_packet_to(udp_socket, ip_port, buffer.data(), static_cast<unsigned long>(size));
         }
     } else if (msg->announce().type() == Announce::PONG) {
         conn->udp_ip_port = ip_port;
@@ -975,9 +974,9 @@ void Networking::Run()
         }
     }
 
-    PRINT_DEBUG("RECV UDP");
+    // PRINT_DEBUG("RECV UDP");
     while((len = receive_packet(udp_socket, &ip_port, data, sizeof(data))) >= 0) {
-        PRINT_DEBUG("recv %i %hhu.%hhu.%hhu.%hhu:%hu", len,
+        PRINT_DEBUG("recv UDP %i %hhu.%hhu.%hhu.%hhu:%hu", len,
             ((unsigned char *)&ip_port.ip)[0], ((unsigned char *)&ip_port.ip)[1], ((unsigned char *)&ip_port.ip)[2], ((unsigned char *)&ip_port.ip)[3], htons(ip_port.port));
         Common_Message msg;
         if (msg.ParseFromArray(data, len)) {
@@ -995,7 +994,7 @@ void Networking::Run()
         }
     }
 
-    PRINT_DEBUG("RECV LOCAL %zu", local_send.size());
+    // PRINT_DEBUG("RECV LOCAL %zu", local_send.size());
     std::vector<Common_Message> local_send_copy = local_send;
     local_send.clear();
 
@@ -1012,7 +1011,7 @@ void Networking::Run()
     socklen_t addrlen = sizeof(addr);
 #endif
     sock_t sock;
-    PRINT_DEBUG("ACCEPTING");
+    // PRINT_DEBUG("ACCEPTING");
     while (is_socket_valid(sock = static_cast<sock_t>(accept(tcp_socket, (struct sockaddr *)&addr, &addrlen)))) {
         PRINT_DEBUG("ACCEPT SOCKET %u", sock);
         struct sockaddr_storage addr;
@@ -1036,7 +1035,7 @@ void Networking::Run()
         }
     }
 
-    PRINT_DEBUG("ACCEPTED %zu", accepted.size());
+    // PRINT_DEBUG("ACCEPTED %zu", accepted.size());
     auto conn = std::begin(accepted);
     while (conn != std::end(accepted)) {
         bool deleted = false;
@@ -1075,7 +1074,7 @@ void Networking::Run()
         }
     }
 
-    PRINT_DEBUG("CONNECTIONS %zu", connections.size());
+    // PRINT_DEBUG("CONNECTIONS %zu", connections.size());
     for (auto &conn: connections) {
         if (!is_tcp_socket_valid(conn.tcp_socket_outgoing)) {
             sock = static_cast<sock_t>(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP));
@@ -1091,7 +1090,7 @@ void Networking::Run()
             }
         }
 
-        PRINT_DEBUG("RUN SOCKET1 %u %u", conn.tcp_socket_outgoing.sock, conn.tcp_socket_incoming.sock);
+        // PRINT_DEBUG("RUN SOCKET1 %u %u", conn.tcp_socket_outgoing.sock, conn.tcp_socket_incoming.sock);
         recv_tcp(conn.tcp_socket_outgoing);
         recv_tcp(conn.tcp_socket_incoming);
 
@@ -1106,24 +1105,26 @@ void Networking::Run()
                             auto i = std::find(c.ids.begin(), c.ids.end(), steam_id);
                             if (i != c.ids.end()) {
                                 c.ids.erase(i);
+                                PRINT_DEBUG("REMOVE OLD USER CONNECTION ID [%llu]", steam_id.ConvertToUint64());
                                 run_callback_user(steam_id, false, c.appid);
-                                PRINT_DEBUG("REMOVE OLD CONNECTION ID");
                             }
                         }
                     }
 
-                    for (auto &steam_id : conn.ids) run_callback_user(steam_id, true, conn.appid);
+                    for (auto &steam_id : conn.ids) {
+                        run_callback_user(steam_id, true, conn.appid);
+                    }
                 }
 
                 conn.connected = true;
             }
         }
 
-        PRINT_DEBUG("RUN SOCKET2 %u %u", conn.tcp_socket_outgoing.sock, conn.tcp_socket_incoming.sock);
+        // PRINT_DEBUG("RUN SOCKET2 %u %u", conn.tcp_socket_outgoing.sock, conn.tcp_socket_incoming.sock);
         send_tcp_pending(conn.tcp_socket_outgoing);
         send_tcp_pending(conn.tcp_socket_incoming);
 
-        PRINT_DEBUG("RUN SOCKET3 %u %u", conn.tcp_socket_outgoing.sock, conn.tcp_socket_incoming.sock);
+        // PRINT_DEBUG("RUN SOCKET3 %u %u", conn.tcp_socket_outgoing.sock, conn.tcp_socket_incoming.sock);
         Common_Message msg;
         while (unbuffer_tcp(conn.tcp_socket_outgoing, &msg)) {
             PRINT_DEBUG("UNBUFFER SOCKET");
@@ -1139,7 +1140,7 @@ void Networking::Run()
             conn.last_received = std::chrono::high_resolution_clock::now();
         }
 
-        PRINT_DEBUG("RUN SOCKET4 %u %u", conn.tcp_socket_outgoing.sock, conn.tcp_socket_incoming.sock);
+        // PRINT_DEBUG("RUN SOCKET4 %u %u", conn.tcp_socket_outgoing.sock, conn.tcp_socket_incoming.sock);
         socket_timeouts(conn.tcp_socket_outgoing, time_extra);
         socket_timeouts(conn.tcp_socket_incoming, time_extra);
 
@@ -1149,11 +1150,15 @@ void Networking::Run()
         auto conn = std::begin(connections);
         while (conn != std::end(connections)) {
             if (check_timedout(conn->last_received, USER_TIMEOUT + time_extra)) {
-                if (conn->connected) for (auto &steam_id : conn->ids) run_callback_user(steam_id, false, conn->appid);
+                if (conn->connected) {
+                    PRINT_DEBUG("USER TIMEOUT");
+                    for (auto &steam_id : conn->ids) {
+                        run_callback_user(steam_id, false, conn->appid);
+                    }
+                }
                 kill_tcp_socket(conn->tcp_socket_outgoing);
                 kill_tcp_socket(conn->tcp_socket_incoming);
                 conn = connections.erase(conn);
-                PRINT_DEBUG("USER TIMEOUT");
             } else {
                 ++conn;
             }
@@ -1162,7 +1167,11 @@ void Networking::Run()
 
     for (auto &conn: connections) {
         if (!(conn.tcp_socket_incoming.received_data || conn.tcp_socket_outgoing.received_data)) {
-            if (conn.connected) for (auto &steam_id : conn.ids) run_callback_user(steam_id, false, conn.appid);
+            if (conn.connected) {
+                for (auto &steam_id : conn.ids) {
+                    run_callback_user(steam_id, false, conn.appid);
+                }
+            }
             conn.connected = false;
         }
     }
@@ -1212,6 +1221,16 @@ uint32 Networking::getIP(CSteamID id)
     Connection *conn = find_connection(id, this->appid);
     if (conn) {
         return ntohl(conn->tcp_ip_port.ip);
+    }
+
+    return 0;
+}
+
+uint16 Networking::getPort(CSteamID id)
+{
+    Connection *conn = find_connection(id, this->appid);
+    if (conn) {
+        return ntohs(conn->tcp_ip_port.port);
     }
 
     return 0;
@@ -1302,14 +1321,28 @@ bool Networking::sendToAll(Common_Message *msg, bool reliable)
 
 void Networking::run_callbacks(Callback_Ids id, Common_Message *msg)
 {
-    for (auto &cb : callbacks[id].callbacks) {
-        uint64 callback_allowed_steamid = cb.steam_id.ConvertToUint64();
-        uint64 message_destination_steamid = msg->dest_id();
+    const uint64 message_destination_steamid = msg->dest_id();
+
+    for (const auto &cb : callbacks[id].callbacks) {
+        const uint64 callback_allowed_steamid = cb.steam_id.ConvertToUint64();
+
         if (callback_allowed_steamid == 0 || // callback wants to receive all messages (callback for broadcast)
             message_destination_steamid == 0 || // message was broadcasted to all (broadcast message)
             callback_allowed_steamid == message_destination_steamid) { // callback destination is the same as the message destination
+            
+            // change broadcast destination ID to a specific one
+            // this is required since otherwise the CSteamID of the destination would be 0 (invalid ID)
+            if (message_destination_steamid == 0) {
+                msg->set_dest_id(callback_allowed_steamid);
+            }
+            // invoke the callback
             cb.message_callback(cb.object, msg);
         }
+    }
+    
+    // restore broadcast destination ID
+    if (message_destination_steamid == 0) {
+        msg->set_dest_id(0);
     }
 }
 

--- a/dll/p2p_manager.cpp
+++ b/dll/p2p_manager.cpp
@@ -1,0 +1,587 @@
+/* Copyright (C) 2019 Mr Goldberg
+   This file is part of the Goldberg Emulator
+
+   The Goldberg Emulator is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
+
+   The Goldberg Emulator is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the Goldberg Emulator; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include "dll/p2p_manager.hpp"
+#include "dll/dll.h"
+
+
+//kingdom 2 crowns doesn't work with a 0.3 delay or lower
+// appid 353090 becomes unstable when joining a lobby if the time is too low,
+// it takes between ~5-12 seconds to get past the message "Waiting for our local client to connect..." !!!
+constexpr static double SESSION_REQUEST_DELAY = 2.0;
+
+// https://partner.steamgames.com/doc/api/ISteamNetworking#SendP2PPacket
+// "if we can't get through to the user after a timeout of 20 seconds, then an error will be posted"
+constexpr static double SESSION_REQUEST_TIMEOUT = 20.0;
+
+
+
+void P2p_Manager::steam_networking_callback(void *object, Common_Message *msg)
+{
+    // PRINT_DEBUG_ENTRY();
+
+    auto *obj = (P2p_Manager *)object;
+    obj->network_callback(msg);
+}
+
+void P2p_Manager::steam_run_every_runcb(void *object)
+{
+    // PRINT_DEBUG_ENTRY();
+
+    auto *obj = (P2p_Manager *)object;
+    obj->periodic_callback();
+}
+
+
+
+
+SteamCallBacks* P2p_Manager::get_my_callbacks(const CSteamID &my_id) const
+{
+    const CSteamID our_id_client = settings_client->get_local_steam_id();
+    const CSteamID our_id_server = settings_server->get_local_steam_id();
+
+    SteamCallBacks *callbacks = nullptr;
+    if (my_id == our_id_client) {
+        PRINT_DEBUG("  using our client callbacks");
+        return callbacks_client;
+    } else if (my_id == our_id_server) {
+        PRINT_DEBUG("  using our server callbacks");
+        return callbacks_server;
+    }
+
+    PRINT_DEBUG("[X] Id=[%llu] is not ours!", my_id.ConvertToUint64());
+    return nullptr;
+}
+
+bool P2p_Manager::is_same_peer(const CSteamID &id, const CSteamID &peer_id) const
+{
+    if (id == peer_id) {
+        return true;
+    }
+
+    return false;
+}
+
+void P2p_Manager::send_peer_session_failure(const Peer_Src_t &peer_conn)
+{
+    Common_Message update_msg{};
+    update_msg.set_source_id(peer_conn.my_dest_id.ConvertToUint64());
+    update_msg.set_dest_id(peer_conn.remote_id.ConvertToUint64());
+    update_msg.set_allocated_network(new Network_pb);
+
+    update_msg.mutable_network()->set_type(Network_pb::FAILED_CONNECT);
+
+    PRINT_DEBUG(
+        "sent a connection failue packet, src id (our client/gameserver)=[%llu], dest id (peer)=[%llu]",
+        (uint64)update_msg.source_id(), (uint64)update_msg.dest_id()
+    );
+    network->sendTo(&update_msg, true);
+}
+
+void P2p_Manager::trigger_session_request(const CSteamID &remote_id, const CSteamID &my_id)
+{
+    PRINT_DEBUG(
+        "triggering session request callback for source steamid=[%llu], I am=[%llu]",
+        remote_id.ConvertToUint64(), my_id.ConvertToUint64()
+    );
+    P2PSessionRequest_t data{};
+    data.m_steamIDRemote = remote_id;
+
+    get_my_callbacks(my_id)->addCBResult(data.k_iCallback, &data, sizeof(data), SESSION_REQUEST_DELAY);
+}
+
+
+
+
+
+bool P2p_Manager::remove_connection(const CSteamID &remote_id, const CSteamID &my_id)
+{
+    auto rem_it = std::remove_if(connections.begin(), connections.end(), [&remote_id, &my_id, this](const Connection_t &item){
+        return is_same_peer(remote_id, item.peer_conn.remote_id)
+            && is_same_peer(my_id, item.peer_conn.my_dest_id)
+            ;
+    });
+
+    if (connections.end() != rem_it) {
+        connections.erase(rem_it, connections.end());
+        return true;
+    }
+
+    return false;
+}
+
+P2p_Manager::Connection_t* P2p_Manager::create_connection(const CSteamID &remote_id, const CSteamID &my_id)
+{
+    auto conn = get_connection(remote_id, my_id);
+    if (conn) {
+        return conn;
+    }
+
+    Connection_t connection{};
+    connection.peer_conn.remote_id = remote_id;
+    connection.peer_conn.my_dest_id = my_id;
+
+    auto &conn_ref = connections.emplace_back(std::move(connection));
+    PRINT_DEBUG(
+        "created for/them=[%llu], from/me=[%llu]",
+        conn_ref.peer_conn.remote_id.ConvertToUint64(), conn_ref.peer_conn.my_dest_id.ConvertToUint64()
+    );
+    return &conn_ref;
+}
+
+P2p_Manager::Connection_t* P2p_Manager::get_connection(const CSteamID &remote_id, const CSteamID &my_id)
+{
+    auto conn = std::find_if(connections.begin(), connections.end(), [&remote_id, &my_id, this](const Connection_t &item) {
+        return is_same_peer(remote_id, item.peer_conn.remote_id)
+            && is_same_peer(my_id, item.peer_conn.my_dest_id)
+            ;
+    });
+
+    if (connections.end() == conn) {
+        return nullptr;
+    }
+
+    return &(*conn);
+}
+
+
+
+
+
+P2p_Manager::P2p_Manager(
+    class Settings *settings_client, class Settings *settings_server,
+    class SteamCallBacks *callbacks_client, class SteamCallBacks *callbacks_server,
+    class Networking *network, class RunEveryRunCB *run_every_runcb
+)
+{
+    this->settings_client = settings_client;
+    this->settings_server = settings_server;
+
+    this->callbacks_client = callbacks_client;
+    this->callbacks_server = callbacks_server;
+
+    this->network = network;
+    this->run_every_runcb = run_every_runcb;
+
+    for (auto settings : { settings_client, settings_server }) {
+        network->setCallback(CALLBACK_ID_NETWORKING, settings->get_local_steam_id(), &P2p_Manager::steam_networking_callback, this);
+        network->setCallback(CALLBACK_ID_USER_STATUS, settings->get_local_steam_id(), &P2p_Manager::steam_networking_callback, this);
+    }
+    
+    run_every_runcb->add(&P2p_Manager::steam_run_every_runcb, this);
+}
+
+P2p_Manager::~P2p_Manager()
+{
+    for (auto settings : { settings_client, settings_server }) {
+        network->rmCallback(CALLBACK_ID_NETWORKING, settings->get_local_steam_id(), &P2p_Manager::steam_networking_callback, this);
+        network->rmCallback(CALLBACK_ID_USER_STATUS, settings->get_local_steam_id(), &P2p_Manager::steam_networking_callback, this);
+    }
+
+    run_every_runcb->remove(&P2p_Manager::steam_run_every_runcb, this);
+}
+
+
+void P2p_Manager::store_packet(CSteamID my_id, CSteamID steamIDRemote, const void *pubData, uint32 cubData, int nChannel)
+{
+    std::lock_guard lock(p2p_mtx);
+
+    auto conn = create_connection(steamIDRemote, my_id);
+
+    {
+        Packet_t channel_msg{};
+        channel_msg.is_processed = conn->is_accepted;
+        if (pubData && cubData > 0) {
+            channel_msg.data.assign((const char *)pubData, (const char *)pubData + cubData);
+        }
+
+        auto &channel = conn->channels[nChannel];
+        channel.packets.emplace_back(std::move(channel_msg));
+    }
+
+    PRINT_DEBUG(
+        "stored msg, size=[%u], from=[%llu] (connection accepted=%i), channel=[%i]",
+        cubData, steamIDRemote.ConvertToUint64(), (int)conn->is_accepted, nChannel
+    );
+
+    if (!conn->is_accepted) {
+        trigger_session_request(steamIDRemote, my_id);
+    }
+}
+
+
+bool P2p_Manager::send_packet(CSteamID my_id, CSteamID steamIDRemote, const void *pubData, uint32 cubData, EP2PSend eP2PSendType, int nChannel)
+{
+    bool reliable = false;
+    if (eP2PSendType == k_EP2PSendReliable || eP2PSendType == k_EP2PSendReliableWithBuffering) {
+        reliable = true;
+    }
+
+    {
+        std::lock_guard lock(p2p_mtx);
+
+        auto conn = create_connection(steamIDRemote, my_id);
+        if (!conn->is_accepted) {
+            // https://partner.steamgames.com/doc/api/ISteamNetworking#AcceptP2PSessionWithUser
+            // "If you've called SendP2PPacket on the other user, this implicitly accepts the session request"
+            conn->is_accepted = true;
+            PRINT_DEBUG(
+                "auto-accepting remote connections from=[%llu], I am=[%llu]",
+                conn->peer_conn.remote_id.ConvertToUint64(), conn->peer_conn.my_dest_id.ConvertToUint64()
+            );
+        }
+    }
+
+    Common_Message msg{};
+    msg.set_source_id(my_id.ConvertToUint64());
+    msg.set_dest_id(steamIDRemote.ConvertToUint64());
+    msg.set_allocated_network(new Network_pb);
+
+    msg.mutable_network()->set_type(Network_pb::DATA);
+    msg.mutable_network()->set_channel(nChannel);
+    msg.mutable_network()->set_data(pubData, cubData);
+
+    bool ret = network->sendTo(&msg, reliable);
+    PRINT_DEBUG(
+        "Sent remote message with size=[%zu] from=[%llu] to=[%llu], is_ok=%u",
+        msg.network().data().size(), (uint64)msg.source_id(), (uint64)msg.dest_id(), ret
+    );
+
+    return ret;
+}
+
+bool P2p_Manager::is_packet_available(CSteamID my_id, uint32 *pcubMsgSize, int nChannel)
+{
+    std::lock_guard lock(p2p_mtx);
+
+    const CSteamID our_id_client = settings_client->get_local_steam_id();
+    const CSteamID our_id_server = settings_server->get_local_steam_id();
+
+    if (pcubMsgSize) *pcubMsgSize = 0;
+
+    for (const auto &conn : connections) {
+        if (!conn.is_accepted) {
+            continue;
+        }
+
+        auto ch_it = conn.channels.find(nChannel);
+        if (conn.channels.end() == ch_it) {
+            continue;
+        }
+
+        auto msg_it = ch_it->second.packets.begin();
+        if (ch_it->second.packets.end() != msg_it) {
+            if (msg_it->is_processed) {
+                uint32 size = static_cast<uint32>(msg_it->data.size());
+                if (pcubMsgSize) {
+                    *pcubMsgSize = size;
+                }
+                PRINT_DEBUG("  available message from=[%llu], size=[%u]", conn.peer_conn.remote_id.ConvertToUint64(), size);
+                
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+bool P2p_Manager::read_packet(CSteamID my_id, void *pubDest, uint32 cubDest, uint32 *pcubMsgSize, CSteamID *psteamIDRemote, int nChannel)
+{
+    std::lock_guard lock(p2p_mtx);
+
+    if (pcubMsgSize) *pcubMsgSize = 0;
+    if (psteamIDRemote) *psteamIDRemote = k_steamIDNil;
+
+    bool read = false;
+    for (auto &conn : connections) {
+        if (!conn.is_accepted) {
+            continue;
+        }
+
+        auto ch_it = conn.channels.find(nChannel);
+        if (conn.channels.end() == ch_it) {
+            continue;
+        }
+
+        auto msg_it = ch_it->second.packets.begin();
+        if (ch_it->second.packets.end() != msg_it) {
+            if (msg_it->is_processed) {
+                if (psteamIDRemote) {
+                    *psteamIDRemote = conn.peer_conn.remote_id;
+                }
+
+                uint32 size = static_cast<uint32>(msg_it->data.size());
+                if (cubDest < size) {
+                    // https://partner.steamgames.com/doc/api/ISteamNetworking#ReadP2PPacket
+                    // "If the cubDest buffer is too small for the packet, then the message will be truncated"
+                    size = cubDest;
+                }
+
+                if (pcubMsgSize) {
+                    *pcubMsgSize = size;
+                }
+
+                if (pubDest) {
+                    memcpy(pubDest, msg_it->data.data(), size);
+                }
+
+                ch_it->second.packets.erase(msg_it);
+
+                PRINT_DEBUG("  copied message from=[%llu], size=[%u]", conn.peer_conn.remote_id.ConvertToUint64(), size);
+                
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+bool P2p_Manager::close_channel(CSteamID my_id, CSteamID steamIDRemote, int nChannel)
+{
+    std::lock_guard lock(p2p_mtx);
+
+    auto conn = get_connection(steamIDRemote, my_id);
+    if (!conn) {
+        return false;
+    }
+
+    conn->channels.erase(nChannel);
+    if (conn->channels.empty()) {
+        // https://partner.steamgames.com/doc/api/ISteamNetworking#CloseP2PChannelWithUser
+        // "Once all channels to a user have been closed,"
+        // "the open session to the user will be closed and new data from this user will trigger a new P2PSessionRequest_t callback."
+        remove_connection(steamIDRemote, my_id);
+        remove_connection(my_id, steamIDRemote);
+    }
+
+    return true;
+}
+
+bool P2p_Manager::close_session(CSteamID my_id, CSteamID steamIDRemote)
+{
+    std::lock_guard lock(p2p_mtx);
+
+    bool res_1 = remove_connection(steamIDRemote, my_id);
+    bool res_2 = remove_connection(my_id, steamIDRemote);
+    return res_1 || res_2;
+}
+
+bool P2p_Manager::get_session_state(CSteamID my_id, CSteamID steamIDRemote, P2PSessionState_t *pConnectionState)
+{
+    std::lock_guard lock(p2p_mtx);
+
+    auto conn = get_connection(steamIDRemote, my_id);
+    if (!conn) {
+        if (pConnectionState) {
+            pConnectionState->m_bConnectionActive = false;
+            pConnectionState->m_bConnecting = false;
+            pConnectionState->m_eP2PSessionError = 0;
+            pConnectionState->m_bUsingRelay = false;
+            pConnectionState->m_nBytesQueuedForSend = 0;
+            pConnectionState->m_nPacketsQueuedForSend = 0;
+            pConnectionState->m_nRemoteIP = 0;
+            pConnectionState->m_nRemotePort = 0;
+        }
+
+        PRINT_DEBUG("  no connection to user=[%llu]", steamIDRemote.ConvertToUint64());
+        return false;
+    }
+
+    if (pConnectionState) {
+        int32 pending_packets = 0;
+        int32 pending_bytes = 0;
+        for (auto& [ch_idx, channel] : conn->channels) {
+            pending_packets += (int32)channel.packets.size();
+            for (auto &msg : channel.packets) {
+                pending_bytes += (int32)msg.data.size();
+            }
+        }
+
+        pConnectionState->m_bConnectionActive = conn->is_accepted;
+        pConnectionState->m_bConnecting = !conn->is_accepted;
+        pConnectionState->m_eP2PSessionError = 0;
+        pConnectionState->m_bUsingRelay = false;
+        pConnectionState->m_nPacketsQueuedForSend = pending_packets;
+        pConnectionState->m_nBytesQueuedForSend = pending_bytes;
+        pConnectionState->m_nRemoteIP = network->getIP(steamIDRemote);
+        pConnectionState->m_nRemotePort = network->getPort(steamIDRemote);
+    }
+
+    PRINT_DEBUG("  user is connected [%llu]", steamIDRemote.ConvertToUint64());
+    return true;
+}
+
+bool P2p_Manager::accept_session(CSteamID my_id, CSteamID steamIDRemote)
+{
+    std::lock_guard lock(p2p_mtx);
+
+    auto conn = get_connection(steamIDRemote, my_id);
+    if (!conn) {
+        PRINT_DEBUG("[X] no connection from=[%llu], I am=[%llu]", steamIDRemote.ConvertToUint64(), my_id.ConvertToUint64());
+        return false;
+    }
+
+    if (!conn->is_accepted) {
+        conn->is_accepted = true;
+        PRINT_DEBUG("accepted new session from=[%llu], I am=[%llu]", steamIDRemote.ConvertToUint64(), my_id.ConvertToUint64());    
+        
+        // process all packets
+        periodic_callback();
+    }
+    return true;
+}
+
+
+
+
+void P2p_Manager::periodic_handle_connections(const std::chrono::high_resolution_clock::time_point &now)
+{
+    for (auto conn_it = connections.begin(); connections.end() != conn_it; ) {
+        if (!conn_it->is_accepted) {
+            if (check_timedout(conn_it->time_added, SESSION_REQUEST_TIMEOUT, now)) {
+                send_peer_session_failure(conn_it->peer_conn);
+                conn_it = connections.erase(conn_it);
+            } else {
+                ++conn_it;
+            }
+        } else {
+            ++conn_it;
+        }
+    }
+}
+
+void P2p_Manager::periodic_handle_channels(const std::chrono::high_resolution_clock::time_point &now)
+{
+    for (auto &conn : connections) {
+        if (!conn.is_accepted) {
+            continue;
+        }
+
+        auto ch_it = conn.channels.begin();
+        while (conn.channels.end() != ch_it) {
+            // TODO anything channel related goes here
+            ++ch_it;
+        }
+    }
+}
+
+void P2p_Manager::periodic_handle_packets(const std::chrono::high_resolution_clock::time_point &now)
+{
+    for (auto &conn : connections) {
+        if (!conn.is_accepted) {
+            continue;
+        }
+
+        for (auto& [ch_num, channel] : conn.channels) {
+            for (auto &msg : channel.packets) {
+                msg.is_processed = true;
+            }
+        }
+    }
+}
+
+void P2p_Manager::periodic_callback()
+{
+    std::lock_guard lock(p2p_mtx);
+
+    auto now = std::chrono::high_resolution_clock::now();
+    periodic_handle_connections(now);
+    periodic_handle_channels(now);
+    periodic_handle_packets(now);
+}
+
+
+
+
+void P2p_Manager::network_data_packets(Common_Message *msg)
+{
+    const CSteamID src_id = (uint64)msg->source_id();
+    const CSteamID dest_id = (uint64)msg->dest_id(); // this is us
+
+    PRINT_DEBUG("got network msg from [%llu], I am [%llu], type <%u>",
+        src_id.ConvertToUint64(), dest_id.ConvertToUint64(), msg->network().type()
+    );
+
+    switch (msg->network().type()) {
+        case Network_pb::DATA: {
+            PRINT_DEBUG("got network data message");
+            store_packet(
+                dest_id, src_id,
+                msg->network().data().c_str(), (uint32)msg->network().data().size(),
+                (int)msg->network().channel()
+            );
+        }
+        break;
+
+        case Network_pb::FAILED_CONNECT: {
+            PRINT_DEBUG("[X] got connection failure packet");
+            P2PSessionConnectFail_t data{};
+            data.m_steamIDRemote = src_id;
+            data.m_eP2PSessionError = EP2PSessionError::k_EP2PSessionErrorTimeout;
+
+            get_my_callbacks(dest_id)->addCBResult(data.k_iCallback, &data, sizeof(data));
+
+            {
+                std::lock_guard lock(p2p_mtx);
+                remove_connection(src_id, dest_id);
+                remove_connection(dest_id, src_id);
+            }
+        }
+        break;
+    }
+}
+
+void P2p_Manager::network_low_level(Common_Message *msg)
+{
+    const CSteamID src_id = (uint64)msg->source_id();
+    const CSteamID dest_id = (uint64)msg->dest_id(); // this is us
+
+    switch (msg->low_level().type()) {
+        case Low_Level::CONNECT: {
+
+        }
+        break;
+
+        case Low_Level::DISCONNECT: {
+            P2PSessionConnectFail_t data{};
+            data.m_steamIDRemote = src_id;
+            data.m_eP2PSessionError = k_EP2PSessionErrorDestinationNotLoggedIn;
+
+            get_my_callbacks(dest_id)->addCBResult(data.k_iCallback, &data, sizeof(data));
+
+            {
+                std::lock_guard lock(p2p_mtx);
+                remove_connection(src_id, dest_id);
+                remove_connection(dest_id, src_id);
+            }
+        }
+        break;
+    }
+}
+
+void P2p_Manager::network_callback(Common_Message *msg)
+{
+    if (msg->has_network()) {
+        network_data_packets(msg);
+    }
+    
+    if (msg->has_low_level()) {
+        network_low_level(msg);
+    }
+}

--- a/dll/steam_client.cpp
+++ b/dll/steam_client.cpp
@@ -30,13 +30,15 @@ void Steam_Client::background_thread_proc()
         std::lock_guard lock(global_mutex);
 
         PRINT_DEBUG("run @@@@@@@@@@@@@@@@@@@@@@@@@@@");
-        last_cb_run = now_ms; // update the time counter just to avoid overlap
         network->Run(); // networking must run first since it receives messages used by each run_callback()
         run_every_runcb->run(); // call each run_callback()
 
         if (settings_client->record_playtime) {
             playtime_counter->tick(); // update playtime counter
         }
+
+        // update the time counter to avoid overlap
+        last_cb_run = (unsigned long long)std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
     }
 }
 
@@ -88,10 +90,14 @@ Steam_Client::Steam_Client()
         }
     }
 
-    // client
-    PRINT_DEBUG("init client");
     callback_results_client = new SteamCallResults();
     callbacks_client = new SteamCallBacks(callback_results_client);
+
+    callback_results_server = new SteamCallResults();
+    callbacks_server = new SteamCallBacks(callback_results_server);
+
+    // client
+    PRINT_DEBUG("init client");
     steam_overlay = new Steam_Overlay(settings_client, local_storage, callback_results_client, callbacks_client, run_every_runcb, network);
 
     steam_user = new Steam_User(settings_client, local_storage, network, callback_results_client, callbacks_client);
@@ -99,12 +105,17 @@ Steam_Client::Steam_Client()
     steam_utils = new Steam_Utils(settings_client, callback_results_client, callbacks_client, steam_overlay);
     
     ugc_bridge = new Ugc_Remote_Storage_Bridge(settings_client);
+    p2p_manager = new P2p_Manager(
+        settings_client, settings_server,
+        callbacks_client, callbacks_server,
+        network, run_every_runcb
+    );
 
     steam_matchmaking = new Steam_Matchmaking(settings_client, local_storage, network, callback_results_client, callbacks_client, run_every_runcb);
     steam_matchmaking_servers = new Steam_Matchmaking_Servers(settings_client, local_storage, network);
     steam_user_stats = new Steam_User_Stats(settings_client, network, local_storage, callback_results_client, callbacks_client, run_every_runcb, steam_overlay);
     steam_apps = new Steam_Apps(settings_client, callback_results_client, callbacks_client);
-    steam_networking = new Steam_Networking(settings_client, network, callbacks_client, run_every_runcb);
+    steam_networking = new Steam_Networking(settings_client, network, p2p_manager, callbacks_client, run_every_runcb);
     steam_remote_storage = new Steam_Remote_Storage(settings_client, ugc_bridge, local_storage, callback_results_client, callbacks_client, run_every_runcb);
     steam_screenshots = new Steam_Screenshots(local_storage, callbacks_client);
     steam_http = new Steam_HTTP(settings_client, network, callback_results_client, callbacks_client);
@@ -134,14 +145,12 @@ Steam_Client::Steam_Client()
 
     // server
     PRINT_DEBUG("init gameserver");
-    callback_results_server = new SteamCallResults();
-    callbacks_server = new SteamCallBacks(callback_results_server);
 
     steam_gameserver = new Steam_GameServer(settings_server, network, callbacks_server);
     steam_gameserver_user = new Steam_User(settings_server, local_storage, network, callback_results_server, callbacks_server);
     steam_gameserver_utils = new Steam_Utils(settings_server, callback_results_server, callbacks_server, steam_overlay);
     steam_gameserverstats = new Steam_GameServerStats(settings_server, network, callback_results_server, callbacks_server, run_every_runcb);
-    steam_gameserver_networking = new Steam_Networking(settings_server, network, callbacks_server, run_every_runcb);
+    steam_gameserver_networking = new Steam_Networking(settings_server, network, p2p_manager, callbacks_server, run_every_runcb);
     steam_gameserver_http = new Steam_HTTP(settings_server, network, callback_results_server, callbacks_server);
     steam_gameserver_inventory = new Steam_Inventory(settings_server, callback_results_server, callbacks_server, run_every_runcb, local_storage);
     steam_gameserver_ugc = new Steam_UGC(settings_server, ugc_bridge, local_storage, callback_results_server, callbacks_server);
@@ -171,7 +180,15 @@ Steam_Client::~Steam_Client()
 {
     #define DEL_INST(_obj_ins) do if (_obj_ins) { delete _obj_ins; _obj_ins = nullptr; } while(0)
 
+    // background thread first to avoid unwanted racing
     DEL_INST(background_thread);
+
+    // ----------------------------------
+    // destroy everything else in reverse
+    // ----------------------------------
+
+    DEL_INST(playtime_counter);
+    DEL_INST(steam_app_ticket);
 
     DEL_INST(steam_gameserver_utils);
     DEL_INST(steam_gameserverstats);
@@ -220,24 +237,22 @@ Steam_Client::~Steam_Client()
     DEL_INST(steam_app_disable_update);
     DEL_INST(steam_billing);
 
+    DEL_INST(p2p_manager);
+    DEL_INST(ugc_bridge);
+
     DEL_INST(steam_utils);
     DEL_INST(steam_friends);
     DEL_INST(steam_user);
+
     DEL_INST(steam_overlay);
-    
-    DEL_INST(steam_app_ticket);
-
-    DEL_INST(playtime_counter);
-
-    DEL_INST(ugc_bridge);
 
     DEL_INST(callbacks_server);
-    DEL_INST(callbacks_client);
     DEL_INST(callback_results_server);
+    DEL_INST(callbacks_client);
     DEL_INST(callback_results_client);
 
-    DEL_INST(network);
     DEL_INST(run_every_runcb);
+    DEL_INST(network);
 
     #undef DEL_INST
 }
@@ -944,15 +959,15 @@ void Steam_Client::RunCallbacks(bool runClientCB, bool runGameserverCB)
 
     // PRINT_DEBUG("steam_matchmaking_servers *********");
     steam_matchmaking_servers->RunCallbacks();
-    
-    // PRINT_DEBUG("run_every_runcb *********");
-    run_every_runcb->run();
 
     // PRINT_DEBUG("steam_gameserver *********");
     steam_gameserver->RunCallbacks();
 
     // PRINT_DEBUG("steam_user *********");
     steam_gameserver_user->RunCallbacks();
+
+    // PRINT_DEBUG("run_every_runcb *********");
+    run_every_runcb->run();
 
     if (runClientCB) {
         // PRINT_DEBUG("callback_results_client *********");

--- a/dll/steam_gameserver.cpp
+++ b/dll/steam_gameserver.cpp
@@ -20,6 +20,9 @@
 
 #define SEND_SERVER_RATE 5.0
 
+// appid 353090 takes ~1.2-1.4 sec to create the gameserver
+#define LOGON_DELAY 1.3
+
 
 void Steam_GameServer::set_version(const char *pchVersionString)
 {
@@ -841,14 +844,14 @@ void Steam_GameServer::RunCallbacks()
     if (temp_call_servers_connected) {
         PRINT_DEBUG("SteamServersConnected_t");
         SteamServersConnected_t data{};
-        callbacks->addCBResult(data.k_iCallback, &data, sizeof(data), 0.1);
+        callbacks->addCBResult(data.k_iCallback, &data, sizeof(data), LOGON_DELAY);
     }
 
     if (logged_in && !policy_response_called) {
         PRINT_DEBUG("GSPolicyResponse_t");
         GSPolicyResponse_t data{};
         data.m_bSecure = !!(flags & k_unServerFlagSecure);
-        callbacks->addCBResult(data.k_iCallback, &data, sizeof(data), 0.11);
+        callbacks->addCBResult(data.k_iCallback, &data, sizeof(data), LOGON_DELAY);
         policy_response_called = true;
     }
 

--- a/dll/steam_matchmaking.cpp
+++ b/dll/steam_matchmaking.cpp
@@ -23,11 +23,14 @@
 #define REQUEST_LOBBY_DATA_TIMEOUT 6.0
 #define LOBBY_DELETED_TIMEOUT 2
 
-#define LOBBY_CREATE_DELAY 0.07 //artificial delay for lobby creation
+// appid 353090 takes ~100ms to create the lobby
+#define LOBBY_CREATE_DELAY 0.2
 
 #define FILTER_MAX_DEFAULT 4096
 
-#define LOBBY_SEARCH_TIMEOUT 0.2 //Tested on real steam
+// https://partner.steamgames.com/doc/api/ISteamMatchmaking#RequestLobbyList
+// "this call can take from 300ms to 5 seconds to complete, and has a timeout of 20 seconds."
+#define LOBBY_SEARCH_TIMEOUT 1.0
 
 
 google::protobuf::Map<std::string,std::string>::const_iterator Steam_Matchmaking::caseinsensitive_find(const ::google::protobuf::Map< ::std::string, ::std::string >& map, std::string key)

--- a/dll/steam_networking.cpp
+++ b/dll/steam_networking.cpp
@@ -16,78 +16,12 @@
    <http://www.gnu.org/licenses/>.  */
 
 #include "dll/steam_networking.h"
+#include "dll/dll.h"
 
 
-//packet timeout in seconds for non connections
-#define ORPHANED_PACKET_TIMEOUT (20)
-#define NEW_CONNECTION_TIMEOUT (20.0)
-
-//kingdom 2 crowns doesn't work with a 0.3 delay or lower
-#define NEW_CONNECTION_DELAY (0.4)
 
 #define OLD_CHANNEL_NUMBER 1
 
-
-bool Steam_Networking::connection_exists(CSteamID id)
-{
-    std::lock_guard<std::recursive_mutex> lock(connections_edit_mutex);
-    return std::find_if(connections.begin(), connections.end(), [&id](struct Steam_Networking_Connection const& conn) { return conn.remote == id;}) != connections.end();
-}
-
-struct Steam_Networking_Connection* Steam_Networking::get_or_create_connection(CSteamID id)
-{
-    std::lock_guard<std::recursive_mutex> lock(connections_edit_mutex);
-    auto conn = std::find_if(connections.begin(), connections.end(), [&id](struct Steam_Networking_Connection const& conn) { return conn.remote == id;});
-
-    if (connections.end() == conn) {
-        struct Steam_Networking_Connection connection;
-        connection.remote = id;
-        connections.push_back(connection);
-        return &(connections[connections.size() - 1]);
-    } else {
-        return &(*conn);
-    }
-}
-
-void Steam_Networking::remove_connection(CSteamID id)
-{
-    {
-        std::lock_guard<std::recursive_mutex> lock(connections_edit_mutex);
-        auto conn = std::begin(connections);
-        while (conn != std::end(connections)) {
-            if (conn->remote == id) {
-
-                conn = connections.erase(conn);
-            } else {
-                ++conn;
-            }
-        }
-    }
-
-    //pretty sure steam also clears the entire queue of messages for that connection
-    {
-        std::lock_guard<std::recursive_mutex> lock(messages_mutex);
-        auto msg = std::begin(messages);
-        while (msg != std::end(messages)) {
-            if (msg->source_id() == id.ConvertToUint64()) {
-                msg = messages.erase(msg);
-            } else {
-                ++msg;
-            }
-        }
-    }
-
-    {
-        auto msg = std::begin(unprocessed_messages);
-        while (msg != std::end(unprocessed_messages)) {
-            if (msg->source_id() == id.ConvertToUint64()) {
-                msg = unprocessed_messages.erase(msg);
-            } else {
-                ++msg;
-            }
-        }
-    }
-}
 
 SNetSocket_t Steam_Networking::create_connection_socket(CSteamID target, int nVirtualPort, uint32 nIP, uint16 nPort, SNetListenSocket_t id, enum steam_socket_connection_status status, SNetSocket_t other_id)
 {
@@ -173,7 +107,7 @@ void Steam_Networking::steam_networking_callback(void *object, Common_Message *m
     steam_networking->Callback(msg);
 }
 
-void Steam_Networking::steam_networking_run_every_runcp(void *object)
+void Steam_Networking::steam_run_every_runcb(void *object)
 {
     // PRINT_DEBUG_ENTRY();
 
@@ -181,25 +115,26 @@ void Steam_Networking::steam_networking_run_every_runcp(void *object)
     steam_networking->RunCallbacks();
 }
 
-Steam_Networking::Steam_Networking(class Settings *settings, class Networking *network, class SteamCallBacks *callbacks, class RunEveryRunCB *run_every_runcb)
+Steam_Networking::Steam_Networking(class Settings *settings, class Networking *network, class P2p_Manager *p2p_manager, class SteamCallBacks *callbacks, class RunEveryRunCB *run_every_runcb)
 {
     this->settings = settings;
     this->network = network;
+    this->p2p_manager = p2p_manager;
     this->callbacks = callbacks;
     this->run_every_runcb = run_every_runcb;
 
     this->network->setCallback(CALLBACK_ID_NETWORKING, settings->get_local_steam_id(), &Steam_Networking::steam_networking_callback, this);
     this->network->setCallback(CALLBACK_ID_USER_STATUS, settings->get_local_steam_id(), &Steam_Networking::steam_networking_callback, this);
-    this->run_every_runcb->add(&Steam_Networking::steam_networking_run_every_runcp, this);
+    this->run_every_runcb->add(&Steam_Networking::steam_run_every_runcb, this);
 
-    PRINT_DEBUG("user id %llu messages: %p", settings->get_local_steam_id().ConvertToUint64(), &messages);
+    PRINT_DEBUG("user id %llu", settings->get_local_steam_id().ConvertToUint64());
 }
 
 Steam_Networking::~Steam_Networking()
 {
     this->network->rmCallback(CALLBACK_ID_NETWORKING, settings->get_local_steam_id(), &Steam_Networking::steam_networking_callback, this);
     this->network->rmCallback(CALLBACK_ID_USER_STATUS, settings->get_local_steam_id(), &Steam_Networking::steam_networking_callback, this);
-    this->run_every_runcb->remove(&Steam_Networking::steam_networking_run_every_runcp, this);
+    this->run_every_runcb->remove(&Steam_Networking::steam_run_every_runcb, this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////
@@ -217,31 +152,15 @@ Steam_Networking::~Steam_Networking()
 // using different channels to talk to the same user will still use the same underlying p2p connection, saving on resources
 bool Steam_Networking::SendP2PPacket( CSteamID steamIDRemote, const void *pubData, uint32 cubData, EP2PSend eP2PSendType, int nChannel)
 {
-    PRINT_DEBUG("len %u sendtype: %u channel: %u to: %llu", cubData, eP2PSendType, nChannel, steamIDRemote.ConvertToUint64());
-    std::lock_guard<std::recursive_mutex> lock(global_mutex);
-    bool reliable = false;
-    if (eP2PSendType == k_EP2PSendReliable || eP2PSendType == k_EP2PSendReliableWithBuffering) reliable = true;
-    Common_Message msg;
-    msg.set_source_id(settings->get_local_steam_id().ConvertToUint64());
-    msg.set_dest_id(steamIDRemote.ConvertToUint64());
-    msg.set_allocated_network(new Network_pb);
+    PRINT_DEBUG(
+        "size=[%u] sendtype: <%u> channel: [%u] from=[%llu] to=[%llu]",
+        cubData, eP2PSendType, nChannel, settings->get_local_steam_id().ConvertToUint64(), steamIDRemote.ConvertToUint64()
+    );
 
-    if (!connection_exists(steamIDRemote)) {
-        msg.mutable_network()->set_type(Network_pb::NEW_CONNECTION);
-        network->sendTo(&msg, true);
-    }
-
-    msg.mutable_network()->set_channel(nChannel);
-    msg.mutable_network()->set_data(pubData, cubData);
-    msg.mutable_network()->set_type(Network_pb::DATA);
-
-    struct Steam_Networking_Connection *conn = get_or_create_connection(steamIDRemote);
-    new_connection_times.erase(steamIDRemote);
-
-    conn->open_channels.insert(nChannel);
-    bool ret = network->sendTo(&msg, reliable);
-    PRINT_DEBUG("Sent message with size: %zu %u", msg.network().data().size(), ret);
-    return ret;
+    return p2p_manager->send_packet(
+        settings->get_local_steam_id(), steamIDRemote,
+        pubData, cubData, eP2PSendType, nChannel
+    );
 }
 
 bool Steam_Networking::SendP2PPacket( CSteamID steamIDRemote, const void *pubData, uint32 cubData, EP2PSend eP2PSendType )
@@ -253,26 +172,20 @@ bool Steam_Networking::SendP2PPacket( CSteamID steamIDRemote, const void *pubDat
 // returns true if any data is available for read, and the amount of data that will need to be read
 bool Steam_Networking::IsP2PPacketAvailable( uint32 *pcubMsgSize, int nChannel)
 {
-    PRINT_DEBUG("channel: %i", nChannel);
-    std::lock_guard<std::recursive_mutex> lock(messages_mutex);
+    PRINT_DEBUG(
+        "channel=[%i], my steam id=%llu (is server=%u)",
+        nChannel, settings->get_local_steam_id().ConvertToUint64(), settings->get_local_steam_id().BGameServerAccount()
+    );
+    
     //Not sure if this should be here because it slightly screws up games that don't like such low "pings"
     //Commenting it out for now because it looks like it causes a bug where 20xx gets stuck in an infinite receive packet loop
     //this->network->Run();
     //RunCallbacks();
 
-    PRINT_DEBUG("Messages %zu %p", messages.size(), &messages);
-    for (auto &msg : messages) {
-        if (connection_exists((uint64)msg.source_id()) && msg.mutable_network()->channel() == nChannel && msg.network().processed()) {
-            uint32 size = static_cast<uint32>(msg.mutable_network()->data().size());
-            if (pcubMsgSize) *pcubMsgSize = size;
-            PRINT_DEBUG("available with size: %u", size);
-            return true;
-        }
-    }
-
-    PRINT_DEBUG("(not available)");
-    if (pcubMsgSize) *pcubMsgSize = 0;
-    return false;
+    return p2p_manager->is_packet_available(
+        settings->get_local_steam_id(),
+        pcubMsgSize, nChannel
+    );
 }
 
 bool Steam_Networking::IsP2PPacketAvailable( uint32 *pcubMsgSize)
@@ -287,38 +200,17 @@ bool Steam_Networking::IsP2PPacketAvailable( uint32 *pcubMsgSize)
 // this call is not blocking, and will return false if no data is available
 bool Steam_Networking::ReadP2PPacket( void *pubDest, uint32 cubDest, uint32 *pcubMsgSize, CSteamID *psteamIDRemote, int nChannel)
 {
-    PRINT_DEBUG("%u %i", cubDest, nChannel);
-    std::lock_guard<std::recursive_mutex> lock(messages_mutex);
+    PRINT_DEBUG("%u %i %p", cubDest, nChannel, pubDest);
+
     //Not sure if this should be here because it slightly screws up games that don't like such low "pings"
     //Commenting it out for now because it looks like it causes a bug where 20xx gets stuck in an infinite receive packet loop
     //this->network->Run();
     //RunCallbacks();
 
-    bool read = false;
-    PRINT_DEBUG("Number messages %zu", messages.size());
-    auto msg = std::begin(messages);
-    while (msg != std::end(messages)) {
-        if (connection_exists((uint64)msg->source_id()) && msg->network().channel() == nChannel && msg->network().processed()) {
-            uint32 msg_size = static_cast<uint32>(msg->network().data().size());
-            if (msg_size > cubDest) msg_size = cubDest;
-            if (pcubMsgSize) *pcubMsgSize = msg_size;
-            memcpy(pubDest, msg->network().data().data(), msg_size);
-
-            PRINT_DEBUG("%s",
-                common_helpers::uint8_vector_to_hex_string(std::vector<uint8_t>((uint8_t*)pubDest, (uint8_t*)pubDest + msg_size)).c_str());
-            
-            *psteamIDRemote = CSteamID((uint64)msg->source_id());
-            PRINT_DEBUG("len %u channel: %u from: " "%" PRIu64 "", msg_size, nChannel, msg->source_id());
-            msg = messages.erase(msg);
-            return true;
-        }
-
-        ++msg;
-    }
-
-    if (pcubMsgSize) *pcubMsgSize = 0;
-    if (psteamIDRemote) *psteamIDRemote = k_steamIDNil;
-    return false;
+    return p2p_manager->read_packet(
+        settings->get_local_steam_id(),
+        pubDest, cubDest, pcubMsgSize, psteamIDRemote, nChannel
+    );
 }
 
 bool Steam_Networking::ReadP2PPacket( void *pubDest, uint32 cubDest, uint32 *pcubMsgSize, CSteamID *psteamIDRemote)
@@ -335,11 +227,15 @@ bool Steam_Networking::ReadP2PPacket( void *pubDest, uint32 cubDest, uint32 *pcu
 // (if you've called SendP2PPacket() on the other user, this implicitly accepts the session request)
 bool Steam_Networking::AcceptP2PSessionWithUser( CSteamID steamIDRemote )
 {
-    PRINT_DEBUG("%llu", steamIDRemote.ConvertToUint64());
-    std::lock_guard<std::recursive_mutex> lock(global_mutex);
-    struct Steam_Networking_Connection *conn = get_or_create_connection(steamIDRemote);
-    if (conn) new_connection_times.erase(steamIDRemote);
-    return !!conn;
+    PRINT_DEBUG("from [%llu], I am=[%llu]", steamIDRemote.ConvertToUint64(), settings->get_local_steam_id().ConvertToUint64());
+
+    if (p2p_manager->accept_session(settings->get_local_steam_id().ConvertToUint64(), steamIDRemote)) {
+        PRINT_DEBUG("  connection accepted");
+        return true;
+    }
+
+    PRINT_DEBUG("  [X] connection NOT accepted");
+    return false;
 }
 
 
@@ -348,15 +244,8 @@ bool Steam_Networking::AcceptP2PSessionWithUser( CSteamID steamIDRemote )
 bool Steam_Networking::CloseP2PSessionWithUser( CSteamID steamIDRemote )
 {
     PRINT_DEBUG("%llu", steamIDRemote.ConvertToUint64());
-    std::lock_guard<std::recursive_mutex> lock(global_mutex);
-    if (!connection_exists(steamIDRemote)) {
-        
-        return false;
-    }
 
-    remove_connection(steamIDRemote);
-    
-    return true;
+    return p2p_manager->close_session(settings->get_local_steam_id().ConvertToUint64(), steamIDRemote);
 }
 
 
@@ -365,20 +254,9 @@ bool Steam_Networking::CloseP2PSessionWithUser( CSteamID steamIDRemote )
 // user will trigger a P2PSessionRequest_t callback
 bool Steam_Networking::CloseP2PChannelWithUser( CSteamID steamIDRemote, int nChannel )
 {
-    PRINT_DEBUG_ENTRY();
-    std::lock_guard<std::recursive_mutex> lock(global_mutex);
-    if (!connection_exists(steamIDRemote)) {
-        return false;
-    }
+    PRINT_DEBUG("%llu", steamIDRemote.ConvertToUint64());
 
-    struct Steam_Networking_Connection *conn = get_or_create_connection(steamIDRemote);
-
-    conn->open_channels.erase(nChannel);
-    if (conn->open_channels.size() == 0) {
-        remove_connection(steamIDRemote);
-    }
-
-    return true;
+    return p2p_manager->close_channel(settings->get_local_steam_id().ConvertToUint64(), steamIDRemote, nChannel);
 }
 
 
@@ -388,36 +266,8 @@ bool Steam_Networking::CloseP2PChannelWithUser( CSteamID steamIDRemote, int nCha
 bool Steam_Networking::GetP2PSessionState( CSteamID steamIDRemote, P2PSessionState_t *pConnectionState )
 {
     PRINT_DEBUG("%llu", steamIDRemote.ConvertToUint64());
-    std::lock_guard<std::recursive_mutex> lock(global_mutex);
-    if (!connection_exists(steamIDRemote) && (steamIDRemote != settings->get_local_steam_id())) {
-        if (pConnectionState) {
-            pConnectionState->m_bConnectionActive = false;
-            pConnectionState->m_bConnecting = false;
-            pConnectionState->m_eP2PSessionError = 0;
-            pConnectionState->m_bUsingRelay = false;
-            pConnectionState->m_nBytesQueuedForSend = 0;
-            pConnectionState->m_nPacketsQueuedForSend = 0;
-            pConnectionState->m_nRemoteIP = 0;
-            pConnectionState->m_nRemotePort = 0;
-        }
-
-        PRINT_DEBUG("No Connection");
-        return false;
-    }
-
-    if (pConnectionState) {
-        pConnectionState->m_bConnectionActive = true;
-        pConnectionState->m_bConnecting = false;
-        pConnectionState->m_eP2PSessionError = 0;
-        pConnectionState->m_bUsingRelay = false;
-        pConnectionState->m_nBytesQueuedForSend = 0;
-        pConnectionState->m_nPacketsQueuedForSend = 0;
-        pConnectionState->m_nRemoteIP = network->getIP(steamIDRemote);
-        pConnectionState->m_nRemotePort = 12345;
-    }
-
-    PRINT_DEBUG("Connection");
-    return true;
+    
+    return p2p_manager->get_session_state(settings->get_local_steam_id().ConvertToUint64(), steamIDRemote, pConnectionState);
 }
 
 
@@ -769,115 +619,18 @@ int Steam_Networking::GetMaxPacketSize( SNetSocket_t hSocket )
     return 1500;
 }
 
+
+
 void Steam_Networking::RunCallbacks()
 {
-    uint64 current_time = std::chrono::duration_cast<std::chrono::duration<uint64>>(std::chrono::system_clock::now().time_since_epoch()).count();
-
-    {
-    std::lock_guard<std::recursive_mutex> lock(messages_mutex);
-
-    {
-        auto msg = std::begin(unprocessed_messages);
-        while (msg != std::end(unprocessed_messages)) {
-            CSteamID source_id((uint64)msg->source_id());
-            if (!connection_exists(source_id)) {
-                if (new_connection_times.find(source_id) == new_connection_times.end()) {
-                    new_connections_to_call_cb.push(source_id);
-                    new_connection_times[source_id] = std::chrono::high_resolution_clock::now();
-                }
-            } else {
-                struct Steam_Networking_Connection *conn = get_or_create_connection(source_id);
-                conn->open_channels.insert(msg->network().channel());
-            }
-
-            msg->mutable_network()->set_processed(true);
-            msg->mutable_network()->set_time_processed(current_time);
-            messages.push_back(*msg);
-            msg = unprocessed_messages.erase(msg);
-        }
-    }
-
-    auto msg = std::begin(messages);
-    while (msg != std::end(messages)) {
-        bool deleted = false;
-        if (msg->network().processed()) {
-            if (!connection_exists((uint64)msg->source_id())) {
-                if (msg->network().time_processed() + ORPHANED_PACKET_TIMEOUT < current_time) {
-                    deleted = true;
-                }
-            }
-        }
-
-        if (deleted) {
-            msg = messages.erase(msg);
-        } else {
-            ++msg;
-        }
-    }
-
-    }
-
-    while (!new_connections_to_call_cb.empty()) {
-        CSteamID source_id = new_connections_to_call_cb.front();
-        auto t = new_connection_times.find(source_id);
-        if (t == new_connection_times.end()) {
-            new_connections_to_call_cb.pop();
-            continue;
-        }
-
-        if (!check_timedout(t->second, NEW_CONNECTION_DELAY)) {
-            break;
-        }
-
-        P2PSessionRequest_t data;
-        memset(&data, 0, sizeof(data));
-        data.m_steamIDRemote = source_id;
-        callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
-        new_connections_to_call_cb.pop();
-    }
-
     //TODO: not sure if sockets should be wiped right away
     remove_killed_connection_sockets();
-
-    for(auto it = new_connection_times.begin(); it != new_connection_times.end(); ) {
-        if (std::chrono::duration_cast<std::chrono::duration<double>>(std::chrono::high_resolution_clock::now() - it->second).count() > NEW_CONNECTION_TIMEOUT) {
-            it = new_connection_times.erase(it);
-            //TODO send packet to other side to tell them connection has "failed".
-        } else {
-            ++it;
-        }
-    }
 }
 
 void Steam_Networking::Callback(Common_Message *msg)
 {
-    if (msg->has_network()) {
-        PRINT_DEBUG("got msg from: " "%" PRIu64 " to: " "%" PRIu64 " size %zu type %u | messages %p: %zu",
-            msg->source_id(), msg->dest_id(), msg->network().data().size(), msg->network().type(), &messages, messages.size()
-        );
-        PRINT_DEBUG("msg data: '%s'",
-            common_helpers::uint8_vector_to_hex_string(std::vector<uint8_t>(msg->network().data().begin(), msg->network().data().end())).c_str());
-
-        if (msg->network().type() == Network_pb::DATA) {
-            unprocessed_messages.push_back(Common_Message(*msg));
-        }
-
-        if (msg->network().type() == Network_pb::NEW_CONNECTION) {
-            std::lock_guard<std::recursive_mutex> lock(messages_mutex);
-            auto msg_temp = std::begin(messages);
-            while (msg_temp != std::end(messages)) {
-                //only delete processed to handle unreliable message arriving at the same time.
-                if (msg_temp->source_id() == msg->source_id() && msg_temp->network().processed()) {
-                    msg_temp = messages.erase(msg_temp);
-                } else {
-                    ++msg_temp;
-                }
-            }
-        }
-    }
-
     if (msg->has_network_old()) {
-        PRINT_DEBUG("got network socket msg %u", msg->network_old().type());
+        PRINT_DEBUG("got old network socket msg %u", msg->network_old().type());
         if (msg->network_old().type() == Network_Old::CONNECTION_REQUEST_IP) {
             for (auto & listen : listen_sockets) {
                 if (listen.nPort == msg->network_old().port()) {
@@ -944,17 +697,9 @@ void Steam_Networking::Callback(Common_Message *msg)
 
     if (msg->has_low_level()) {
         if (msg->low_level().type() == Low_Level::DISCONNECT) {
-            CSteamID source_id((uint64)msg->source_id());
-            if (connection_exists(source_id)) {
-                P2PSessionConnectFail_t data;
-                data.m_steamIDRemote = source_id;
-                data.m_eP2PSessionError = k_EP2PSessionErrorDestinationNotLoggedIn;
-                callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
-            }
-
             for (auto & socket : connection_sockets) {
                 if (socket.target.ConvertToUint64() == msg->source_id()) {
-                    struct SocketStatusCallback_t data;
+                    struct SocketStatusCallback_t data{};
                     socket.status = SOCKET_DISCONNECTED;
                     data.m_hSocket = socket.id;
                     data.m_hListenSocket = socket.listen_id;
@@ -963,9 +708,7 @@ void Steam_Networking::Callback(Common_Message *msg)
                     callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
                 }
             }
-        } else
-
-        if (msg->low_level().type() == Low_Level::CONNECT) {
+        } else if (msg->low_level().type() == Low_Level::CONNECT) {
             
         }
     }


### PR DESCRIPTION
Properly fixes #132, now multiplayer in these old games will work.

- Share network connections pool between client/gameserver in P2P APIs
- Increase server/lobby creation time
- Increase lobby search time
- Properly set `CSteamID` for broadcast network messages (whose ID = 0), to avoid propagating invalid ID to the emu runnable/callback

The reason the games like appid 353090 (and also 301300) didn't work is that it relies on an unclear/undocumented behavior, Steam treats the client instance, and the gameserver instance, as a **single peer**.
This is the most important change that has to be implemented.

Previously, each instance of the client/gameserver would use its own collection of connections, channels, packets, ... now they share the same set of collections.

When you attempt to create a multiplayer session in that game:
- The game initially sends a P2P packet from: **game client** ---> to: its own **gameserver**.
- The gameserver instance must trigger a `P2PSessionRequest_t` callback, with `m_steamIDRemote` set to the client ID
- The gameserver instance must also accept this connection by calling `AcceptP2PSessionWithUser()`
- So far, the **client instance** sent one (or more) packets, and the **gameserver instance** received them
- Then, instead of using **the gameserver** to check if these packets are received, the game uses the **client instance** to perform this check, and of course it expects to find these packets!

You can see how both the client and gameserver are intertwined as if they represent the same entity, this is the definition of a **single peer**, a client instance and its own gameserver, according to Steam's behavior.

When the game later calls `IsP2PPacketAvailable()` and `ReadP2PPacket()`, using the **client instance** which never received anything, it expects a positive result (a packet to be available) from *itself*.
This is why the current code uses a shared pool between both instances to allow such behavior to work as expected.

There is also a reliance on timing when creating the gameserver, the lobby, and when triggering the `P2PSessionRequest_t` callback.
Basically everything must happen at a **slow pace**, you can see a comment from goldberg noting that appid 701160 didn't work when the `P2PSessionRequest_t` callback was triggered earlier than ~300ms.
After some testing, the game (appid 353090) didn't even work reliably with that timing, it had to be even slower, in the scale of seconds.
This is why some of artificial delays were increased in this PR.
