### PR TITLE
Add `free_weekend` option

### DIFF
--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -366,6 +366,9 @@ public:
     bool overlay_always_show_frametime = false;
     bool overlay_always_show_playtime = false;
 
+    // free weekend
+    bool free_weekend = false;
+
 
 #ifdef LOBBY_CONNECT
     static constexpr const bool is_lobby_connect = true;

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -1549,6 +1549,9 @@ static void parse_simple_features(class Settings *settings_client, class Setting
 
     settings_client->enable_builtin_preowned_ids = ini.GetBoolValue("main::misc", "enable_steam_preowned_ids", settings_client->enable_builtin_preowned_ids);
     settings_server->enable_builtin_preowned_ids = ini.GetBoolValue("main::misc", "enable_steam_preowned_ids", settings_server->enable_builtin_preowned_ids);
+
+    settings_client->free_weekend = ini.GetBoolValue("main::misc", "free_weekend", settings_client->free_weekend);
+    settings_server->free_weekend = ini.GetBoolValue("main::misc", "free_weekend", settings_server->free_weekend);
 }
 
 // [main::stats]

--- a/dll/steam_apps.cpp
+++ b/dll/steam_apps.cpp
@@ -208,7 +208,8 @@ uint32 Steam_Apps::GetEarliestPurchaseUnixTime( AppId_t nAppID )
 bool Steam_Apps::BIsSubscribedFromFreeWeekend()
 {
     PRINT_DEBUG_ENTRY();
-    return false;
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    return settings->free_weekend;
 }
 
 

--- a/post_build/steam_settings.EXAMPLE/configs.main.EXAMPLE.ini
+++ b/post_build/steam_settings.EXAMPLE/configs.main.EXAMPLE.ini
@@ -142,3 +142,6 @@ enable_steam_preowned_ids=0
 # the emu will create the folders if they are missing but the path specified must be writable
 # default=
 steam_game_stats_reports_dir=./path/relative/to/dll/
+# some games may have extra bonuses/achievements when being or playing with a free-weekend player
+# default=0
+free_weekend=0


### PR DESCRIPTION
Some games may have extra bonuses/achievements when being or playing with a free-weekend player. For example, appid 550 (Left 4 Dead 2) contains an achievement "GOOD GUY NICK" unlocked when "Plays games with free weekend players and helps them survive a campaign.". With this new option you can pretend to be a free-weekend player and join whatever servers you can join to help other players unlock this achievement.