### PR TITLE
Persistent playtime

### DIFF
--- a/dll/dll/playtime.h
+++ b/dll/dll/playtime.h
@@ -1,0 +1,50 @@
+/* Copyright (C) 2019 Mr Goldberg
+   This file is part of the Goldberg Emulator
+
+   The Goldberg Emulator is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
+
+   The Goldberg Emulator is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the Goldberg Emulator; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#pragma once
+
+#include <cstdint>
+#include <chrono>
+#include <mutex>
+#include <string>
+
+class Local_Storage;
+
+class PlaytimeCounter {
+public:
+    explicit PlaytimeCounter(Local_Storage* local_storage);
+    ~PlaytimeCounter();
+
+    // Tick the playtime counter, call regularly
+    void tick();
+
+    // Force load/save
+    void load();
+    void save();
+
+    // Get current playtime in seconds
+    uint64_t seconds() const;
+
+private:
+    Local_Storage* local_storage{};
+    const std::string playtime_filename = "playtime.txt";
+    std::chrono::steady_clock::time_point last_tick{};
+    uint64_t playtime_seconds = 0;
+    mutable std::mutex mutex;
+    bool initialized = false;
+    uint64_t since_save = 0; // seconds since last save
+};

--- a/dll/dll/playtime.h
+++ b/dll/dll/playtime.h
@@ -17,12 +17,11 @@
 
 #pragma once
 
+#include "local_storage.h"
 #include <cstdint>
 #include <chrono>
 #include <mutex>
 #include <string>
-
-class Local_Storage;
 
 class PlaytimeCounter {
 public:

--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -291,6 +291,9 @@ public:
     // >0 == load icons in the background as mentioned above
     int paginated_achievements_icons = 10;
 
+    // whether to record playtime
+    bool record_playtime = false;
+
     // bypass to make SetAchievement() always return true, prevent some games from breaking
     bool achievement_bypass = false;
 

--- a/dll/dll/steam_client.h
+++ b/dll/dll/steam_client.h
@@ -61,6 +61,7 @@
 #include "steam_masterserver_updater.h"
 
 #include "overlay/steam_overlay.h"
+#include "playtime.h"
 
 enum Steam_Pipe {
     NO_USER,
@@ -170,6 +171,8 @@ public:
     Steam_AppTicket *steam_app_ticket{};
 
     Steam_Overlay* steam_overlay{};
+
+    PlaytimeCounter* playtime_counter{};
 
     bool steamclient_server_inited = false;
 

--- a/dll/playtime.cpp
+++ b/dll/playtime.cpp
@@ -17,8 +17,6 @@
 
 #include "dll/playtime.h"
 
-#include <chrono>
-#include <mutex>
 #include <limits>
 
 PlaytimeCounter::PlaytimeCounter(Local_Storage* local_storage)
@@ -65,6 +63,7 @@ void PlaytimeCounter::tick()
         save();
     }
 }
+
 void PlaytimeCounter::load()
 {
     std::lock_guard<std::mutex> lock(mutex);

--- a/dll/playtime.cpp
+++ b/dll/playtime.cpp
@@ -1,0 +1,88 @@
+/* Copyright (C) 2019 Mr Goldberg
+   This file is part of the Goldberg Emulator
+
+   The Goldberg Emulator is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
+
+   The Goldberg Emulator is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the Goldberg Emulator; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include "dll/playtime.h"
+#include "dll/local_storage.h"
+
+#include <chrono>
+#include <mutex>
+
+PlaytimeCounter::PlaytimeCounter(Local_Storage* local_storage)
+   : local_storage(local_storage), last_tick(std::chrono::steady_clock::now())
+{
+    load();
+}
+
+PlaytimeCounter::~PlaytimeCounter()
+{
+    save();
+}
+
+void PlaytimeCounter::tick()
+{
+    std::lock_guard<std::mutex> lock(mutex);
+    auto now = std::chrono::steady_clock::now();
+    if (!initialized) {
+        load();
+        last_tick = now;
+        initialized = true;
+        return;
+    }
+
+    auto delta = std::chrono::duration_cast<std::chrono::seconds>(now - last_tick).count();
+    if (delta <= 0) return;
+
+    playtime_seconds += static_cast<uint64_t>(delta);
+    last_tick = now;
+
+    lock.~lock_guard();
+
+    since_save += delta;
+    if (since_save >= 60) {
+        save();
+        since_save = 0;
+    }
+}
+
+void PlaytimeCounter::load()
+{
+    std::lock_guard<std::mutex> lock(mutex);
+
+    playtime_seconds = 0;
+
+    std::string data(32, '\0');
+    if (local_storage->get_data("", playtime_filename, data.data(), static_cast<unsigned int>(data.size()), 0) > 0 &&
+        std::all_of(data.begin(), data.end(), ::isdigit)) {
+        playtime_seconds = std::stoull(data);
+    }
+
+    initialized = true;
+}
+
+void PlaytimeCounter::save()
+{
+    std::lock_guard<std::mutex> lock(mutex);
+
+    std::string data = std::to_string(playtime_seconds);
+    local_storage->store_data("", playtime_filename, data.data(), static_cast<unsigned int>(data.size()));
+}
+
+uint64_t PlaytimeCounter::seconds() const
+{
+    std::lock_guard<std::mutex> lock(mutex);
+    return playtime_seconds;
+}

--- a/dll/playtime.cpp
+++ b/dll/playtime.cpp
@@ -16,10 +16,10 @@
    <http://www.gnu.org/licenses/>.  */
 
 #include "dll/playtime.h"
