### PR TITLE
SteamInventory items.json fixes

### DIFF
--- a/dll/steam_inventory.cpp
+++ b/dll/steam_inventory.cpp
@@ -161,8 +161,13 @@ bool Steam_Inventory::GetResultItems( SteamInventoryResult_t resultHandle,
             for( auto i = user_items.begin(); i != user_items.end() && max_items; ++i, --max_items )
             {
                 pOutItemsArray->m_itemId = std::stoi(i.key());
-                pOutItemsArray->m_iDefinition = i->value("definition", static_cast<int32>(pOutItemsArray->m_itemId));
-                pOutItemsArray->m_unQuantity = i->value("quantity", static_cast<uint16>(0));
+                try {
+                    pOutItemsArray->m_iDefinition = i->value("definition", static_cast<int32>(pOutItemsArray->m_itemId));
+                    pOutItemsArray->m_unQuantity = i->value("quantity", static_cast<uint16>(1));
+                } catch (...) {
+                    pOutItemsArray->m_iDefinition = pOutItemsArray->m_itemId;
+                    pOutItemsArray->m_unQuantity = 1;
+                }
                 pOutItemsArray->m_unFlags = k_ESteamItemNoTrade;
                 ++pOutItemsArray;
             }
@@ -172,8 +177,13 @@ bool Steam_Inventory::GetResultItems( SteamInventoryResult_t resultHandle,
                 auto it = user_items.find(std::to_string(itemid));
                 if (it != user_items.end()) {
                     pOutItemsArray->m_itemId = itemid;
-                    pOutItemsArray->m_iDefinition = it->value("definition", static_cast<int32>(itemid));
-                    pOutItemsArray->m_unQuantity = it->value("quantity", static_cast<uint16>(0));
+                    try {
+                        pOutItemsArray->m_iDefinition = it->value("definition", static_cast<int32>(pOutItemsArray->m_itemId));
+                        pOutItemsArray->m_unQuantity = it->value("quantity", static_cast<uint16>(1));
+                    } catch (...) {
+                        pOutItemsArray->m_iDefinition = pOutItemsArray->m_itemId;
+                        pOutItemsArray->m_unQuantity = 1;
+                    }
                     pOutItemsArray->m_unFlags = k_ESteamItemNoTrade;
                     ++pOutItemsArray;
                     --max_items;

--- a/post_build/steam_settings.EXAMPLE/default_items.EXAMPLE.json
+++ b/post_build/steam_settings.EXAMPLE/default_items.EXAMPLE.json
@@ -1,4 +1,10 @@
 {
-  "2001": 1,
-  "2002": 1
+  "1": {
+    "definition": 2001,
+    "quantity": 1
+  },
+  "2": {
+    "definition": 2002,
+    "quantity": 1
+  }
 }


### PR DESCRIPTION
Quick fix for issues described in https://github.com/Detanup01/gbe_fork/pull/445#discussion_r2934578149. I've updated default_items.json example so it actually showcases the current items.json format, and I've also restored exception handling to protect against bad custom json files.