### PR TITLE
Fully implement Steam_GameServer::BGetUserAchievementStatus

### DIFF
--- a/dll/dll/steam_gameserverstats.h
+++ b/dll/dll/steam_gameserverstats.h
@@ -40,6 +40,14 @@ public ISteamGameServerStats
 		bool timeout = false;
 	};
 
+    struct RequestAchievement {
+        std::chrono::high_resolution_clock::time_point created{};
+        CSteamID steamIDUser{};
+        std::string achievement_name;
+
+        bool timeout = false;
+    };
+
 	struct CachedStat {
 		bool dirty = false; // true means it was changed on the server and should be sent to the user
 		StatInfo stat{};
@@ -55,6 +63,7 @@ public ISteamGameServerStats
 	};
 
 	std::vector<RequestAllStats> pending_RequestUserStats{};
+	std::vector<RequestAchievement> pending_RequestAchievement{};
 	std::map<uint64, UserData> all_users_data{};
 
 	CachedStat* find_stat(CSteamID steamIDUser, const std::string &key);
@@ -67,6 +76,7 @@ public ISteamGameServerStats
 	// reponses from player
 	void network_callback_initial_stats(Common_Message *msg);
 	void network_callback_updated_stats(Common_Message *msg);
+	void network_callback_achievement_response(Common_Message *msg);
 	void network_callback(Common_Message *msg);
 
 	// user connect/disconnect
@@ -79,6 +89,8 @@ public ISteamGameServerStats
 public:
 	Steam_GameServerStats(class Settings *settings, class Networking *network, class SteamCallResults *callback_results, class SteamCallBacks *callbacks, class RunEveryRunCB *run_every_runcb);
 	~Steam_GameServerStats();
+
+    bool request_user_achievement(CSteamID steamIDUser, const char *ach_name);
 	
 	// downloads stats for the user
 	// returns a GSStatsReceived_t callback when completed

--- a/dll/dll/steam_user_stats.h
+++ b/dll/dll/steam_user_stats.h
@@ -157,6 +157,7 @@ private:
     // requests from server
     void network_stats_initial(Common_Message *msg);
     void network_stats_updated(Common_Message *msg);
+    void network_achievement_request(Common_Message *msg);
     void network_callback_stats(Common_Message *msg);
 
     // requests from other users to share leaderboards

--- a/dll/net.proto
+++ b/dll/net.proto
@@ -254,6 +254,15 @@ message GameServerStats_Messages {
         // optional because the server send doesn't send any data, just steam api call id
         optional AllStats all_data = 2;
     }
+
+    message AchievementRequest {
+        string name = 1;
+    }
+    message AchievementResponse {
+        string name = 1;
+        AchievementInfo info = 2;
+    }
+
     // Request_: from Steam_GameServerStats
     // Response_: from Steam_User_Stats
     enum Types {
@@ -262,12 +271,17 @@ message GameServerStats_Messages {
 
         UpdateUserStatsFromServer = 2; // sent by Steam_GameServerStats
         UpdateUserStatsFromUser = 3; // sent by Steam_User_Stats
+
+        Request_UserAchievement = 4;
+        Response_UserAchievement = 5;
     }
 
-	Types type = 1;
+    Types type = 1;
     oneof data_messages {
         InitialAllStats initial_user_stats = 2;
         AllStats update_user_stats = 3;
+        AchievementRequest achievement_request = 4;
+        AchievementResponse achievement_response = 5;
     }
 }
 

--- a/dll/steam_gameserver.cpp
+++ b/dll/steam_gameserver.cpp
@@ -17,6 +17,7 @@
 
 #include "dll/steam_gameserver.h"
 #include "dll/source_query.h"
+#include "dll/dll.h"
 
 #define SEND_SERVER_RATE 5.0
 
