### PR TITLE
Add SteamInput controller type override

### DIFF
--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -109,8 +109,8 @@ struct Controller_Settings {
     std::map<std::string, std::map<std::string, std::pair<std::set<std::string>, std::string>>> action_sets{};
     std::map<std::string, std::string> action_set_layer_parents{};
     std::map<std::string, std::map<std::string, std::pair<std::set<std::string>, std::string>>> action_set_layers{};
-    std::string controller_type_override;
-    bool enabled;
+    std::string controller_type_override{};
+    bool enabled{};
 };
 
 struct Group_Clans {

--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -109,6 +109,7 @@ struct Controller_Settings {
     std::map<std::string, std::map<std::string, std::pair<std::set<std::string>, std::string>>> action_sets{};
     std::map<std::string, std::string> action_set_layer_parents{};
     std::map<std::string, std::map<std::string, std::pair<std::set<std::string>, std::string>>> action_set_layers{};
+    std::string controller_type_override;
 };
 
 struct Group_Clans {
@@ -322,7 +323,6 @@ public:
     //controller
     struct Controller_Settings controller_settings{};
     std::string glyphs_directory{};
-    std::string controller_type_override;
 
     // allow Steam_User_Stats::FindLeaderboard() to always succeed and create the given unknown leaderboard
     bool disable_leaderboards_create_unknown = false;

--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -322,7 +322,7 @@ public:
     //controller
     struct Controller_Settings controller_settings{};
     std::string glyphs_directory{};
-
+    std::string controller_type_override;
 
     // allow Steam_User_Stats::FindLeaderboard() to always succeed and create the given unknown leaderboard
     bool disable_leaderboards_create_unknown = false;

--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -110,6 +110,7 @@ struct Controller_Settings {
     std::map<std::string, std::string> action_set_layer_parents{};
     std::map<std::string, std::map<std::string, std::pair<std::set<std::string>, std::string>>> action_set_layers{};
     std::string controller_type_override;
+    bool enabled;
 };
 
 struct Group_Clans {

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -31,7 +31,6 @@ constexpr const static char config_ini_overlay[] = "configs.overlay.ini";
 constexpr const static char config_ini_user[]    = "configs.user.ini";
 
 static CSimpleIniA ini{};
-
 typedef struct IniValue {
     enum class Type {
         STR,
@@ -518,11 +517,11 @@ static void load_gamecontroller_settings(Settings *settings)
     settings->glyphs_directory = path + (PATH_SEPARATOR "glyphs" PATH_SEPARATOR);
 }
 
-//controller type override
-static void parse_controller_type_override(class Settings *settings_client)
+// controller
+static void parse_controller_config(class Settings *settings_client)
 {
     std::string type(common_helpers::to_upper(common_helpers::string_strip(ini.GetValue("app::controller", "type", ""))));
-    settings_client->controller_type_override = type;
+    settings->controller_settings.controller_type_override = type;
     PRINT_DEBUG("Setting Controller type override to: '%s'", type.c_str());
 }
 
@@ -1953,7 +1952,7 @@ uint32 create_localstorage_settings(Settings **settings_client_out, Settings **s
 
     parse_mods_folder(settings_client, settings_server, local_storage);
     load_gamecontroller_settings(settings_client);
-    parse_controller_type_override(settings_client);
+    parse_controller_config(settings_client);
     parse_auto_accept_invite(settings_client, settings_server);
     parse_auto_send_invite(settings_client, settings_server);
     parse_ip_country(local_storage, settings_client, settings_server);

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -518,6 +518,14 @@ static void load_gamecontroller_settings(Settings *settings)
     settings->glyphs_directory = path + (PATH_SEPARATOR "glyphs" PATH_SEPARATOR);
 }
 
+//controller type override
+static void parse_controller_type_override(class Settings *settings_client)
+{
+    std::string type(common_helpers::to_upper(common_helpers::string_strip(ini.GetValue("app::controller", "type", ""))));
+    settings_client->controller_type_override = type;
+    PRINT_DEBUG("Setting Controller type override to: '%s'", type.c_str());
+}
+
 // steam_appid.txt
 static uint32 parse_steam_app_id(const std::string &program_path)
 {
@@ -1945,6 +1953,7 @@ uint32 create_localstorage_settings(Settings **settings_client_out, Settings **s
 
     parse_mods_folder(settings_client, settings_server, local_storage);
     load_gamecontroller_settings(settings_client);
+    parse_controller_type_override(settings_client);
     parse_auto_accept_invite(settings_client, settings_server);
     parse_auto_send_invite(settings_client, settings_server);
     parse_ip_country(local_storage, settings_client, settings_server);

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -526,8 +526,12 @@ static void parse_controller_config(class Settings *settings_client)
     
     bool enabled = ini.GetBoolValue("app::controller", "steam_input", false);
     settings_client->controller_settings.enabled = enabled;
-    if (enabled) PRINT_DEBUG("Enable SteamInput");
-    else PRINT_DEBUG("Disable SteamInput");   
+    if (enabled) {
+        PRINT_DEBUG("Enable SteamInput");
+    }
+    else {
+        PRINT_DEBUG("Disable SteamInput");
+    }
 }
 
 // steam_appid.txt

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -521,8 +521,13 @@ static void load_gamecontroller_settings(Settings *settings)
 static void parse_controller_config(class Settings *settings_client)
 {
     std::string type(common_helpers::to_upper(common_helpers::string_strip(ini.GetValue("app::controller", "type", ""))));
-    settings->controller_settings.controller_type_override = type;
+    settings_client->controller_settings.controller_type_override = type;
     PRINT_DEBUG("Setting Controller type override to: '%s'", type.c_str());
+    
+    bool enabled = ini.GetBoolValue("app::controller", "steam_input", false);
+    settings_client->controller_settings.enabled = enabled;
+    if (enabled) PRINT_DEBUG("Enable SteamInput");
+    else PRINT_DEBUG("Disable SteamInput");   
 }
 
 // steam_appid.txt

--- a/dll/steam_controller.cpp
+++ b/dll/steam_controller.cpp
@@ -221,7 +221,7 @@ Steam_Controller::Steam_Controller(class Settings *settings, class SteamCallResu
     this->run_every_runcb = run_every_runcb;
 
     set_handles(settings->controller_settings.action_sets);
-    disabled = !settings->controller_settings.enabled;
+    disabled = !settings->controller_settings.enabled && action_handles.empty();
     initialized = false;
     
     this->run_every_runcb->add(&Steam_Controller::steam_run_every_runcb, this);

--- a/dll/steam_controller.cpp
+++ b/dll/steam_controller.cpp
@@ -1088,14 +1088,14 @@ ESteamInputType Steam_Controller::GetInputTypeForHandle( ControllerHandle_t cont
     if (controller == controllers.end()) return k_ESteamInputType_Unknown;
     
     // Playstation
-    if (settings->controller_type_override == "PS3") return k_ESteamInputType_PS3Controller;
-    if (settings->controller_type_override == "PS4") return k_ESteamInputType_PS4Controller;
-    if (settings->controller_type_override == "PS5") return k_ESteamInputType_PS5Controller;
+    if (settings->controller_settings.controller_type_override == "PS3") return k_ESteamInputType_PS3Controller;
+    if (settings->controller_settings.controller_type_override == "PS4") return k_ESteamInputType_PS4Controller;
+    if (settings->controller_settings.controller_type_override == "PS5") return k_ESteamInputType_PS5Controller;
     // Xbox
-    if (settings->controller_type_override == "XBOX360") return k_ESteamInputType_XBox360Controller;
-    if (settings->controller_type_override == "XBOXONE") return k_ESteamInputType_XBoxOneController;
+    if (settings->controller_settings.controller_type_override == "XBOX360") return k_ESteamInputType_XBox360Controller;
+    if (settings->controller_settings.controller_type_override == "XBOXONE") return k_ESteamInputType_XBoxOneController;
     // Nintendo
-    if (settings->controller_type_override == "SWITCHPRO") return k_ESteamInputType_SwitchProController;
+    if (settings->controller_settings.controller_type_override == "SWITCHPRO") return k_ESteamInputType_SwitchProController;
 
     return k_ESteamInputType_XBox360Controller;
 }

--- a/dll/steam_controller.cpp
+++ b/dll/steam_controller.cpp
@@ -1095,7 +1095,7 @@ ESteamInputType Steam_Controller::GetInputTypeForHandle( ControllerHandle_t cont
     if (settings->controller_settings.controller_type_override == "XBOX360") return k_ESteamInputType_XBox360Controller;
     if (settings->controller_settings.controller_type_override == "XBOXONE") return k_ESteamInputType_XBoxOneController;
     // Nintendo
-    if (settings->controller_settings.controller_type_override == "SWITCHPRO") return k_ESteamInputType_SwitchProController;
+    if (settings->controller_settings.controller_type_override == "SWITCH") return k_ESteamInputType_SwitchProController;
 
     return k_ESteamInputType_XBox360Controller;
 }

--- a/dll/steam_controller.cpp
+++ b/dll/steam_controller.cpp
@@ -1086,6 +1086,17 @@ ESteamInputType Steam_Controller::GetInputTypeForHandle( ControllerHandle_t cont
     PRINT_DEBUG("%llu", controllerHandle);
     auto controller = controllers.find(controllerHandle);
     if (controller == controllers.end()) return k_ESteamInputType_Unknown;
+    
+    // Playstation
+    if (settings->controller_type_override == "PS3") return k_ESteamInputType_PS3Controller;
+    if (settings->controller_type_override == "PS4") return k_ESteamInputType_PS4Controller;
+    if (settings->controller_type_override == "PS5") return k_ESteamInputType_PS5Controller;
+    // Xbox
+    if (settings->controller_type_override == "XBOX360") return k_ESteamInputType_XBox360Controller;
+    if (settings->controller_type_override == "XBOXONE") return k_ESteamInputType_XBoxOneController;
+    // Nintendo
+    if (settings->controller_type_override == "SWITCHPRO") return k_ESteamInputType_SwitchProController;
+
     return k_ESteamInputType_XBox360Controller;
 }
 

--- a/dll/steam_controller.cpp
+++ b/dll/steam_controller.cpp
@@ -221,7 +221,7 @@ Steam_Controller::Steam_Controller(class Settings *settings, class SteamCallResu
     this->run_every_runcb = run_every_runcb;
 
     set_handles(settings->controller_settings.action_sets);
-    disabled = action_handles.empty();
+    disabled = !settings->controller_settings.enabled;
     initialized = false;
     
     this->run_every_runcb->add(&Steam_Controller::steam_run_every_runcb, this);

--- a/post_build/steam_settings.EXAMPLE/configs.app.EXAMPLE.ini
+++ b/post_build/steam_settings.EXAMPLE/configs.app.EXAMPLE.ini
@@ -30,7 +30,7 @@ unlock_all=0
 steam_input=0
 
 # Controller type reported to SteamInput
-# XBOX360 (default) | XBOXONE | PS3 | PS4 | PS5 | SWITCHPRO
+# XBOX360 (default) | XBOXONE | PS3 | PS4 | PS5 | SWITCH
 type=XBOX360
 
 [app::paths]

--- a/post_build/steam_settings.EXAMPLE/configs.app.EXAMPLE.ini
+++ b/post_build/steam_settings.EXAMPLE/configs.app.EXAMPLE.ini
@@ -27,6 +27,7 @@ unlock_all=0
 # 1=Enable SteamInput
 # 0=Disable SteamInput
 # default=0
+# SteamInput is automatically enabled when there are action sets in `steam_settings\controller\`
 steam_input=0
 
 # Controller type reported to SteamInput

--- a/post_build/steam_settings.EXAMPLE/configs.app.EXAMPLE.ini
+++ b/post_build/steam_settings.EXAMPLE/configs.app.EXAMPLE.ini
@@ -23,6 +23,11 @@ unlock_all=0
 1234=DLCNAME
 56789=This is another example DLC name
 
+[app::controller]
+# Controller type reported to SteamInput (override)
+# XBOX360 (default) | XBOXONE | PS3 | PS4 | PS5 | SWITCHPRO
+type=XBOX360
+
 [app::paths]
 # some rare games might need to be provided one or more paths to appids
 # for example the path to where a DLC is installed

--- a/post_build/steam_settings.EXAMPLE/configs.app.EXAMPLE.ini
+++ b/post_build/steam_settings.EXAMPLE/configs.app.EXAMPLE.ini
@@ -24,7 +24,12 @@ unlock_all=0
 56789=This is another example DLC name
 
 [app::controller]
-# Controller type reported to SteamInput (override)
+# 1=Enable SteamInput
+# 0=Disable SteamInput
+# default=0
+steam_input=0
+
+# Controller type reported to SteamInput
 # XBOX360 (default) | XBOXONE | PS3 | PS4 | PS5 | SWITCHPRO
 type=XBOX360
 


### PR DESCRIPTION
This PR adds an option to change the reported controller type to SteamInput via `GetInputTypeForHandle()`

Some games **do have** multiple built-in button icons set but rely on SteamInput to query the controller type to decide which one to use _(whether the game does use SteamInput or fallbacks to XInput)_.

Also added an _"enable switch"_ for SteamInput instead of the presence of action sets.
With the old behavior user need to create dummy action file(s) in `steam_settings/controller` to enable the feature above which is counterintuitive.

Both options combined provide an easy way for the user to control the built-in icon set displayed when the game does not expose an option for it in its settings menu.
Users relying on 3rd party XInput translation layer and/or tools like DS4Windows, DSX can also use this to avoid having to mod the game to display Playstation button prompt for example.

```ini
# configs.app.ini

[app::controller]
# 1=Enable SteamInput
# 0=Disable SteamInput
# default=0
steam_input=1

# Controller type reported to SteamInput
# XBOX360 (default) | XBOXONE | PS3 | PS4 | PS5 | SWITCHPRO
type=PS4
```

Are there any convention and/or preferences for how the settings are handled in this project(?) 
I tried to mimic the existing ones. Feel free to change the settings name and whatnot.

Some games may need more API coverage, I do not know, but querying `GetInputTypeForHandle()` seems to be a common one.

## 🎮 Tested with:

- (2592160) Dispatch                      
- (3375780) Trails in the Sky 1st Chapter //on auto setting (game menu)
- (2679460) Metaphor: ReFantazio          //on auto setting (game menu)

<details><summary>Screenshots</summary>


<p align="center">
<img width="466" height="720" alt="2592160" src="https://github.com/user-attachments/assets/31740eb5-9a7a-49a8-ab09-9f8db03808dd" />
<br /><em>(2592160) Dispatch </em>
</p>

<p align="center">
<img width="2349" height="631" alt="3375780" src="https://github.com/user-attachments/assets/ea1bbd67-5854-4cf4-854f-1dd7e45284c3" />
<br /><em>(3375780) Trails in the Sky 1st Chapter</em>
</p>

<p align="center">

<img width="1818" height="552" alt="2679460" src="https://github.com/user-attachments/assets/efdf9caf-2f84-463d-947a-d2061a43b8c6" />
<br /><em>(2679460) Metaphor: ReFantazio </em>
</p>
</details>

_NB: Testing was done with a DS4 using [InputFusion](https://github.com/xan105/InputFusion) as translation layer (XInput -> SDL3)._

