### PR TITLE
Implementation of Steam_AppTicket::GetAppOwnershipTicketData

### DIFF
--- a/dll/appticket.cpp
+++ b/dll/appticket.cpp
@@ -259,8 +259,32 @@ Steam_AppTicket::Steam_AppTicket(class Settings *settings) :
 
 uint32 Steam_AppTicket::GetAppOwnershipTicketData( uint32 nAppID, void *pvBuffer, uint32 cbBufferLength, uint32 *piAppId, uint32 *piSteamId, uint32 *piSignature, uint32 *pcbSignature )
 {
-    PRINT_DEBUG("TODO %u, %p, %u, %p, %p, %p, %p", nAppID, pvBuffer, cbBufferLength, piAppId, piSteamId, piSignature, pcbSignature);
+    PRINT_DEBUG("%u, %p, %u, %p, %p, %p, %p", nAppID, pvBuffer, cbBufferLength, piAppId, piSteamId, piSignature, pcbSignature);
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
+
+    if (pvBuffer != nullptr && cbBufferLength >= 24) {
+        *reinterpret_cast<uint32_t*>(pvBuffer) = nAppID;
+        *reinterpret_cast<uint64_t*>(reinterpret_cast<uintptr_t>(pvBuffer) + 8) = settings->get_current_steam_id().ConvertToUint64();
+        *reinterpret_cast<uint32_t*>(reinterpret_cast<uintptr_t>(pvBuffer) + 16) = 0;
+
+        if (piAppId != nullptr) {
+            *piAppId = 0;
+        }
+
+        if (piSteamId != nullptr) {
+            *piSteamId = 8;
+        }
+
+        if (piSignature != nullptr) {
+            *piSignature = 16;
+        }
+
+        if (pcbSignature != nullptr) {
+            *pcbSignature = 8;
+        }
+
+        return 24;
+    }
 
     return 0;
 }


### PR DESCRIPTION
This provides a partial implementation for Implementation of Steam_AppTicket::GetAppOwnershipTicketData.
This fixes the check that Capcom has been doing in Resident Evil Requiem, they exploited the fact that this function isn't implemented on GBE. In case of RE, only the appid is checked.
The signature can't be replicated cause it's generated by Steam.

For additional infos, the official Steam documentation about the method is available here: https://web.archive.org/web/20230315041727/https://partner.steamgames.com/doc/api/ISteamAppTicket