### PR TITLE
Minor changes to build scripts

### DIFF
--- a/.github/workflows/emu-build-all-linux.yml
+++ b/.github/workflows/emu-build-all-linux.yml
@@ -17,6 +17,9 @@ env:
   PACKAGE_BASE_DIR: "build/package/linux"
   THIRD_PARTY_BASE_DIR: "third-party"
 
+  # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+  MAX_PARALLEL_JOBS: 4
+
 jobs:
   deps:
     name: "Restore or build deps"
@@ -110,9 +113,9 @@ jobs:
         working-directory: "${{ github.workspace }}/build/project/gmake2/linux"
         run: |
           echo "dry run..."
-          make -n -j 2 config=${{ matrix.cfg }}_${{ matrix.arch }} ${{ matrix.prj }}
+          make -n -j ${{ env.MAX_PARALLEL_JOBS }} config=${{ matrix.cfg }}_${{ matrix.arch }} ${{ matrix.prj }}
           echo "actual run..."
-          make -j 2 config=${{ matrix.cfg }}_${{ matrix.arch }} ${{ matrix.prj }}
+          make -j ${{ env.MAX_PARALLEL_JOBS }} config=${{ matrix.cfg }}_${{ matrix.arch }} ${{ matrix.prj }}
 
       # upload artifact/package to github Actions
       - name: "Upload target package"

--- a/.github/workflows/emu-build-all-win.yml
+++ b/.github/workflows/emu-build-all-win.yml
@@ -16,6 +16,9 @@ env:
 
   THIRD_PARTY_BASE_DIR: "third-party"
 
+  # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+  MAX_PARALLEL_JOBS: 4
+
 jobs:
   deps:
     name: "Restore or build deps"
@@ -107,7 +110,7 @@ jobs:
         shell: "cmd"
         working-directory: "${{ github.workspace }}/build/project/vs2022/win"
         run: |
-          msbuild /nologo /target:${{ matrix.prj }} /m:2 /v:n /p:Configuration=${{ matrix.cfg }},Platform=${{ matrix.arch }} gbe.sln
+          msbuild /nologo /target:${{ matrix.prj }} /m:1 -p:CL_MPCount=${{ env.MAX_PARALLEL_JOBS }} /v:n /p:Configuration=${{ matrix.cfg }},Platform=${{ matrix.arch }} gbe.sln
 
       # upload artifact/package to github Actions
       - name: "Upload target package"

--- a/.github/workflows/emu-deps-linux.yml
+++ b/.github/workflows/emu-deps-linux.yml
@@ -17,6 +17,9 @@ env:
   PACKAGE_BASE_DIR: "build/package/linux"
   THIRD_PARTY_BASE_DIR: "third-party"
 
+  # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+  MAX_PARALLEL_JOBS: 4
+
 jobs:
   deps-build:
     runs-on: "ubuntu-22.04"
@@ -87,4 +90,4 @@ jobs:
         run: |
           export CMAKE_GENERATOR="Unix Makefiles"
           sudo chmod 777 ./${{env.THIRD_PARTY_BASE_DIR}}/common/linux/premake/premake5
-          ./${{env.THIRD_PARTY_BASE_DIR}}/common/linux/premake/premake5 --file=premake5-deps.lua --64-build --32-build --all-ext --all-build --j=2 --verbose --clean --os=linux gmake2
+          ./${{env.THIRD_PARTY_BASE_DIR}}/common/linux/premake/premake5 --file=premake5-deps.lua --64-build --32-build --all-ext --all-build --j=${{ env.MAX_PARALLEL_JOBS }} --verbose --clean --os=linux gmake2

--- a/.github/workflows/emu-deps-win.yml
+++ b/.github/workflows/emu-deps-win.yml
@@ -17,6 +17,9 @@ env:
   PACKAGE_BASE_DIR: "build/package/win"
   THIRD_PARTY_BASE_DIR: "third-party"
 
+  # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+  MAX_PARALLEL_JOBS: 4
+
 jobs:
   deps-build:
     runs-on: "windows-2022"
@@ -79,4 +82,4 @@ jobs:
         working-directory: "${{ github.workspace }}"
         run: |
           set "CMAKE_GENERATOR=Visual Studio 17 2022"