@@ -568,15 +569,10 @@ void Steam_GameServer::SetGameType( const char *pchGameType )
 // Ask if a user has a specific achievement for this game, will get a callback on reply
 bool Steam_GameServer::BGetUserAchievementStatus( CSteamID steamID, const char *pchAchievementName )
 {
-    PRINT_DEBUG("%llu %s", steamID.ConvertToUint64(), pchAchievementName);
+    PRINT_DEBUG("%llu '%s'", steamID.ConvertToUint64(), pchAchievementName);
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
-    GSClientAchievementStatus_t data = {};
-    data.m_bUnlocked = true;
-    data.m_SteamID = steamID.ConvertToUint64();
-    strncpy(data.m_pchAchievement, pchAchievementName, sizeof(data.m_pchAchievement) - 1);
-    callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
-    return true;
+    return get_steam_client()->steam_gameserverstats->request_user_achievement(steamID, pchAchievementName);
 }
 
 // New auth system APIs - do not mix with the old auth system APIs.

--- a/dll/steam_gameserverstats.cpp
+++ b/dll/steam_gameserverstats.cpp
@@ -106,6 +106,45 @@ Steam_GameServerStats::~Steam_GameServerStats()
     }
 }
 
+bool Steam_GameServerStats::request_user_achievement(CSteamID steamIDUser, const char *ach_name)
+{
+    std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    if (settings->disable_sharing_stats_with_gameserver) return false;
+    if (!ach_name) return false;
+
+    auto ach = find_ach(steamIDUser, ach_name);
+    if (ach) {
+        GSClientAchievementStatus_t data{};
+        data.m_bUnlocked = ach->ach.achieved();
+        data.m_SteamID = steamIDUser.ConvertToUint64();
+        strncpy(data.m_pchAchievement, ach_name, sizeof(data.m_pchAchievement) - 1);
+        callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
+        return true;
+    }
+
+    struct RequestAchievement new_request{};
+    new_request.created = std::chrono::high_resolution_clock::now();
+    new_request.steamIDUser = steamIDUser;
+    new_request.achievement_name = ach_name;
+
+    pending_RequestAchievement.push_back(new_request);
+
+    auto ach_request_msg = new GameServerStats_Messages::AchievementRequest();
+    ach_request_msg->set_name(ach_name);
+
+    auto gameserverstats_msg = new GameServerStats_Messages();
+    gameserverstats_msg->set_type(GameServerStats_Messages::Request_UserAchievement);
+    gameserverstats_msg->set_allocated_achievement_request(ach_request_msg);
+
+    Common_Message msg{};
+    msg.set_allocated_gameserver_stats_messages(gameserverstats_msg);
+    msg.set_source_id(settings->get_local_steam_id().ConvertToUint64());
+    msg.set_dest_id(steamIDUser.ConvertToUint64());
+    network->sendTo(&msg, true);
+
+    return true;
+}
+
 
 // downloads stats for the user
 // returns a GSStatsReceived_t callback when completed
@@ -363,8 +402,6 @@ SteamAPICall_t Steam_GameServerStats::StoreUserStats( CSteamID steamIDUser )
 
 void Steam_GameServerStats::remove_timedout_userstats_requests()
 {
-    if (pending_RequestUserStats.empty()) return;
-
     // send all pending RequestUserStats() requests
     for (auto &pendReq : pending_RequestUserStats) {
         if (check_timedout(pendReq.created, PENDING_RequestUserStats_TIMEOUT)) {
@@ -387,6 +424,28 @@ void Steam_GameServerStats::remove_timedout_userstats_requests()
         [](const struct RequestAllStats &item) { return item.timeout; }
     );
     pending_RequestUserStats.erase(itrm, pending_RequestUserStats.end());
+
+    // send all pending BGetUserAchievementStatus requests
+    for (auto &pendReq : pending_RequestAchievement) {
+        if (check_timedout(pendReq.created, PENDING_RequestUserStats_TIMEOUT)) {
+            pendReq.timeout = true;
+
+            GSClientAchievementStatus_t data{};
+            data.m_bUnlocked = false;
+            data.m_SteamID = pendReq.steamIDUser.ConvertToUint64();
+            pendReq.achievement_name.copy(data.m_pchAchievement, sizeof(data.m_pchAchievement) - 1);
+            callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
+
+            PRINT_DEBUG("BGetUserAchievementStatus timeout, %llu", pendReq.steamIDUser.ConvertToUint64());
+        }
+    }
+
+    // remove all timedout requests
+    auto itrm2 = std::remove_if(
+        pending_RequestAchievement.begin(), pending_RequestAchievement.end(),
+        [](const struct RequestAchievement &item) { return item.timeout; }
+    );
+    pending_RequestAchievement.erase(itrm2, pending_RequestAchievement.end());
 }
 
 void Steam_GameServerStats::collect_and_send_updated_user_stats()
@@ -519,8 +578,6 @@ void Steam_GameServerStats::network_callback_initial_stats(Common_Message *msg)
     PRINT_DEBUG("server got all player stats %llu: %zu stats, %zu achievements",
         user_steamid, all_users_data[user_steamid].stats.size(), all_users_data[user_steamid].achievements.size()
     );
-
-    
 }
 
 // user has updated/new stats
