### PR TITLE
Always trigger logoff on server shutdown, bot SteamID fix

### DIFF
--- a/dll/auth.cpp
+++ b/dll/auth.cpp
@@ -881,7 +881,7 @@ HAuthTicket Auth_Manager::getWebApiTicket( const char* pchIdentity )
 CSteamID Auth_Manager::fakeUser()
 {
     Auth_Data data = {};
-    data.id = generate_steam_anon_user();
+    data.id = generate_steam_id_anonserver(); // not k_EAccountTypeAnonUser
     inbound.push_back(data);
     return data.id;
 }

--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -1168,7 +1168,7 @@ STEAMAPI_API void SteamGameServer_Shutdown()
         return;
     }
 
-    get_steam_client()->serverShutdown();
+    get_steam_client()->ReleaseUser(server_steam_pipe, SERVER_HSTEAMUSER);
     get_steam_client()->BReleaseSteamPipe(server_steam_pipe);
     get_steam_client()->BShutdownIfAllPipesClosed();
 

--- a/dll/steam_client.cpp
+++ b/dll/steam_client.cpp
@@ -399,6 +399,10 @@ void Steam_Client::ReleaseUser( HSteamPipe hSteamPipe, HSteamUser hUser )
 {
     PRINT_DEBUG_ENTRY();
     if (hUser == SERVER_HSTEAMUSER && steam_pipes.count(hSteamPipe)) {
+        if (steam_gameserver->BLoggedOn()) {
+            steam_gameserver->LogOff();
+        }
+
         steamclient_server_inited = false;
     }
 }


### PR DESCRIPTION
* Real steam_api.dll doesn't call `ISteamGameServer::LogOff` if `SteamGameServer_InitSafe` was used, it just skips straight to `ISteamClient::ReleaseUser` and such. This results in Goldberg not doing the necessary cleanup, so creating a second listen server in one session will fail because `Steam_GameServer::InitGameServer` returns false. I've made `Steam_Client::ReleaseUser` call server logoff and also updated our implementation of `SteamGameServer_Shutdown` to fix that.
* From checking real steamclient.dll, bots are assigned SteamID of `k_EAccountTypeAnonGameServer` type, not `k_EAccountTypeAnonUser`. I've updated the code to reflect that.