-#include "dll/local_storage.h"
 
 #include <chrono>
 #include <mutex>
+#include <limits>
 
 PlaytimeCounter::PlaytimeCounter(Local_Storage* local_storage)
    : local_storage(local_storage), last_tick(std::chrono::steady_clock::now())
@@ -34,30 +34,37 @@ PlaytimeCounter::~PlaytimeCounter()
 
 void PlaytimeCounter::tick()
 {
-    std::lock_guard<std::mutex> lock(mutex);
     auto now = std::chrono::steady_clock::now();
+
     if (!initialized) {
         load();
+        std::lock_guard<std::mutex> lock(mutex);
         last_tick = now;
         initialized = true;
         return;
     }
 
-    auto delta = std::chrono::duration_cast<std::chrono::seconds>(now - last_tick).count();
-    if (delta <= 0) return;
+    bool need_save = false;
+    {
+        std::lock_guard<std::mutex> lock(mutex);
 
-    playtime_seconds += static_cast<uint64_t>(delta);
-    last_tick = now;
+        auto delta = std::chrono::duration_cast<std::chrono::seconds>(now - last_tick).count();
+        if (delta <= 0) return;
 
-    lock.~lock_guard();
+        playtime_seconds += static_cast<uint64_t>(delta);
+        last_tick = now;
 
-    since_save += delta;
-    if (since_save >= 60) {
+        since_save += delta;
+        if (since_save >= 60) {
+            since_save = 0;
+            need_save = true;
+        }
+    }
+
+    if (need_save) {
         save();
-        since_save = 0;
     }
 }
-
 void PlaytimeCounter::load()
 {
     std::lock_guard<std::mutex> lock(mutex);
@@ -67,7 +74,9 @@ void PlaytimeCounter::load()
     std::string data(32, '\0');
     if (local_storage->get_data("", playtime_filename, data.data(), static_cast<unsigned int>(data.size()), 0) > 0 &&
         std::all_of(data.begin(), data.end(), ::isdigit)) {
-        playtime_seconds = std::stoull(data);
+        try {
+            playtime_seconds = std::stoull(data);
+        } catch (...) {}
     }
 
     initialized = true;

--- a/dll/playtime.cpp
+++ b/dll/playtime.cpp
@@ -49,7 +49,14 @@ void PlaytimeCounter::tick()
         auto delta = std::chrono::duration_cast<std::chrono::seconds>(now - last_tick).count();
         if (delta <= 0) return;
 
-        playtime_seconds += static_cast<uint64_t>(delta);
+        uint64_t inc = static_cast<uint64_t>(delta);
+        const uint64_t maxv = std::numeric_limits<uint64_t>::max();
+        if (playtime_seconds > maxv - inc) {
+            playtime_seconds = maxv;
+        } else {
+            playtime_seconds += inc;
+        }
+        
         last_tick = now;
 
         since_save += delta;

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -1573,6 +1573,9 @@ static void parse_stats_features(class Settings *settings_client, class Settings
         long val_server = ini.GetLongValue("main::stats", "paginated_achievements_icons", settings_server->paginated_achievements_icons);
         settings_server->paginated_achievements_icons = static_cast<int>(val_server);
     }
+
+    settings_client->record_playtime = ini.GetBoolValue("main::stats", "record_playtime", settings_client->record_playtime);
+    settings_server->record_playtime = ini.GetBoolValue("main::stats", "record_playtime", settings_server->record_playtime);
 }
 
 

--- a/dll/steam_client.cpp
+++ b/dll/steam_client.cpp
@@ -34,7 +34,9 @@ void Steam_Client::background_thread_proc()
         network->Run(); // networking must run first since it receives messages used by each run_callback()
         run_every_runcb->run(); // call each run_callback()
 
-        playtime_counter->tick(); // update playtime counter
+        if (settings_client->record_playtime) {
+            playtime_counter->tick(); // update playtime counter
+        }
     }
 }
 
