### PR TITLE
Fix SteamInternal_CreateInterface throw

### DIFF
--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -324,9 +324,12 @@ static void *create_client_interface(const char *ver)
         } else if (strcmp(ver, STEAMCLIENT_INTERFACE_VERSION) == 0) {
             return static_cast<ISteamClient *>(client_ptr);
         }
+
+        client_ptr->report_missing_impl_and_exit(ver, EMU_FUNC_NAME);
     }
     
-    client_ptr->report_missing_impl_and_exit(ver, EMU_FUNC_NAME);
+    // Assuming old games (1110100) and old version of Facepunch.Steamworks call this first then it will throw because this is not here.
+    return get_steam_client()->GetISteamGenericInterface(SteamAPI_GetHSteamUser(), SteamAPI_GetHSteamPipe(), pszVersion);
 }
 
 STEAMAPI_API void * S_CALLTYPE SteamInternal_CreateInterface( const char *ver )

--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -325,11 +325,12 @@ static void *create_client_interface(const char *ver)
             return static_cast<ISteamClient *>(client_ptr);
         }
 
-        client_ptr->report_missing_impl_and_exit(ver, EMU_FUNC_NAME);
+        // report the missing interface if it is a client
+        client_ptr->report_missing_impl(ver, EMU_FUNC_NAME);
     }
     
-    // Assuming old games (1110100) and old version of Facepunch.Steamworks call this first then it will throw because this is not here.
-    return get_steam_client()->GetISteamGenericInterface(SteamAPI_GetHSteamUser(), SteamAPI_GetHSteamPipe(), ver);
+    // Original steam returns 0 here.
+    return nullptr;
 }
 
 STEAMAPI_API void * S_CALLTYPE SteamInternal_CreateInterface( const char *ver )

--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -329,7 +329,7 @@ static void *create_client_interface(const char *ver)
     }
     
     // Assuming old games (1110100) and old version of Facepunch.Steamworks call this first then it will throw because this is not here.
-    return get_steam_client()->GetISteamGenericInterface(SteamAPI_GetHSteamUser(), SteamAPI_GetHSteamPipe(), pszVersion);
+    return get_steam_client()->GetISteamGenericInterface(SteamAPI_GetHSteamUser(), SteamAPI_GetHSteamPipe(), ver);
 }
 
 STEAMAPI_API void * S_CALLTYPE SteamInternal_CreateInterface( const char *ver )

--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -329,6 +329,7 @@ static void *create_client_interface(const char *ver)
         client_ptr->report_missing_impl(ver, EMU_FUNC_NAME);
     }
     
+    PRINT_DEBUG("%s interface is not SteamClient, returning nullptr!", ver);
     // Original steam returns 0 here.
     return nullptr;
 }


### PR DESCRIPTION
Fix SteamInternal_CreateInterface throw when called by NOT Client related interface version