@@ -556,6 +613,50 @@ void Steam_GameServerStats::network_callback_updated_stats(Common_Message *msg)
     );
 }
 
+// user responded with achievement status
+void Steam_GameServerStats::network_callback_achievement_response(Common_Message *msg)
+{
+    uint64 user_steamid = msg->source_id();
+
+    PRINT_DEBUG("player returned achievement %llu", user_steamid);
+    if (!msg->gameserver_stats_messages().has_achievement_response()) {
+        PRINT_DEBUG("error empty msg");
+        return;
+    }
+
+    const auto &ach_response_msg = msg->gameserver_stats_messages().achievement_response();
+    std::string ach_name = ach_response_msg.name();
+    const auto &ach_info = ach_response_msg.info();
+
+    // find this pending request
+    auto it = std::find_if(
+        pending_RequestAchievement.begin(), pending_RequestAchievement.end(),
+        [=](const RequestAchievement &item) {
+            return item.steamIDUser == user_steamid &&
+                item.achievement_name == ach_name;
+        }
+    );
+    if (pending_RequestAchievement.end() == it) { // timeout and already removed
+        PRINT_DEBUG("error got player achievement but pending request timedout/removed (doesn't exist)");
+        return;
+    }
+
+    all_users_data[user_steamid].achievements[ach_name].ach = ach_info;
+
+    GSClientAchievementStatus_t data{};
+    data.m_bUnlocked = ach_info.achieved();
+    data.m_SteamID = user_steamid;
+    ach_name.copy(data.m_pchAchievement, sizeof(data.m_pchAchievement) - 1);
+    callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
+
+    // remove this pending request
+    pending_RequestAchievement.erase(it);
+
+    PRINT_DEBUG("server got player achievement %llu: '%s' %s",
+        user_steamid, ach_name.c_str(), ach_info.achieved() ? "earned" : "unearned"
+    );
+}
+
 // only triggered when we have a message
 void Steam_GameServerStats::network_callback(Common_Message *msg)
 {
@@ -572,6 +673,11 @@ void Steam_GameServerStats::network_callback(Common_Message *msg)
     // user has updated/new stats
     case GameServerStats_Messages::UpdateUserStatsFromUser:
         network_callback_updated_stats(msg);
+    break;
+
+    // user responded with achievement status
+    case GameServerStats_Messages::Response_UserAchievement:
+        network_callback_achievement_response(msg);
     break;
     
     default:
@@ -596,6 +702,7 @@ void Steam_GameServerStats::network_callback_low_level(Common_Message *msg)
     
     case Low_Level::DISCONNECT: {
         all_users_data.erase(steamid);
+
         auto it_rm = std::remove_if(
             pending_RequestUserStats.begin(), pending_RequestUserStats.end(),
             [=](const RequestAllStats &item) { return item.steamIDUser.ConvertToUint64() == steamid; }
@@ -610,6 +717,21 @@ void Steam_GameServerStats::network_callback_low_level(Common_Message *msg)
             
             PRINT_DEBUG("RequestUserStats timeout, %llu", it_rm->steamIDUser.ConvertToUint64());
             it_rm = pending_RequestUserStats.erase(it_rm);
+        }
+
+        auto it_rm2 = std::remove_if(
+            pending_RequestAchievement.begin(), pending_RequestAchievement.end(),
+            [=](const RequestAchievement &item) { return item.steamIDUser.ConvertToUint64() == steamid; }
+        );
+        while (pending_RequestAchievement.end() != it_rm2) {
+            GSClientAchievementStatus_t data{};
+            data.m_bUnlocked = false;
+            data.m_SteamID = it_rm2->steamIDUser.ConvertToUint64();
+            it_rm2->achievement_name.copy(data.m_pchAchievement, sizeof(data.m_pchAchievement) - 1);
+            callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
+
+            PRINT_DEBUG("BGetUserAchievementStatus timeout, %llu", it_rm2->steamIDUser.ConvertToUint64());
+            it_rm2 = pending_RequestAchievement.erase(it_rm2);
         }
         
         // PRINT_DEBUG("removed user %llu", steamid);

--- a/dll/steam_gameserverstats.cpp
+++ b/dll/steam_gameserverstats.cpp
@@ -491,9 +491,6 @@ void Steam_GameServerStats::network_callback_initial_stats(Common_Message *msg)
         PRINT_DEBUG("error got all player stats but pending request timedout/removed (doesn't exist)");
         return;
     }
-
-    // remove this pending request
-    pending_RequestUserStats.erase(it);
     
     // copy new stats
     auto &current_stats = all_users_data[user_steamid].stats;
@@ -515,6 +512,9 @@ void Steam_GameServerStats::network_callback_initial_stats(Common_Message *msg)
 
     callback_results->addCallResult(it->steamAPICall, data.k_iCallback, &data, sizeof(data));
     callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
+
+    // remove this pending request
+    pending_RequestUserStats.erase(it);
     
     PRINT_DEBUG("server got all player stats %llu: %zu stats, %zu achievements",
         user_steamid, all_users_data[user_steamid].stats.size(), all_users_data[user_steamid].achievements.size()

--- a/dll/steam_user_stats_stats.cpp
+++ b/dll/steam_user_stats_stats.cpp
@@ -899,6 +899,40 @@ void Steam_User_Stats::network_stats_updated(Common_Message *msg)
     );
 }
 
