### PR TITLE
Fix return code for `CreateInterface()`

### DIFF
--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -1358,10 +1358,13 @@ STEAMCLIENT_API void* CreateInterface( const char *pName, int *pReturnCode )
 {
     PRINT_DEBUG("%s %p", pName, pReturnCode);
     auto ptr = create_client_interface(pName);
-    if (ptr) {
-        if (pReturnCode) *pReturnCode = 1;
-    } else {
-        if (pReturnCode) *pReturnCode = 0;
+    if (pReturnCode) {
+        // https://github.com/ValveSoftware/source-sdk-2013/blob/57a8b644af418c691f1fba45791019cf2367dedd/src/public/tier1/interface.h#L156-L160
+        if (ptr) {
+            *pReturnCode = 0; // IFACE_OK
+        } else {
+            *pReturnCode = 1; // IFACE_FAILED
+        }
     }
     return ptr;
 }

--- a/steamclient/steamclient.cpp
+++ b/steamclient/steamclient.cpp
@@ -14,22 +14,23 @@ extern "C" __declspec( dllexport )  void* __cdecl CreateInterface( const char *p
 
     auto steam_api = LoadLibraryA(DLL_NAME);
     if (!steam_api) {
-        if (pReturnCode) *pReturnCode = 0;
+        if (pReturnCode) *pReturnCode = 1; // IFACE_FAILED
         return nullptr;
     }
 
     auto create_interface = (fn_create_interface_t)GetProcAddress(steam_api, "SteamInternal_CreateInterface");
+    // https://github.com/ValveSoftware/source-sdk-2013/blob/57a8b644af418c691f1fba45791019cf2367dedd/src/public/tier1/interface.h#L156-L160
     if (!create_interface) {
-        if (pReturnCode) *pReturnCode = 0;
+        if (pReturnCode) *pReturnCode = 1; // IFACE_FAILED
         return nullptr;
     }
 
     auto ptr = create_interface(pName);
     if (pReturnCode) {
         if (ptr) {
-            *pReturnCode = 1;
+            *pReturnCode = 0; // IFACE_OK
         } else {
-            *pReturnCode = 0;
+            *pReturnCode = 1; // IFACE_FAILED
         }
     }
 


### PR DESCRIPTION
Reading their open source [header file](https://github.com/ValveSoftware/source-sdk-2013/blob/57a8b644af418c691f1fba45791019cf2367dedd/src/public/tier1/interface.h#L156-L160) made it clear that the code was inverted.
Checked again in Ghidra and it was definitely inverted, 0 = success, 1 = failure.