### PR TITLE
Minor fix for Linux experimental build to load .so files properly

### DIFF
--- a/dll/base.cpp
+++ b/dll/base.cpp
@@ -658,15 +658,25 @@ BOOL WINAPI DllMain( HINSTANCE, DWORD dwReason, LPVOID )
 
 #else
 
-__attribute__((__constructor__)) static void lib_base_entry()
-{
-    load_dlls();
-}
 
-__attribute__((__destructor__)) static void lib_base_exit()
-{
-    unload_dlls();
-}
+// this acts as both an entry and an exit points for the library
+// avoid "__attribute__((__constructor__))" and "__attribute__((__destructor__))"
+// since they run before the C+++ runtime has been initialized
+// causing problems related to uninitialized global objects
+struct CppRuntimeTrick {
+    CppRuntimeTrick()
+    {
+        PRINT_DEBUG_ENTRY();
+        load_dlls();
+    }
+
+    ~CppRuntimeTrick()
+    {
+        PRINT_DEBUG_ENTRY();
+        unload_dlls();
+    }
+} static g_cpp_rt{};
+
 
 void set_whitelist_ips(uint32_t *from, uint32_t *to, unsigned num_ips)
 {

--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -347,7 +347,7 @@ STEAMAPI_API steam_bool S_CALLTYPE SteamAPI_Init()
     // call this first since it loads old interfaces
     Steam_Client* client = get_steam_client();
 
-#ifdef EMU_EXPERIMENTAL_BUILD
+#if defined(EMU_EXPERIMENTAL_BUILD) && defined(__WINDOWS__)
     crack_SteamAPI_Init();
 #endif
 
@@ -446,10 +446,11 @@ STEAMAPI_API steam_bool S_CALLTYPE SteamAPI_RestartAppIfNecessary( uint32 unOwnA
     
     // call this first since it loads old interfaces
     Steam_Client* client = get_steam_client();
-    
-#ifdef EMU_EXPERIMENTAL_BUILD
+
+#if defined(EMU_EXPERIMENTAL_BUILD) && defined(__WINDOWS__)
     crack_SteamAPI_RestartAppIfNecessary(unOwnAppID);
 #endif
+
     client->setAppID(unOwnAppID);
     return false;
 }

--- a/dll/dll/base.h
+++ b/dll/dll/base.h
@@ -55,7 +55,7 @@ unsigned int file_size_(const std::string &full_path);
 void set_whitelist_ips(uint32_t *from, uint32_t *to, unsigned num_ips);
 
 
-#ifdef EMU_EXPERIMENTAL_BUILD
+#if defined(EMU_EXPERIMENTAL_BUILD) && defined(__WINDOWS__)
 bool crack_SteamAPI_RestartAppIfNecessary(uint32 unOwnAppID);
 bool crack_SteamAPI_Init();
 #endif

--- a/premake5.lua
+++ b/premake5.lua
@@ -840,12 +840,8 @@ project "api_experimental"
     filter {} -- reset the filter and remove all active keywords
     defines { -- added to all filters, later defines will be appended
         "EMU_OVERLAY", "ImTextureID=ImU64",
+        "EMU_EXPERIMENTAL_BUILD",
     }
-    -- Windows defines
-    filter { "system:windows" }
-        defines {
-            "EMU_EXPERIMENTAL_BUILD",
-        }
 
 
     -- include dir
@@ -975,12 +971,8 @@ project "steamclient_experimental"
     filter {} -- reset the filter and remove all active keywords
     defines { -- added to all filters, later defines will be appended
         "STEAMCLIENT_DLL", "EMU_OVERLAY", "ImTextureID=ImU64",
+        "EMU_EXPERIMENTAL_BUILD",
     }
-    -- Windows defines
-    filter { "system:windows" }
-        defines {
-            "EMU_EXPERIMENTAL_BUILD",
-        }
 
 
     -- include dir


### PR DESCRIPTION
* Don't skip defining the experimental macro for Linux builds
* Avoid calling Windows-related hooks in Linux builds
* Workaround to allow C++ runtime to initialize, before loading .so files, partially solves problems related to uninitialized global objects.

This should allow the experimental build to load .so files from `steam_settings/load_dlls`, previously this wasn't enabled since the macro wasn't defined.