+// server requested achievement status
+void Steam_User_Stats::network_achievement_request(Common_Message *msg)
+{
+    if (!msg->gameserver_stats_messages().has_achievement_request()) {
+        PRINT_DEBUG("error empty msg");
+        return;
+    }
+
+    uint64 server_steamid = msg->source_id();
+
+    const auto &ach_request_msg = msg->gameserver_stats_messages().achievement_request();
+    std::string ach_name = ach_request_msg.name();
+    bool achieved = false;
+    GetAchievement(ach_name.c_str(), &achieved);
+
+    auto ach_response_msg = new GameServerStats_Messages::AchievementResponse();
+    ach_response_msg->set_name(ach_name);
+    auto ach_info = new GameServerStats_Messages::AchievementInfo();
+    ach_info->set_achieved(achieved);
+    ach_response_msg->set_allocated_info(ach_info);
+
+    auto gameserverstats_msg = new GameServerStats_Messages();
+    gameserverstats_msg->set_type(GameServerStats_Messages::Response_UserAchievement);
+    gameserverstats_msg->set_allocated_achievement_response(ach_response_msg);
+
+    Common_Message new_msg{};
+    new_msg.set_allocated_gameserver_stats_messages(gameserverstats_msg);
+    new_msg.set_source_id(settings->get_local_steam_id().ConvertToUint64());
+    new_msg.set_dest_id(server_steamid);
+    network->sendTo(&new_msg, true);
+
+    PRINT_DEBUG("server requested achievement '%s'", ach_name.c_str());
+}
+
 void Steam_User_Stats::send_pending_user_stats_requests()
 {
     if (!pending_user_stats_requests.empty()) {
@@ -1006,6 +1040,11 @@ void Steam_User_Stats::network_callback_stats(Common_Message *msg)
     // a user has updated/new stats
     case GameServerStats_Messages::UpdateUserStatsFromUser:
         // nothing
+    break;
+
+    // server requested achievement status
+    case GameServerStats_Messages::Request_UserAchievement:
+        network_achievement_request(msg);
     break;
     
     default:


### PR DESCRIPTION
This adds a full implementation for Steam_GameServer::BGetUserAchievementStatus with the server requesting achievement status from the client over P2P system.