### PR TITLE
Create new connection in `P2p_Manager::accept_session` if needed, and change `old_p2p_packet_sharing_mode` to never share packets by default

### DIFF
--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -202,28 +202,28 @@ struct Branch_Info {
 
 struct OldP2pBehavior {
     enum class EPacketShareMode {
-        // if the sending type is unreliable (UDP), share packets between gameserver and client
-        // otherwise, don't share packets
-        DEFAULT,
-
-        // always share packets between gameserver and client
-        ALWAYS_SHARE,
-
         // never share packets between gameserver and client
         NEVER_SHARE,
+
+        // always share packets between gameserver and client, this is needed for some older games
+        ALWAYS_SHARE,
+
+        // if the sending type is unreliable (UDP), share packets between gameserver and client
+        // otherwise, don't share packets
+        MIXED,
 
         _LAST,
     };
 
     static EPacketShareMode to_share_mode(int val) {
         if (val < 0 || val >= (unsigned)EPacketShareMode::_LAST) {
-            return EPacketShareMode::DEFAULT;
+            return EPacketShareMode::NEVER_SHARE;
         }
 
         return (EPacketShareMode)val;
     }
 
-    EPacketShareMode mode = EPacketShareMode::DEFAULT;
+    EPacketShareMode mode = EPacketShareMode::NEVER_SHARE;
 };
 
 class Settings {

--- a/dll/p2p_manager.cpp
+++ b/dll/p2p_manager.cpp
@@ -274,7 +274,16 @@ std::optional<std::tuple<
 
             switch (my_settings->old_p2p_behavior.mode) {
             default:
-            case OldP2pBehavior::EPacketShareMode::DEFAULT: {
+            case OldP2pBehavior::EPacketShareMode::NEVER_SHARE: {
+                can_share_packet = false;
+            }
+
+            case OldP2pBehavior::EPacketShareMode::ALWAYS_SHARE: {
+                can_share_packet = true;
+            }
+            break;
+
+            case OldP2pBehavior::EPacketShareMode::MIXED: {
                 // appids (353090, 301300) do this:
                 // - send packet from client >>> to gameserver
                 // - use the **client** to check for these packets
@@ -286,18 +295,8 @@ std::optional<std::tuple<
                 // and they do not need the gameserver to share its packets with the client
                 // even multiplayer in appid 248390 won't work if packets were shared
                 can_share_packet =
-                    packet_it->send_type == EP2PSend::k_EP2PSendUnreliable ||
-                    packet_it->send_type == EP2PSend::k_EP2PSendUnreliableNoDelay;
-            }
-            break;
-
-            case OldP2pBehavior::EPacketShareMode::ALWAYS_SHARE: {
-                can_share_packet = true;
-            }
-            break;
-            
-            case OldP2pBehavior::EPacketShareMode::NEVER_SHARE: {
-                can_share_packet = false;
+                    EP2PSend::k_EP2PSendUnreliable == packet_it->send_type ||
+                    EP2PSend::k_EP2PSendUnreliableNoDelay == packet_it->send_type;
             }
             break;
             }

--- a/dll/p2p_manager.cpp
+++ b/dll/p2p_manager.cpp
@@ -544,15 +544,27 @@ bool P2p_Manager::accept_session(CSteamID my_id, CSteamID steamIDRemote)
 {
     std::lock_guard lock(p2p_mtx);
 
-    auto conn = get_connection(steamIDRemote, my_id);
-    if (!conn) {
-        PRINT_DEBUG("[X] no connection from=[%llu], I am=[%llu]", steamIDRemote.ConvertToUint64(), my_id.ConvertToUint64());
+    // https://partner.steamgames.com/doc/api/ISteamNetworking#AcceptP2PSessionWithUser
+    // "Returns: bool
+    // true upon success; false only if steamIDRemote is invalid."
+    if (!steamIDRemote.IsValid()) {
+        PRINT_DEBUG(
+            "[X] bad remote steam ID [%llu], I am=[%llu]",
+            steamIDRemote.ConvertToUint64(), my_id.ConvertToUint64()
+        );
         return false;
     }
 
+    // NOTE: don't call get_connection() here, appid 632360 attempts to close the connection first
+    // by calling Steam_Networking::CloseP2PSessionWithUser(), before calling this function!
+    // and it expects success
+    auto conn = create_connection(steamIDRemote, my_id);
     if (!conn->is_accepted) {
         conn->is_accepted = true;
-        PRINT_DEBUG("accepted new session from=[%llu], I am=[%llu]", steamIDRemote.ConvertToUint64(), my_id.ConvertToUint64());    
+        PRINT_DEBUG(
+            "accepted new session from=[%llu], I am=[%llu]",
+            steamIDRemote.ConvertToUint64(), my_id.ConvertToUint64()
+        );
     }
     return true;
 }
@@ -690,9 +702,8 @@ void P2p_Manager::network_low_level(Common_Message *msg)
     const CSteamID my_dest_id = (uint64)msg->dest_id(); // this is us
 
     switch (msg->low_level().type()) {
-        case Low_Level::CONNECT: {
-
-        }
+        case Low_Level::CONNECT:
+        // nothing
         break;
 
         case Low_Level::DISCONNECT: {

--- a/post_build/steam_settings.EXAMPLE/configs.main.EXAMPLE.ini
+++ b/post_build/steam_settings.EXAMPLE/configs.main.EXAMPLE.ini
@@ -133,9 +133,9 @@ download_steamhttp_requests=0
 # other games won't work properly if the packets were shared,
 # and the original receiver (either gameserver or client) must handle that packet
 #
-# 0=share packets flagged as "unreliable" (k_EP2PSendUnreliable | k_EP2PSendUnreliableNoDelay), otherwise don't share packets
-# 1=always share the packets
-# 2=never share the packets
+# 0=never share the packets
+# 1=always share the packets, this is needed for some older games
+# 2=(mixed) share packets flagged as "unreliable" (k_EP2PSendUnreliable | k_EP2PSendUnreliableNoDelay), otherwise don't share packets
 # default=0
 old_p2p_packet_sharing_mode=0
 


### PR DESCRIPTION
Should fix #396 , didn't test it though.