-          "${{env.THIRD_PARTY_BASE_DIR}}\common\win\premake\premake5.exe" --file=premake5-deps.lua --64-build --32-build --all-ext --all-build --j=2 --verbose --clean --os=windows vs2022
+          "${{env.THIRD_PARTY_BASE_DIR}}\common\win\premake\premake5.exe" --file=premake5-deps.lua --64-build --32-build --all-ext --all-build --j=${{ env.MAX_PARALLEL_JOBS }} --verbose --clean --os=windows vs2022

--- a/build_linux_premake.sh
+++ b/build_linux_premake.sh
@@ -5,21 +5,22 @@ function help_page () {
   echo "switches:"
   echo "  --deps: rebuild third-party dependencies"
   echo "  --nogen: don't regenerate build files"
+  echo "  --j: parallel build jobs"
   echo "  --help: show this page"
 }
 
-# use 70%
-build_threads="$(( $(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 0) * 70 / 100 ))"
-[[ $build_threads -lt 2 ]] && build_threads=2
-
 BUILD_DEPS=0
 GEN_PROJECT=1
+BUILD_JOBS=-1
 for (( i=1; i<=$#; ++i )); do
   arg="${!i}"
   if [[ "$arg" = "--deps" ]]; then
     BUILD_DEPS=1
   elif [[ "$arg" = "--nogen" ]]; then
     GEN_PROJECT=0
+  elif [[ "$arg" = "--j" ]]; then
+    BUILD_JOBS="$2"
+    shift 1
   elif [[ "$arg" = "--help" ]]; then
     help_page
     exit 0
@@ -28,6 +29,11 @@ for (( i=1; i<=$#; ++i )); do
     exit 1
   fi
 done
+
+# use 70%
+build_threads="$(( $(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 0) * 70 / 100 ))"
+[[ $build_threads -lt 2 ]] && build_threads=2
+[[ "$BUILD_JOBS" -ge "1" ]] && build_threads="$BUILD_JOBS"
 
 premake_exe=./"third-party/common/linux/premake/premake5"
 if [[ ! -f "$premake_exe" ]]; then

--- a/build_linux_premake.sh
+++ b/build_linux_premake.sh
@@ -33,7 +33,7 @@ done
 # use 70%
 build_threads="$(( $(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 0) * 70 / 100 ))"
 [[ $build_threads -lt 2 ]] && build_threads=2
-[[ "$BUILD_JOBS" -ge "1" ]] && build_threads="$BUILD_JOBS"
+[[ "$BUILD_JOBS" -ge 1 ]] && build_threads="$BUILD_JOBS"
 
 premake_exe=./"third-party/common/linux/premake/premake5"
 if [[ ! -f "$premake_exe" ]]; then

--- a/build_win_premake.bat
+++ b/build_win_premake.bat
@@ -100,7 +100,7 @@ set /a "BUILD_JOBS=-1"
       for %%C in (%BUILD_TARGETS%) do (
         set "BUILD_TARGET=%%C"
         echo. & echo:building !BUILD_TARGET! !BUILD_TYPE! !BUILD_PLATFORM!
-        call "%MSBUILD_EXE%" /nologo -m:%MAX_THREADS% -v:n /p:Configuration=!BUILD_TYPE!,Platform=!BUILD_PLATFORM! /target:!BUILD_TARGET! "%SLN_FILE%" || (
+        call "%MSBUILD_EXE%" /nologo -m:1 -p:CL_MPCount=%MAX_THREADS% -v:n /p:Configuration=!BUILD_TYPE!,Platform=!BUILD_PLATFORM! /target:!BUILD_TARGET! "%SLN_FILE%" || (
           goto :end_script_with_err
         )
       )

--- a/build_win_premake.bat
+++ b/build_win_premake.bat
@@ -67,6 +67,14 @@ set /a "BUILD_JOBS=-1"
   for /f "tokens=* delims=" %%A in ('"%VSWHERE_EXE%" -prerelease -latest -nocolor -nologo -property installationPath 2^>nul') do (
     set "MSBUILD_EXE=%%~A\MSBuild\Current\Bin\MSBuild.exe"
   )
+  :: in case we are running inside a vcvars cmd from a portable buildtools installation without Visual Studio
+  if not exist "%MSBUILD_EXE%" (
+    for /f "tokens=* delims=" %%A in ('where MSBuild 2^>nul') do (
+      set "MSBUILD_EXE=%%~A"
+      goto :end_find_custom_msbuild
+    )
+  )
+:end_find_custom_msbuild
   if not exist "%MSBUILD_EXE%" (
     1>&2 echo:MSBuild wasn't found
     goto :end_script_with_err

--- a/build_win_premake.bat
+++ b/build_win_premake.bat
@@ -2,17 +2,9 @@
 setlocal EnableDelayedExpansion
 cd /d "%~dp0"
 
-set /a "MAX_THREADS=2"
-if defined NUMBER_OF_PROCESSORS (
-  :: use 70%
-  set /a "MAX_THREADS=%NUMBER_OF_PROCESSORS% * 70 / 100"
-  if %MAX_THREADS% lss 1 (
-    set /a "MAX_THREADS=1"
-  )
-)
-
 set /a "BUILD_DEPS=0"
 set /a "GEN_PROJECT=1"
+set /a "BUILD_JOBS=-1"
 
 :args_loop
   if "%~1" equ "" (
@@ -21,6 +13,9 @@ set /a "GEN_PROJECT=1"
     set /a "BUILD_DEPS=1"
   ) else if "%~1" equ "--nogen" (
     set /a "GEN_PROJECT=0"
+  ) else if "%~1" equ "--j" (
+    set /a "BUILD_JOBS=%~2"
+    shift /1
   ) else if "%~1" equ "--help" (
     goto :help_page
   ) else (
@@ -32,6 +27,18 @@ set /a "GEN_PROJECT=1"
   goto :args_loop
 
 :args_loop_end
+  set /a "MAX_THREADS=2"
+  if defined NUMBER_OF_PROCESSORS (
+    :: use 70%
+    set /a "MAX_THREADS=%NUMBER_OF_PROCESSORS% * 70 / 100"
+    if %MAX_THREADS% lss 1 (
+      set /a "MAX_THREADS=1"
+    )
+  )
+  if %BUILD_JOBS% geq 1 (
+    set /a MAX_THREADS=BUILD_JOBS
+  )
+
   :: check premake
   set "PREMAKE_EXE=third-party\common\win\premake\premake5.exe"
   if not exist "%PREMAKE_EXE%" (
@@ -116,5 +123,6 @@ set /a "GEN_PROJECT=1"
   echo:switches:
   echo:  --deps: rebuild third-party dependencies
   echo:  --nogen: don't regenerate build files
+  echo   --j: parallel build jobs
   echo:  --help: show this page
   goto :end_script

--- a/build_win_premake.bat
+++ b/build_win_premake.bat
@@ -131,6 +131,6 @@ set /a "BUILD_JOBS=-1"
   echo:switches:
   echo:  --deps: rebuild third-party dependencies
   echo:  --nogen: don't regenerate build files
-  echo   --j: parallel build jobs
+  echo:  --j: parallel build jobs
   echo:  --help: show this page
   goto :end_script


### PR DESCRIPTION
- Allow specifying max parallel build jobs via new switch, ex: `--j 12`

- Fix build parallelism on windows
  Turns out `-m:NUMBER` flag defines how many processes are used, which ends up being how many **projects** to build in parallel, not how many **files** per project.
  With `--j 4` I noticed too many `cl.exe` processes in task manager not 4 as I expected, this was the reason.
  Also this flag = 1 by default (for a good reason) https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference
  To build multiple files and only 1 project at a time we need this obscure flag `CL_MPCount`
  https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/
  https://devblogs.microsoft.com/cppblog/cpp-build-throughput-investigation-and-tune-up/
  https://devblogs.microsoft.com/visualstudio/tuning-c-build-parallelism-in-vs2010/

- Attempt to recognize custom `msbuild` paths using `where` command line tool before failing, this is useful when you're using a portable installation of `build tools` without a full Visual Studio installation.
  This also allows the Windows build script to run inside `WINE` on Linux with this project: https://github.com/mstorsjo/msvc-wine