@@ -224,6 +226,8 @@ Steam_Client::~Steam_Client()
     DEL_INST(steam_overlay);
     
     DEL_INST(steam_app_ticket);
+
+    DEL_INST(playtime_counter);
 
     DEL_INST(ugc_bridge);
 

--- a/dll/steam_client.cpp
+++ b/dll/steam_client.cpp
@@ -33,6 +33,8 @@ void Steam_Client::background_thread_proc()
         last_cb_run = now_ms; // update the time counter just to avoid overlap
         network->Run(); // networking must run first since it receives messages used by each run_callback()
         run_every_runcb->run(); // call each run_callback()
+
+        playtime_counter->tick(); // update playtime counter
     }
 }
 
@@ -151,6 +153,8 @@ Steam_Client::Steam_Client()
 
     PRINT_DEBUG("init AppTicket");
     steam_app_ticket = new Steam_AppTicket(settings_client);
+
+    playtime_counter = new PlaytimeCounter(local_storage);
 
     gameserver_has_ipv6_functions = false;
     steamclient_version = 6; // default for C exports

--- a/post_build/steam_settings.EXAMPLE/configs.main.EXAMPLE.ini
+++ b/post_build/steam_settings.EXAMPLE/configs.main.EXAMPLE.ini
@@ -72,6 +72,12 @@ save_only_higher_stat_achievement_progress=1
 #  0=load the icon in memory only when it's requested
 # default=10
 paginated_achievements_icons=10
+# 1=enable the functionality that allows the emu to record the user's playtime
+# this will create a file named "playtime.txt" in the game's GSE Saves folder
+# the recorded playtime will be updated every minute
+# the emu will also resume recording playtime when the game is relaunched
+# default=0
+record_playtime=0
 
 [main::connectivity]
 # 1=prevent hooking OS networking APIs and allow any external requests


### PR DESCRIPTION
This PR allows to record the playtime to a file, it differs from the overlay playtime since this last one is only session wise and not persistent.
The playtime get's saved every 60 seconds in the app's GSE Saves.
A tick function get's called every 300ms from the already existing `background_thread_proc` function.