### PR TITLE
fix crash in `lobby_connect`

### DIFF
--- a/dll/settings_parser_ufs.cpp
+++ b/dll/settings_parser_ufs.cpp
@@ -268,16 +268,21 @@ void parse_cloud_save(CSimpleIniA *ini, class Settings *settings_client, class S
         auto default_cloud_dir = factory_default_cloud_dir(ini, settings_client, settings_server, local_storage);
         if (default_cloud_dir.empty()) {
             PRINT_DEBUG("[X] cannot resolve default cloud save dir");
-        } else if (std::filesystem::is_directory(default_cloud_dir) || std::filesystem::create_directories(default_cloud_dir)) {
-            PRINT_DEBUG(
-                "successfully created default cloud save dir '%s'",
-                default_cloud_dir.u8string().c_str()
-            );
-        } else {
-            PRINT_DEBUG(
-                "[X] failed to create default cloud save dir '%s'",
-                default_cloud_dir.u8string().c_str()
-            );
+        } else if (!std::filesystem::is_directory(default_cloud_dir)) {
+            std::error_code ec;
+            if (std::filesystem::create_directories(default_cloud_dir, ec)) {
+                PRINT_DEBUG(
+                    "successfully created default cloud save dir '%s'",
+                    default_cloud_dir.u8string().c_str()
+                );
+            } else {
+                PRINT_DEBUG(
+                    "[X] failed to create default cloud save dir '%s': '%s'",
+                    default_cloud_dir.u8string().c_str(),
+                    ec.message().c_str()
+                );
+                // TODO crash the program here, or just print and move on?
+            }
         }
     }
 

--- a/dll/settings_parser_ufs.cpp
+++ b/dll/settings_parser_ufs.cpp
@@ -270,12 +270,11 @@ void parse_cloud_save(CSimpleIniA *ini, class Settings *settings_client, class S
             PRINT_DEBUG("[X] cannot resolve default cloud save dir");
         } else if (!std::filesystem::is_directory(default_cloud_dir)) {
             try {
-                if (std::filesystem::create_directories(default_cloud_dir)) {
-                    PRINT_DEBUG(
-                        "successfully created default cloud save dir '%s'",
-                        default_cloud_dir.u8string().c_str()
-                    );
-                }
+                std::filesystem::create_directories(default_cloud_dir);
+                PRINT_DEBUG(
+                    "successfully created default cloud save dir '%s'",
+                    default_cloud_dir.u8string().c_str()
+                );
             } catch (const std::filesystem::filesystem_error& e) {
                 PRINT_DEBUG(
                     "[X] failed to create default cloud save dir '%s': '%s'",

--- a/dll/settings_parser_ufs.cpp
+++ b/dll/settings_parser_ufs.cpp
@@ -269,17 +269,18 @@ void parse_cloud_save(CSimpleIniA *ini, class Settings *settings_client, class S
         if (default_cloud_dir.empty()) {
             PRINT_DEBUG("[X] cannot resolve default cloud save dir");
         } else if (!std::filesystem::is_directory(default_cloud_dir)) {
-            std::error_code ec;
-            if (std::filesystem::create_directories(default_cloud_dir, ec)) {
-                PRINT_DEBUG(
-                    "successfully created default cloud save dir '%s'",
-                    default_cloud_dir.u8string().c_str()
-                );
-            } else {
+            try {
+                if (std::filesystem::create_directories(default_cloud_dir)) {
+                    PRINT_DEBUG(
+                        "successfully created default cloud save dir '%s'",
+                        default_cloud_dir.u8string().c_str()
+                    );
+                }
+            } catch (const std::filesystem::filesystem_error& e) {
                 PRINT_DEBUG(
                     "[X] failed to create default cloud save dir '%s': '%s'",
                     default_cloud_dir.u8string().c_str(),
-                    ec.message().c_str()
+                    e.what()
                 );
                 // TODO crash the program here, or just print and move on?
             }

--- a/dll/settings_parser_ufs.cpp
+++ b/dll/settings_parser_ufs.cpp
@@ -282,7 +282,6 @@ void parse_cloud_save(CSimpleIniA *ini, class Settings *settings_client, class S
                     default_cloud_dir.u8string().c_str(),
                     e.what()
                 );
-                // TODO crash the program here, or just print and move on?
             }
         }
     }


### PR DESCRIPTION
Closes https://github.com/Detanup01/gbe_fork/issues/389

output in `STEAM_LOG`: `parse_cloud_save() [X] failed to create default cloud save dir ' \userdata\852830572\16777214': 'create_directories: The system cannot find the path specified.: " \userdata\852830572\16777214"'`

There is probably another underlying issue that causes this exception, but at least now the tool runs.