### PR TITLE
Fire Steam2 deny callback for denied Steam2 auth requests

### DIFF
--- a/dll/auth.cpp
+++ b/dll/auth.cpp
@@ -691,18 +691,18 @@ void Auth_Manager::launch_callback_gs_steam2(CSteamID steam_id, uint32_t user_id
         data3.m_SteamID = data3.m_OwnerSteamID = steam_id;
         callbacks->addCBResult(data3.k_iCallback, &data3, sizeof(data3), STEAM_TICKET_PROCESS_TIME * 2.0);
     } else {
-        /*
+        // Fire Steam2 callback. Only one of these is actually needed to kick the client.
         GSClientSteam2Deny_t data2{};
         data2.m_UserID = user_id;
-        data2.m_eSteamError = k_EDenyNotLoggedOn;
+        data2.m_eSteamError = k_EDenyNotLoggedOn; //TODO: other reasons?
         callbacks->addCBResult(data2.k_iCallback, &data2, sizeof(data2), STEAM_TICKET_PROCESS_TIME);
-        */
 
-        // Fire Steam3 callback. Only one of these is actually needed to kick the client.
+        /*
         GSClientDeny_t data3{};
         data3.m_SteamID = steam_id;
-        data3.m_eDenyReason = k_EDenyNotLoggedOn; //TODO: other reasons?
-        callbacks->addCBResult(data3.k_iCallback, &data3, sizeof(data3), STEAM_TICKET_PROCESS_TIME);
+        data3.m_eDenyReason = k_EDenyNotLoggedOn;
+        callbacks->addCBResult(data3.k_iCallback, &data3, sizeof(data3), STEAM_TICKET_PROCESS_TIME * 2.0);
+        */
     }
 }
 


### PR DESCRIPTION
It has occurred to me that only firing GSClientDeny_t will not work here because it references client by SteamID which is supposed to be assigned by GSClientSteam2Accept_t. I don't know why I changed this snippet last time so I just reverted it back to the old behavior where it only fires GSClientSteam2Deny_t.

This function is never actually called with "false" argument anywhere but it doesn't hurt to future-proof this.