### PR TITLE
Auto send invites to friends

### DIFF
--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -361,6 +361,10 @@ public:
     bool auto_accept_any_overlay_invites = false;
     // list of user steam IDs to auto-accept invites from
     std::set<uint64_t> auto_accept_overlay_invites_friends{};
+    // whether to auto send any overlay invites
+    bool auto_send_any_overlay_invites = false;
+    // list of user steam IDs to auto-send invites to
+    std::set<uint64_t> auto_send_overlay_invites_friends{};
     bool overlay_always_show_user_info = false;
     bool overlay_always_show_fps = false;
     bool overlay_always_show_frametime = false;
@@ -449,6 +453,12 @@ public:
     void addFriendToOverlayAutoAccept(uint64_t friend_id);
     bool hasOverlayAutoAcceptInviteFromFriend(uint64_t friend_id) const;
     size_t overlayAutoAcceptInvitesCount() const;
+
+    // overlay auto send stuff
+    void autoSendAnyOverlayInvites(bool value);
+    void addFriendToOverlayAutoSend(uint64_t friend_id);
+    bool hasOverlayAutoSendToFriend(uint64_t friend_id) const;
+    size_t overlayAutoSendInvitesCount() const;
 };
 
 #endif // SETTINGS_INCLUDE_H

--- a/dll/settings.cpp
+++ b/dll/settings.cpp
@@ -445,3 +445,26 @@ size_t Settings::overlayAutoAcceptInvitesCount() const
 {
     return auto_accept_overlay_invites_friends.size();
 }
+
+void Settings::autoSendAnyOverlayInvites(bool value)
+{
+    auto_send_any_overlay_invites = value;
+}
+
+void Settings::addFriendToOverlayAutoSend(uint64_t friend_id)
+{
+    auto_send_overlay_invites_friends.insert(friend_id);
+}
+
+bool Settings::hasOverlayAutoSendToFriend(uint64_t friend_id) const
+{
+    if (auto_send_any_overlay_invites) {
+        return true;
+    }
+    return !!auto_send_overlay_invites_friends.count(friend_id);
+}
+
+size_t Settings::overlayAutoSendInvitesCount() const
+{
+    return auto_send_overlay_invites_friends.size();
+}

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -1297,6 +1297,38 @@ static void parse_auto_accept_invite(class Settings *settings_client, class Sett
     }
 }
 
