### PR TITLE
Add "GseSavePath" env var for overriding emu save path

### DIFF
--- a/dll/local_storage.cpp
+++ b/dll/local_storage.cpp
@@ -477,6 +477,15 @@ std::string Local_Storage::get_game_settings_path()
 
 std::string Local_Storage::get_user_appdata_path()
 {
+    std::string env_save_path = get_env_variable("GseSavePath");
+    if (env_save_path.length()) {
+        if (env_save_path.back() != PATH_SEPARATOR[0]) {
+            env_save_path = env_save_path.append(PATH_SEPARATOR);
+        }
+
+        return env_save_path;
+    }
+
     std::string user_appdata_path("SAVE");
 #if defined(STEAM_WIN32)
     WCHAR szPath[MAX_PATH] = {};

--- a/dll/local_storage.cpp
+++ b/dll/local_storage.cpp
@@ -477,15 +477,6 @@ std::string Local_Storage::get_game_settings_path()
 
 std::string Local_Storage::get_user_appdata_path()
 {
-    std::string env_save_path = get_env_variable("GseSavePath");
-    if (env_save_path.length()) {
-        if (env_save_path.back() != PATH_SEPARATOR[0]) {
-            env_save_path = env_save_path.append(PATH_SEPARATOR);
-        }
-
-        return env_save_path;
-    }
-
     std::string user_appdata_path("SAVE");
 #if defined(STEAM_WIN32)
     WCHAR szPath[MAX_PATH] = {};

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -607,6 +607,17 @@ static uint32 parse_steam_app_id(const std::string &program_path)
 // user::saves::local_save_path
 static bool parse_local_save(std::string &save_path)
 {
+    std::string env_save_path = get_env_variable("GseSavePath");
+    if (env_save_path.length()) {
+        if (env_save_path.back() != *PATH_SEPARATOR) {
+            env_save_path.push_back(*PATH_SEPARATOR);
+        }
+
+        save_path = env_save_path;
+        PRINT_DEBUG("using local save path '%s'", save_path.c_str());
+        return true;
+    }
+
     auto ptr = ini.GetValue("user::saves", "local_save_path");
     if (!ptr || !ptr[0]) return false;
     


### PR DESCRIPTION
Much like the existing env var "GseAppPath" that overrides the emu's program path. This new env var may make it easier for programs like Nucleus Coop or my own PartyDeck that launch multiple instances of games at a time with goldberg. The check for the env var seemed most appropriate in `Local_Storage::get_user_appdata_path()`, but you can let me know if it would be better off as part of a different function.