### PR TITLE
SteamGameServer fixes

### DIFF
--- a/dll/auth.cpp
+++ b/dll/auth.cpp
@@ -17,7 +17,8 @@
 
 #include "dll/auth.h"
 
-#define STEAM_TICKET_PROCESS_TIME 0.03
+// this should be at least as long as SteamGameServer logon time
+#define STEAM_TICKET_PROCESS_TIME 0.15
 
 static inline int generate_random_int()
 {

--- a/dll/dll/steam_gameserver.h
+++ b/dll/dll/steam_gameserver.h
@@ -57,16 +57,15 @@ public ISteamGameServer
     class Networking *network{};
     class SteamCallBacks *callbacks{};
 
-    CSteamID steam_id{};
-
-    bool call_servers_connected = false;
-    bool logged_in = false;
-    bool call_servers_disconnected = false;
+    bool call_servers_connected{};
+    std::chrono::high_resolution_clock::time_point logon_time{};
+    bool call_servers_disconnected{};
+    std::chrono::high_resolution_clock::time_point logoff_time{};
+    bool logged_in{};
     Gameserver server_data{};
     std::vector<std::pair<CSteamID, Gameserver_Player_Info_t>> players{};
 
     uint32 flags{};
-    bool policy_response_called{};
 
     std::chrono::high_resolution_clock::time_point last_sent_server_info{};
     Auth_Manager *auth_manager{};

--- a/dll/net.proto
+++ b/dll/net.proto
@@ -143,6 +143,12 @@ message Networking_Messages {
 }
 
 message Gameserver {
+    message PlayerInfo {
+        string name = 1;
+        uint32 score = 2;
+        float playtime = 3;
+    }
+
     uint64 id = 1;
     bytes game_description = 2;
     bytes mod_dir = 3;
@@ -171,6 +177,8 @@ message Gameserver {
 
     bool offline = 48;
     uint32 type = 49;
+
+    repeated PlayerInfo players = 50;
 }
 
 message Friend {

--- a/dll/source_query.cpp
+++ b/dll/source_query.cpp
@@ -206,11 +206,13 @@ std::vector<uint8_t> Source_Query::handle_source_query(const void* buffer, size_
                 serialize_response(output_buffer, source_response_header::A2S_PLAYER);
                 serialize_response(output_buffer, static_cast<uint8_t>(players.size())); // num_players
 
+                auto cur_time = std::chrono::steady_clock::now();
+
                 for (unsigned i = 0; i < players.size(); ++i) {
                     serialize_response(output_buffer, static_cast<uint8_t>(i)); // player index
                     serialize_response(output_buffer, players[i].second.name); // player name
                     serialize_response(output_buffer, players[i].second.score); // player score
-                    serialize_response(output_buffer, static_cast<float>(std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - players[i].second.join_time).count()));
+                    serialize_response(output_buffer, std::chrono::duration<float>(cur_time - players[i].second.join_time).count());
                 }
             }
         }

--- a/dll/steam_gameserver.cpp
+++ b/dll/steam_gameserver.cpp
@@ -948,7 +948,17 @@ void Steam_GameServer::RunCallbacks()
         Common_Message msg{};
         msg.set_source_id(settings->get_local_steam_id().ConvertToUint64());
         msg.set_allocated_gameserver(new Gameserver(server_data));
-        //msg.mutable_gameserver()->set_num_players(auth_manager->countInboundAuth());
+
+        // Fill player list and calculate their playtime.
+        auto cur_time = std::chrono::steady_clock::now();
+
+        for (const auto &[steam_id, info] : players) {
+            auto new_player = msg.mutable_gameserver()->add_players();
+            new_player->set_name(info.name);
+            new_player->set_score(info.score);
+            new_player->set_playtime(std::chrono::duration<float>(cur_time - info.join_time).count());
+        }
+
         network->sendToAllIndividuals(&msg, true);
         last_sent_server_info = std::chrono::high_resolution_clock::now();
     }

--- a/dll/steam_gameserver.cpp
+++ b/dll/steam_gameserver.cpp
@@ -180,7 +180,6 @@ bool Steam_GameServer::InitGameServer( uint32 unIP, uint16 usGamePort, uint16 us
     if (!settings->disable_source_query)
         network->startQuery({ unIP, usQueryPort });
 
-    policy_response_called = false;
     call_servers_connected = false;
     call_servers_disconnected = false;
 
@@ -248,8 +247,7 @@ void Steam_GameServer::LogOn( const char *pszToken )
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
     call_servers_connected = true;
     call_servers_disconnected = false;
-    logged_in = true;
-    settings->set_offline(false);
+    logon_time = std::chrono::high_resolution_clock::now();
 }
 
 void Steam_GameServer::LogOn(
@@ -271,8 +269,7 @@ void Steam_GameServer::LogOnAnonymous()
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
     call_servers_connected = true;
     call_servers_disconnected = false;
-    logged_in = true;
-    settings->set_offline(false);
+    logon_time = std::chrono::high_resolution_clock::now();
 }
 
 void Steam_GameServer::LogOn()