+// auto_send_invite.txt
+static void parse_auto_send_invite(class Settings *settings_client, class Settings *settings_server)
+{
+    std::string auto_send_list_path = Local_Storage::get_game_settings_path() + "auto_send_invite.txt";
+    std::ifstream input( std::filesystem::u8path(auto_send_list_path) );
+    if (input.is_open()) {
+        bool send_any_invite = true;
+        common_helpers::consume_bom(input);
+        for( std::string line; getline( input, line ); ) {
+            line = common_helpers::string_strip(line);
+            if (!line.empty()) {
+                send_any_invite = false;
+                try {
+                    auto friend_id = std::stoull(line);
+                    settings_client->addFriendToOverlayAutoSend((uint64_t)friend_id);
+                    settings_server->addFriendToOverlayAutoSend((uint64_t)friend_id);
+                    PRINT_DEBUG("Adding user with ID (SteamID64) = %llu to auto invite list", friend_id);
+                } catch (...) {}
+            }
+        }
+
+        if (send_any_invite) {
+            PRINT_DEBUG("Auto sending any overlay invitation");
+            settings_client->autoSendAnyOverlayInvites(true);
+            settings_server->autoSendAnyOverlayInvites(true);
+        } else {
+            settings_client->autoSendAnyOverlayInvites(false);
+            settings_server->autoSendAnyOverlayInvites(false);
+        }
+    }
+}
+
 // branches.json
 static bool parse_branches_file(
     const std::string &base_path, const bool force_load,
@@ -1875,6 +1907,7 @@ uint32 create_localstorage_settings(Settings **settings_client_out, Settings **s
     parse_mods_folder(settings_client, settings_server, local_storage);
     load_gamecontroller_settings(settings_client);
     parse_auto_accept_invite(settings_client, settings_server);
+    parse_auto_send_invite(settings_client, settings_server);
     parse_ip_country(local_storage, settings_client, settings_server);
 
     parse_encrypted_app_ticket(settings_client, settings_server);

--- a/dll/steam_friends.cpp
+++ b/dll/steam_friends.cpp
@@ -16,6 +16,7 @@
    <http://www.gnu.org/licenses/>.  */
 
 #include "dll/steam_friends.h"
+#include "dll/dll.h"
 
 #define SEND_FRIEND_RATE 4.0
 
@@ -780,12 +781,23 @@ void Steam_Friends::SetInGameVoiceSpeaking( CSteamID steamIDUser, bool bSpeaking
 
 
 // activates the game overlay, with an optional dialog to open 
-// valid options are "Friends", "Community", "Players", "Settings", "OfficialGameGroup", "Stats", "Achievements"
+// valid options are "Friends", "Community", "Players", "Settings", "OfficialGameGroup", "Stats", "Achievements", "LobbyInvite"
 void Steam_Friends::ActivateGameOverlay( const char *pchDialog )
 {
     PRINT_DEBUG("%s", pchDialog);
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
-    overlay->OpenOverlay(pchDialog);
+
+    if ((strncmp(pchDialog, "LobbyInvite", sizeof("LobbyInvite") - 1) == 0)) {
+        std::string connect_str = get_friend_rich_presence_silent(settings->get_local_steam_id(), "connect");
+
+        if (connect_str.length() > 0) {
+            ActivateGameOverlayInviteDialogConnectString(connect_str.c_str());
+        } else if (settings->get_lobby().IsValid()) {
+            ActivateGameOverlayInviteDialog(settings->get_lobby());
+        }
+    } else {
+        overlay->OpenOverlay(pchDialog);
+    }
 }
 
 
@@ -850,6 +862,18 @@ void Steam_Friends::ActivateGameOverlayInviteDialog( CSteamID steamIDLobby )
 {
     PRINT_DEBUG_ENTRY();
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
+
+    // Invite all friends playing the same game
+    for (auto &fr : friends) {
+        if (settings->hasOverlayAutoSendToFriend(fr.id()) && is_appid_compatible(&fr) && steamIDLobby.IsValid()) {
+            uint64 friend_id = (uint64)fr.id();
+
+            Steam_Matchmaking* steamMatchmaking = get_steam_client()->steam_matchmaking;
+            steamMatchmaking->InviteUserToLobby(steamIDLobby, friend_id);
+            PRINT_DEBUG("sent lobby invitation to friend with id = %llu", friend_id);
+        }
+    }
+
     overlay->OpenOverlayInvite(steamIDLobby);
 }
 
@@ -1359,8 +1383,20 @@ bool Steam_Friends::RegisterProtocolInOverlayBrowser( const char *pchProtocol )
 // Activates the game overlay to open an invite dialog that will send the provided Rich Presence connect string to selected friends
 void Steam_Friends::ActivateGameOverlayInviteDialogConnectString( const char *pchConnectString )
 {
-    PRINT_DEBUG_TODO();
+    PRINT_DEBUG_ENTRY();
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
+
+    // Invite all friends playing the same game
+    for (auto &fr : friends) {
+        if (settings->hasOverlayAutoSendToFriend(fr.id()) && is_appid_compatible(&fr)) {
+            uint64 friend_id = (uint64)fr.id();
+
+            InviteUserToGame(friend_id, pchConnectString);
+            PRINT_DEBUG("sent game invitation to friend with id = %llu", friend_id);
+        }
+    }
+
+    overlay->OpenOverlay("Friends");
 }
 
 // Steam Community items equipped by a user on their profile

--- a/dll/steam_friends.cpp
+++ b/dll/steam_friends.cpp
@@ -865,7 +865,7 @@ void Steam_Friends::ActivateGameOverlayInviteDialog( CSteamID steamIDLobby )
 
     // Invite all friends playing the same game
     for (auto &fr : friends) {
-        if (settings->hasOverlayAutoSendToFriend(fr.id()) && is_appid_compatible(&fr) && steamIDLobby.IsValid()) {
+        if (settings->hasOverlayAutoSendToFriend(fr.id()) && is_appid_compatible(&fr) && steamIDLobby.IsValid() && fr.lobby_id() != settings->get_lobby().ConvertToUint64()) {
             uint64 friend_id = (uint64)fr.id();
 
             Steam_Matchmaking* steamMatchmaking = get_steam_client()->steam_matchmaking;
@@ -1388,7 +1388,7 @@ void Steam_Friends::ActivateGameOverlayInviteDialogConnectString( const char *pc
 
     // Invite all friends playing the same game
     for (auto &fr : friends) {
-        if (settings->hasOverlayAutoSendToFriend(fr.id()) && is_appid_compatible(&fr)) {
+        if (settings->hasOverlayAutoSendToFriend(fr.id()) && is_appid_compatible(&fr) && fr.lobby_id() != settings->get_lobby().ConvertToUint64()) {
             uint64 friend_id = (uint64)fr.id();
 
             InviteUserToGame(friend_id, pchConnectString);

--- a/dll/steam_utils.cpp
+++ b/dll/steam_utils.cpp
@@ -221,7 +221,10 @@ bool Steam_Utils::IsOverlayEnabled()
 {
     PRINT_DEBUG_ENTRY();
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
-    return overlay->Ready();
+    if (overlay->Ready()) return true;
+    else if (settings->auto_send_any_overlay_invites || settings->overlayAutoSendInvitesCount() > 0) return true;
+
+    return false;
 }
 
 


### PR DESCRIPTION
Some games (e.g. Deep Rock Galactic, PEAK) don't have any in-game UI for sending friend invites, and instead activate the overlay with either `Steam_Friends::ActivateGameOverlay("LobbyInvite")`, `Steam_Friends::ActivateGameOverlayInviteDialog(steamIDLobby)` or `Steam_Friends::ActivateGameOverlayInviteDialogConnectString(pchConnectString)` to open a friend invite dialog. Given that the goldberg experimental overlay is not well-supported and even broken on many Linux games, ideally there should be a way to send out invites in these kinds of games without having the overlay enabled at all.

I've added functionality that parses a `steam_settings/auto_send_invites.txt` file. This behaves almost exactly like the `auto_accept_invites.txt` functionality currently in the emu: Having a list of SteamIDs in this file will add them to an auto-send list, and if a game calls one of the three aforementioned API functions, the emu will automatically send lobby invitations to the IDs on that list, as long as they are playing the same appID. If the `auto_send_invites.txt` file is empty, the emu will send out invites to all friends playing the same appID.

In addition, some games (e.g. Left 4 Dead 2) will check if the overlay is enabled by calling `Steam_Utils::IsOverlayEnabled()` before trying to open the invite dialogs, so I've modified `IsOverlayEnabled()` to return true if the `auto_send_invites.txt` file is present, even if the experimental overlay is disabled.

Tested on L4D2 and Deep Rock Galactic.