### PR TITLE
Various fixes

### DIFF
--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -1498,29 +1498,29 @@ SteamMasterServerUpdater
 */
 
 
-STEAMCLIENT_API steam_bool Steam_BGetCallback( HSteamPipe hSteamPipe, CallbackMsg_t *pCallbackMsg )
+bool steamclient_get_callback(HSteamPipe hSteamPipe, CallbackMsg_t *pCallbackMsg)
 {
-    PRINT_DEBUG("%i", hSteamPipe);
     SteamAPI_ManualDispatch_Init();
     Steam_Client *steam_client = get_steam_client();
     steam_client->RunCallbacks(true, true);
-    return SteamAPI_ManualDispatch_GetNextCallback( hSteamPipe, pCallbackMsg );
+    return SteamAPI_ManualDispatch_GetNextCallback(hSteamPipe, pCallbackMsg);
+}
+
+void steamclient_free_callback(HSteamPipe hSteamPipe)
+{
+    SteamAPI_ManualDispatch_FreeLastCallback(hSteamPipe);
+}
+
+STEAMCLIENT_API steam_bool Steam_BGetCallback( HSteamPipe hSteamPipe, CallbackMsg_t *pCallbackMsg )
+{
+    PRINT_DEBUG("%i", hSteamPipe);
+    return steamclient_get_callback(hSteamPipe, pCallbackMsg);
 }
 
 STEAMCLIENT_API void Steam_FreeLastCallback( HSteamPipe hSteamPipe )
 {
     //PRINT_DEBUG("%i", hSteamPipe);
-    SteamAPI_ManualDispatch_FreeLastCallback( hSteamPipe );
-}
-
-bool steamclient_get_callback(HSteamPipe hSteamPipe, CallbackMsg_t *pCallbackMsg)
-{
-    return Steam_BGetCallback(hSteamPipe, pCallbackMsg);
-}
-
-void steamclient_free_callback(HSteamPipe hSteamPipe)
-{
-    return Steam_FreeLastCallback(hSteamPipe);
+    steamclient_free_callback(hSteamPipe);
 }
 
 STEAMCLIENT_API steam_bool Steam_GetAPICallResult( HSteamPipe hSteamPipe, SteamAPICall_t hSteamAPICall, void* pCallback, int cubCallback, int iCallbackExpected, bool* pbFailed )

--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -211,15 +211,6 @@ static void load_old_steam_interfaces()
     reset_LastError();
 }
 
-//steam_api_internal.h
-STEAMAPI_API HSteamUser SteamAPI_GetHSteamUser()
-{
-    PRINT_DEBUG_ENTRY();
-    if (!get_steam_client()->IsUserLogIn()) return 0;
-    return CLIENT_HSTEAMUSER;
-}
-
-
 // declare "g_pSteamClientGameServer" as an export for API library, then actually define it
 #if !defined(STEAMCLIENT_DLL) // api
 STEAMAPI_API ISteamClient *g_pSteamClientGameServer;
@@ -688,6 +679,8 @@ STEAMAPI_API void Steam_RegisterInterfaceFuncs( void *hModule )
     PRINT_DEBUG_TODO();
 }
 
+STEAMAPI_API HSteamUser SteamAPI_GetHSteamUser();
+
 // returns the HSteamUser of the last user to dispatch a callback
 STEAMAPI_API HSteamUser Steam_GetHSteamUserCurrent()
 {
@@ -712,6 +705,14 @@ STEAMAPI_API const char *SteamAPI_GetSteamInstallPath()
 
     PRINT_DEBUG("returned path '%s'", steam_folder);
     return steam_folder;
+}
+
+//steam_api_internal.h
+STEAMAPI_API HSteamUser SteamAPI_GetHSteamUser()
+{
+    PRINT_DEBUG_ENTRY();
+    if (!steamclient_instance || !get_steam_client()->IsUserLogIn()) return 0;
+    return CLIENT_HSTEAMUSER;
 }
 
 // returns the pipe we are communicating to Steam with
