### PR TITLE
Fix playtime tick not being always called

### DIFF
--- a/dll/playtime.cpp
+++ b/dll/playtime.cpp
@@ -78,8 +78,7 @@ void PlaytimeCounter::load()
     playtime_seconds = 0;
 
     std::string data(32, '\0');
-    if (local_storage->get_data("", playtime_filename, data.data(), static_cast<unsigned int>(data.size()), 0) > 0 &&
-        std::all_of(data.begin(), data.end(), ::isdigit)) {
+    if (local_storage->get_data("", playtime_filename, data.data(), static_cast<unsigned int>(data.size()), 0) > 0) {
         try {
             playtime_seconds = std::stoull(data);
         } catch (...) {}

--- a/dll/steam_client.cpp
+++ b/dll/steam_client.cpp
@@ -33,12 +33,12 @@ void Steam_Client::background_thread_proc()
         network->Run(); // networking must run first since it receives messages used by each run_callback()
         run_every_runcb->run(); // call each run_callback()
 
-        if (settings_client->record_playtime) {
-            playtime_counter->tick(); // update playtime counter
-        }
-
         // update the time counter to avoid overlap
         last_cb_run = (unsigned long long)std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+    }
+
+    if (settings_client->record_playtime) {
+        playtime_counter->tick(); // update playtime counter
     }
 }
 


### PR DESCRIPTION
I noticed that in some games the tick function of the playtime counter doesn't always get called, moving the function outside of the if statement resolved the issue while still making the function call happen once every 300ms
A game that had that problem was Hollow Knight