@@ -289,11 +286,16 @@ void Steam_GameServer::LogOff()
     if (logged_in) {
         call_servers_connected = false;
         call_servers_disconnected = true;
-    }
+        logoff_time = std::chrono::high_resolution_clock::now();
 
-    policy_response_called = false;
-    logged_in = false;
-    settings->set_offline(true);
+        logged_in = false;
+        settings->set_offline(true);
+
+        // Shutdown Source Query
+        network->shutDownQuery();
+        // And empty the queue if needed
+        outgoing_packets.clear();
+    }
 }
 
 
@@ -309,7 +311,7 @@ bool Steam_GameServer::BSecure()
 {
     PRINT_DEBUG_ENTRY();
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
-    if (!policy_response_called) {
+    if (!logged_in) {
       server_data.set_secure(0);
       return false;
     }
@@ -322,7 +324,7 @@ CSteamID Steam_GameServer::GetSteamID()
 {
     PRINT_DEBUG_ENTRY();
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
-    if (!logged_in) return k_steamIDNil;
+    if (!logged_in) return CSteamID(0, 0, k_EUniversePublic, k_EAccountTypeAnonGameServer); // blank anon server id
     return settings->get_local_steam_id();
 }
 
@@ -597,7 +599,6 @@ bool Steam_GameServer::BSetServerType( uint32 unServerFlags, uint32 unGameIP, ui
     if (!settings->disable_source_query && !network->isQueryAlive())
         network->startQuery({ unGameIP, usQueryPort });
 
-    //TODO?
     return true;
 }
 
@@ -907,22 +908,37 @@ SteamAPICall_t Steam_GameServer::ComputeNewPlayerCompatibility( CSteamID steamID
 
 void Steam_GameServer::RunCallbacks()
 {
-    bool temp_call_servers_connected = call_servers_connected;
-    bool temp_call_servers_disconnected = call_servers_disconnected;
-    call_servers_disconnected = call_servers_connected = false;
-
-    if (temp_call_servers_connected) {
+    if (call_servers_connected && check_timedout(logon_time, 0.1)) {
         PRINT_DEBUG("SteamServersConnected_t");
+
+        call_servers_connected = false;
+        logged_in = true;
+        settings->set_offline(false);
+
         SteamServersConnected_t data{};
-        callbacks->addCBResult(data.k_iCallback, &data, sizeof(data), 0.1);
+        callbacks->addCBResult(data.k_iCallback, &data, sizeof(data), 0.0);
+
+        PRINT_DEBUG("GSPolicyResponse_t");
+        GSPolicyResponse_t data2{};
+        data2.m_bSecure = !!(flags & k_unServerFlagSecure);
+        callbacks->addCBResult(data2.k_iCallback, &data2, sizeof(data2), 0.1);
     }
 
-    if (logged_in && !policy_response_called) {
-        PRINT_DEBUG("GSPolicyResponse_t");
-        GSPolicyResponse_t data{};
-        data.m_bSecure = !!(flags & k_unServerFlagSecure);
-        callbacks->addCBResult(data.k_iCallback, &data, sizeof(data), 0.11);
-        policy_response_called = true;
+    if (call_servers_disconnected && check_timedout(logoff_time, 0.1)) {
+        PRINT_DEBUG("Gameserver is disconnected");
+
+        call_servers_disconnected = false;
+
+        SteamServersDisconnected_t data{};
+        data.m_eResult = k_EResultOK;
+        callbacks->addCBResult(data.k_iCallback, &data, sizeof(data), 0.0);
+
+        PRINT_DEBUG("notifying all that Gameserver is not logged in");
+        Common_Message msg{};
+        msg.set_source_id(settings->get_local_steam_id().ConvertToUint64());
+        msg.set_allocated_gameserver(new Gameserver(server_data));
+        msg.mutable_gameserver()->set_offline(true);
+        network->sendToAllIndividuals(&msg, true);
     }
 
     if (logged_in &&
@@ -935,26 +951,6 @@ void Steam_GameServer::RunCallbacks()
         //msg.mutable_gameserver()->set_num_players(auth_manager->countInboundAuth());
         network->sendToAllIndividuals(&msg, true);
         last_sent_server_info = std::chrono::high_resolution_clock::now();
-    }
-
-    if (temp_call_servers_disconnected) {
-        PRINT_DEBUG("Gameserver is disconnected");
-        SteamServersDisconnected_t data{};
-        data.m_eResult = k_EResultOK;
-        callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
-
-        if (!logged_in) {
-            PRINT_DEBUG("notifying all that Gameserver is not logged in");
-            Common_Message msg{};
-            msg.set_source_id(settings->get_local_steam_id().ConvertToUint64());
-            msg.set_allocated_gameserver(new Gameserver(server_data));
-            msg.mutable_gameserver()->set_offline(true);
-            network->sendToAllIndividuals(&msg, true);
-            // Shutdown Source Query
-            network->shutDownQuery();
-            // And empty the queue if needed
-            outgoing_packets.clear();
-        }
     }
 }
 

--- a/dll/steam_matchmaking_servers.cpp
+++ b/dll/steam_matchmaking_servers.cpp
@@ -15,7 +15,7 @@
    License along with the Goldberg Emulator; if not, see
    <http://www.gnu.org/licenses/>.  */
 
-#include "dll/dll.h"
+#include "dll/steam_matchmaking_servers.h"
 
 #define SERVER_TIMEOUT 10.0
 #define DIRECT_IP_DELAY 0.05
@@ -755,13 +755,12 @@ void Steam_Matchmaking_Servers::server_details_players(Gameserver *g, Steam_Matc
     } else if (!settings->matchmaking_server_details_via_source_query) { // original behavior
         uint32_t number_players = g->num_players();
         PRINT_DEBUG("  players: %u", number_players);
-        const auto &players = get_steam_client()->steam_gameserver->get_players();
-        auto player = players->cbegin();
-        for (uint32_t i = 0; i < number_players && player != players->end(); ++i, ++player) {
-            auto duration = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - player->second.join_time);
-            float playtime = static_cast<float>(duration.count());
-            PRINT_DEBUG("  PLAYER [%u] '%s' %u %f", i, player->second.name.c_str(), player->second.score, playtime);
-            r->players_response->AddPlayerToList(player->second.name.c_str(), player->second.score, playtime);
+
+        int player_num = 1;
+
+        for (const auto &player : g->players()) {
+            PRINT_DEBUG("  PLAYER [%u] '%s' %u %.2f", player_num++, player.name().c_str(), player.score(), player.playtime());
+            r->players_response->AddPlayerToList(player.name().c_str(), player.score(), player.playtime());
         }
     }
 

--- a/dll/steam_user.cpp
+++ b/dll/steam_user.cpp
@@ -50,10 +50,9 @@ HSteamUser Steam_User::GetHSteamUser()
 void Steam_User::LogOn( CSteamID steamID )
 {
     PRINT_DEBUG_ENTRY();
-    settings->set_offline(false);
-    logon_time = std::chrono::high_resolution_clock::now();
     call_logged_on = true;
     call_logged_off = false;
+    logon_time = std::chrono::high_resolution_clock::now();
 
     if (settings == get_steam_client()->settings_server) {
         get_steam_client()->steam_gameserver->LogOnAnonymous();
@@ -63,10 +62,11 @@ void Steam_User::LogOn( CSteamID steamID )
 void Steam_User::LogOff()
 {
     PRINT_DEBUG_ENTRY();
-    settings->set_offline(true);
-    logoff_time = std::chrono::high_resolution_clock::now();
     call_logged_on = false;
     call_logged_off = true;
+    logoff_time = std::chrono::high_resolution_clock::now();
+
+    settings->set_offline(true);
     player_auths.clear();
 
     if (settings == get_steam_client()->settings_server) {
@@ -1107,6 +1107,7 @@ void Steam_User::RunCallbacks()
     if (callbacks_old1) {
         if (call_logged_on && check_timedout(logon_time, 0.1)) {
             PRINT_DEBUG("ICMCallback -> OnLogonSuccess");
+            settings->set_offline(false);
             callbacks_old1->OnLogonSuccess();
             call_logged_on = false;
         }
@@ -1129,6 +1130,7 @@ void Steam_User::RunCallbacks()
     } else if (callbacks_old2) {
         if (call_logged_on && check_timedout(logon_time, 0.1)) {
             PRINT_DEBUG("ICMCallback -> OnLogonSuccess");
+            settings->set_offline(false);
             callbacks_old2->OnLogonSuccess();
             call_logged_on = false;
         }


### PR DESCRIPTION
- Implemented proper delay for setting logged in state. This fixes Team Fortress 2 which calls BLoggedOn on the same tick it calls SteamGameServer_Init (old behavior breaks some of re-initialization code when starting a second listen server in one session).
- Now sending player info with game server info. Previously, SteamMatchmakingServers was reading player info from the local SteamGameServer instance, which doesn't make sense. Now it gets the actual player list from the server. This should not break network compatibility with older versions.