@@ -757,7 +758,7 @@ STEAMAPI_API ISteamClient *SteamClient()
     return (ISteamClient *)SteamInternal_CreateInterface(old_client);
 }
 
-#define CACHE_OLDSTEAM_INSTANCE(variable, get_func) { if (variable) return variable; else return variable = (get_func); }
+#define CACHE_OLDSTEAM_INSTANCE(variable, get_func) { if (!steamclient_instance) return nullptr; if (variable) return variable; else return variable = (get_func); }
 
 STEAMAPI_API ISteamUser *SteamUser()
 {
@@ -960,6 +961,7 @@ STEAMAPI_API HSteamPipe S_CALLTYPE SteamGameServer_GetHSteamPipe()
 STEAMAPI_API HSteamUser S_CALLTYPE SteamGameServer_GetHSteamUser()
 {
     PRINT_DEBUG_ENTRY();
+    if (!steamclient_instance) return 0;
     if (!get_steam_client()->IsServerInit()) return 0;
     return SERVER_HSTEAMUSER;
 }
@@ -1197,12 +1199,14 @@ STEAMAPI_API void SteamGameServer_RunCallbacks()
 STEAMAPI_API steam_bool SteamGameServer_BSecure()
 {
     PRINT_DEBUG_ENTRY();
+    if (!steamclient_instance) return false;
     return get_steam_client()->steam_gameserver->BSecure();
 }
 
 STEAMAPI_API uint64 SteamGameServer_GetSteamID()
 {
     PRINT_DEBUG_ENTRY();
+    if (!steamclient_instance) return 0;
     return get_steam_client()->steam_gameserver->GetSteamID().ConvertToUint64();
 }
 
@@ -1215,6 +1219,7 @@ STEAMAPI_API ISteamClient *SteamGameServerClient()
 
 STEAMAPI_API uint32 SteamGameServer_GetIPCCallCount()
 {
+    if (!steamclient_instance) return 0;
     return get_steam_client()->GetIPCCallCount();
 }
 

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -523,40 +523,12 @@ static uint32 parse_steam_app_id(const std::string &program_path)
 {
     uint32 appid = 0;
 
-    // try steam_settings folder
-    char array[10] = {};
-    array[0] = '0';
-    Local_Storage::get_file_data(Local_Storage::get_game_settings_path() + "steam_appid.txt", array, sizeof(array) - 1);
-    try {
-        appid = std::stoul(array);
-    } catch (...) {}
-
-    // try current dir
-    if (!appid) {
-        memset(array, 0, sizeof(array));
-        array[0] = '0';
-        Local_Storage::get_file_data("steam_appid.txt", array, sizeof(array) - 1);
-        try {
-            appid = std::stoul(array);
-        } catch (...) {}
-    }
-
-    // try exe dir
-    if (!appid) {
-        memset(array, 0, sizeof(array));
-        array[0] = '0';
-        Local_Storage::get_file_data(program_path + "steam_appid.txt", array, sizeof(array) - 1);
-        try {
-            appid = std::stoul(array);
-        } catch (...) {}
-    }
-
     // try env vars
     if (!appid) {
         std::string str_appid = get_env_variable("SteamAppId");
         std::string str_gameid = get_env_variable("SteamGameId");
         std::string str_overlay_gameid = get_env_variable("SteamOverlayGameId");
-        
+
         PRINT_DEBUG("str_appid %s str_gameid: %s str_overlay_gameid: %s", str_appid.c_str(), str_gameid.c_str(), str_overlay_gameid.c_str());
         uint32 appid_env = 0;
         uint32 gameid_env = 0;
@@ -598,6 +570,34 @@ static uint32 parse_steam_app_id(const std::string &program_path)
         if (overlay_gameid) {
             appid = overlay_gameid;
         }
+    }
+
+    // try steam_settings folder
+    char array[10] = {};
+    array[0] = '0';
+    Local_Storage::get_file_data(Local_Storage::get_game_settings_path() + "steam_appid.txt", array, sizeof(array) - 1);
+    try {
+        appid = std::stoul(array);
+    } catch (...) {}
+
+    // try current dir
+    if (!appid) {
+        memset(array, 0, sizeof(array));
+        array[0] = '0';
+        Local_Storage::get_file_data("steam_appid.txt", array, sizeof(array) - 1);
+        try {
+            appid = std::stoul(array);
+        } catch (...) {}
+    }
+
+    // try exe dir
+    if (!appid) {
+        memset(array, 0, sizeof(array));
+        array[0] = '0';
+        Local_Storage::get_file_data(program_path + "steam_appid.txt", array, sizeof(array) - 1);
+        try {
+            appid = std::stoul(array);
+        } catch (...) {}
     }
 
     PRINT_DEBUG("final appid = %u", appid);

--- a/dll/steam_gameserver.cpp
+++ b/dll/steam_gameserver.cpp
@@ -582,6 +582,13 @@ bool Steam_GameServer::BSetServerType( uint32 unServerFlags, uint32 unGameIP, ui
 
     flags = unServerFlags;
 
+    if (bLANMode) {
+        flags &= ~k_unServerFlagSecure;
+        flags |= k_unServerFlagPrivate;
+    } else {
+        flags &= ~k_unServerFlagPrivate;
+    }
+
     if (!settings->disable_source_query && !network->isQueryAlive())
         network->startQuery({ unGameIP, usQueryPort });
 

--- a/dll/steam_gameserver_items.cpp
+++ b/dll/steam_gameserver_items.cpp
@@ -412,7 +412,7 @@ void Steam_GameServer_Items::network_callback_inventory_pos_update(Common_Messag
         data.m_ulItemID = item_id;
         callbacks->addCBResult(data.k_iCallback, &data, sizeof(data), 0.15);
 
-        PRINT_DEBUG("server got updated item inventory position: %llu 0x%08x", item_id, item_inv_pos);
+        PRINT_DEBUG("server got updated item inventory position: %llu 0x%08X", item_id, item_inv_pos);
         return;
     }
 

--- a/dll/steam_user_items.cpp
+++ b/dll/steam_user_items.cpp
@@ -273,10 +273,10 @@ bool Steam_User_Items::GetItemAttribute( uint64 ulItemID, uint32 unAttributeInde
 
 SteamAPICall_t Steam_User_Items::UpdateInventoryPos( uint64 ulItemID, uint32 unNewInventoryPos )
 {
-    PRINT_DEBUG("%llu 0x%08x", ulItemID, unNewInventoryPos);
+    PRINT_DEBUG("%llu 0x%08X", ulItemID, unNewInventoryPos);
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
-    for (auto &item : items) {
+    for (Econ_Item &item : items) {
         if (item.id != ulItemID)
             continue;
 
@@ -430,7 +430,7 @@ void Steam_User_Items::network_callback_inventory_request(Common_Message *msg)
     new_msg.set_dest_id(server_steamid);
     network->sendTo(&new_msg, true);
 
-    PRINT_DEBUG("server requested inventory, sent %u items", items.size());
+    PRINT_DEBUG("server requested inventory, sent %u items", static_cast<uint32>(items.size()));
 }
 
 // only triggered when we have a message


### PR DESCRIPTION
Bunch of small fixes:
- From looking at the real steamclient.dll, SteamAppId environment variable actually has higher priority than steam_appid.txt. So I bumped env vars to the top of our appid detection.
- Added proper handling of bLANMode parameter in Steam_GameServer::BSetServerType.
- Minor logging fixes.
- Moved some of callback code around so that the function layout makes more sense.
- Added more checks for whether Steam_Client is initialized to guard against sloppy game coding.