### PR TITLE
Further work on Game Coordinator

### DIFF
--- a/dll/dll/econ_item.h
+++ b/dll/dll/econ_item.h
@@ -51,24 +51,35 @@
 
 struct Econ_Item_Attribute
 {
-    uint32 def;
-    float value;
+    enum Attribute_Type
+    {
+        ATTR_TYPE_DEFAULT = 0,
+        ATTR_TYPE_FLOAT,
+        ATTR_TYPE_INT,
+        ATTR_TYPE_STRING,
+    };
+    uint32 def{};
+    float value{}; // for backwards compatibility
+    std::string value_bytes;
+    Attribute_Type type{}; // this is only used on the client side to know how to save attribute into file
 };
 
 struct Econ_Item
 {
-    uint64 id;
-    uint32 def;
-    uint32 level;
-    EItemQuality quality;
-    uint32 inv_pos;
-    uint32 quantity;
-    uint8 flags;
-    uint8 origin;
+    uint64 id{};
+    uint32 def{};
+    uint32 level{};
+    EItemQuality quality{};
+    uint32 inv_pos{};
+    uint32 quantity{};
+    uint8 flags{};
+    uint8 origin{};
     std::string custom_name;
     std::string custom_desc;
-    bool in_use;
-    uint64 original_id;
+    bool in_use{};
+    uint64 original_id{};
+    uint8 style{};
+    std::map<uint16, uint16> equip_states;
     std::vector<Econ_Item_Attribute> attributes;
 };
 

--- a/dll/dll/steam_game_coordinator.h
+++ b/dll/dll/steam_game_coordinator.h
@@ -26,6 +26,7 @@ class Steam_GameServer_Items;
 struct GCMsgHdr_t;
 struct GCMsgHdrEx_t;
 struct ProtoBufMsgHeader_t;
+class CMsgProtoBufHeader;
 
 class Steam_Game_Coordinator :
 public ISteamGameCoordinator
@@ -52,8 +53,20 @@ public ISteamGameCoordinator
     std::vector<GC_Message> pending_messages;
     std::queue<GC_Message> incoming_messages;
 
+    enum GC_Profile
+    {
+        GC_PROFILE_INVALID = 0,
+        GC_PROFILE_TF2,
+        //GC_PROFILE_PORTAL2,
+    };
+
     int gc_version{};
+    GC_Profile gc_profile{};
+    bool is_portal2{};
     bool gc_initialized{};
+    bool delay_init{};
+    bool welcome_received{};
+    std::chrono::high_resolution_clock::time_point welcome_time{};
 
     std::vector<Econ_Item> items;
     bool items_loaded{};
@@ -61,7 +74,7 @@ public ISteamGameCoordinator
     struct RequestInventory
     {
         std::chrono::high_resolution_clock::time_point created{};
-        CSteamID steam_id;
+        CSteamID steam_id{};
         SteamAPICall_t steam_api_call{};
         bool is_gc{};
     };
@@ -73,21 +86,38 @@ public ISteamGameCoordinator
     Steam_User_Items *client_items();
     Steam_GameServer_Items *server_items();
     void parse_gc_config();
+    bool is_welcome_message(const GC_Message &message);
     void push_incoming(uint32 msg_type, const std::string &message, double delay = 0.1);
 
     std::string build_msg_header(JobID_t target_job = k_GIDNil, JobID_t source_job = k_GIDNil);
     GCMsgHdrEx_t parse_msg_header(const char *&p);
+    std::string build_protomsg_header(uint32 msg_type, JobID_t target_job = k_GIDNil, JobID_t source_job = k_GIDNil);
+    template <class T>
+    std::tuple<ProtoBufMsgHeader_t, CMsgProtoBufHeader, T, bool> parse_protomsg(const void *input, uint32 input_size);
     uint64 item_id_local_to_network(uint64 item_id);
     uint64 item_id_network_to_local(uint64 item_id);
+    std::string item_to_gcstruct(const Econ_Item &item, CSteamID steam_id);
+    std::string item_to_gcprotobuf(const Econ_Item &item, CSteamID steam_id);
 
     void handle_set_item_pos(const void *input, uint32 input_size);
     void handle_delete_item(const void *input, uint32 input_size);
-    void handle_respawn(const void *input, uint32 input_size);
     void handle_motd_request(const void *input, uint32 input_size);
+    void handle_respawn(const void *input, uint32 input_size);
+    void handle_set_item_style(const void *input, uint32 input_size);
+    void handle_adjust_equip_state(const void *input, uint32 input_size);
+    void handle_set_multiple_item_pos(const void *input, uint32 input_size);
+
+    void callback_client_welcome();
+    void callback_server_welcome();
+    void callback_items_received(CSteamID steam_id, const std::vector<Econ_Item> &items);
+    void callback_items_removed(CSteamID steam_id);
+    void callback_item_updated(CSteamID steam_id, const Econ_Item &item);
+    void callback_item_deleted(CSteamID steam_id, uint64 item_id);
+    void callback_respawn_request(CSteamID steam_id);
 
     void network_callback_inventory_request(Common_Message *msg);
     void network_callback_inventory_response(Common_Message *msg);
-    void network_callback_inventory_pos_update(Common_Message *msg);
+    void network_callback_item_update(Common_Message *msg);
     void network_callback_item_deletion(Common_Message *msg);
     void network_callback_respawn_request(Common_Message *msg);
     void network_callback(Common_Message *msg);
@@ -101,6 +131,7 @@ public:
     ~Steam_Game_Coordinator();
 
     void initialize_gc();
+    void shutdown_gc();
 
     const std::vector<Econ_Item> &get_items() { return items; }
     const std::map<CSteamID, std::vector<Econ_Item>> &get_all_user_items() { return all_user_items; }
@@ -109,7 +140,7 @@ public:
 
     const std::vector<Econ_Item> &load_items_from_file();
     void save_items_to_file();
-    const Econ_Item *set_item_pos(uint64 item_id, uint32 inv_pos, bool is_gc);
+    const Econ_Item *set_item_pos(uint64 item_id, uint32 inv_pos, bool is_gc, bool save = true);
     bool delete_item(uint64 item_id, bool is_gc);
 
     void request_user_items(CSteamID steam_id, SteamAPICall_t api_call, bool is_gc);
@@ -118,9 +149,6 @@ public:
 
     void on_client_connected(CSteamID steam_id);
     void on_client_disconnected(CSteamID steam_id);
-    void on_items_received(CSteamID steam_id, const std::vector<Econ_Item> &items);
-    void on_item_pos_updated(CSteamID steam_id, const Econ_Item &item);
-    void on_item_deleted(CSteamID steam_id, uint64 item_id);
 
     // sends a message to the Game Coordinator
     EGCResults SendMessage_( uint32 unMsgType, const void *pubData, uint32 cubData );

--- a/dll/dll/steam_gameserver_items.h
+++ b/dll/dll/steam_gameserver_items.h
@@ -19,7 +19,6 @@
 #define __INCLUDED_STEAM_GAMESERVER_ITEMS_H__
 
 #include "base.h"
-#include "econ_item.h"
 
 class Steam_Game_Coordinator;
 
@@ -39,9 +38,9 @@ public:
     Steam_GameServer_Items(class Settings *settings, class SteamCallBacks *callbacks, class SteamCallResults *callback_results);
     ~Steam_GameServer_Items();
 
-    void on_items_received(CSteamID steam_id, size_t num_items, SteamAPICall_t api_call, bool success);
-    void on_item_pos_updated(CSteamID steam_id, uint64 item_id, uint32 inv_pos);
-    void on_item_deleted(CSteamID steam_id, uint64 item_id);
+    void callback_items_received(CSteamID steam_id, size_t num_items, SteamAPICall_t api_call, bool success);
+    void callback_item_pos_updated(CSteamID steam_id, uint64 item_id, uint32 inv_pos);
+    void callback_item_deleted(CSteamID steam_id, uint64 item_id);
 
     SteamAPICall_t LoadItems( CSteamID ownerID );
     void LoadItems_old( CSteamID ownerID );

--- a/dll/dll/steam_user_items.h
+++ b/dll/dll/steam_user_items.h
@@ -19,7 +19,6 @@
 #define __INCLUDED_STEAM_USER_ITEMS_H__
 
 #include "base.h"
-#include "econ_item.h"
 
 class Steam_Game_Coordinator;
 

--- a/dll/gc_steam/steammessages.proto
+++ b/dll/gc_steam/steammessages.proto
@@ -1,0 +1,577 @@
+import "google/protobuf/descriptor.proto";
+
+option optimize_for = SPEED;
+option cc_generic_services = false;
+
+extend google.protobuf.FieldOptions {
+	optional bool key_field = 60000 [default = false];
+}
+
+extend google.protobuf.MessageOptions {
+	optional int32 msgpool_soft_limit = 60000 [default = 32];
+	optional int32 msgpool_hard_limit = 60001 [default = 384];
+}
+
+enum GCProtoBufMsgSrc {
+	GCProtoBufMsgSrc_Unspecified = 0;
+	GCProtoBufMsgSrc_FromSystem = 1;
+	GCProtoBufMsgSrc_FromSteamID = 2;
+	GCProtoBufMsgSrc_FromGC = 3;
+	GCProtoBufMsgSrc_ReplySystem = 4;
+}
+
+message CMsgProtoBufHeader {
+	option (msgpool_soft_limit) = 256;
+	option (msgpool_hard_limit) = 1024;
+
+	optional fixed64 client_steam_id = 1;
+	optional int32 client_session_id = 2;
+	optional uint32 source_app_id = 3;
+	optional fixed64 job_id_source = 10 [default = 18446744073709551615];
+	optional fixed64 job_id_target = 11 [default = 18446744073709551615];
+	optional string target_job_name = 12;
+	optional int32 eresult = 13 [default = 2];
+	optional string error_message = 14;
+	optional GCProtoBufMsgSrc gc_msg_src = 200 [default = GCProtoBufMsgSrc_Unspecified];
+	optional uint32 gc_dir_index_source = 201;
+}
+
+message CMsgWebAPIKey {
+	optional uint32 status = 1 [default = 255];
+	optional uint32 account_id = 2 [default = 0];
+	optional uint32 publisher_group_id = 3 [default = 0];
+	optional uint32 key_id = 4;
+	optional string domain = 5;
+}
+
+message CMsgHttpRequest {
+	message RequestHeader {
+		optional string name = 1;
+		optional string value = 2;
+	}
+
+	message QueryParam {
+		optional string name = 1;
+		optional bytes value = 2;
+	}
+
+	optional uint32 request_method = 1;
+	optional string hostname = 2;
+	optional string url = 3;
+	repeated CMsgHttpRequest.RequestHeader headers = 4;
+	repeated CMsgHttpRequest.QueryParam get_params = 5;
+	repeated CMsgHttpRequest.QueryParam post_params = 6;
+	optional bytes body = 7;
+	optional uint32 absolute_timeout = 8;
+}
+
+message CMsgWebAPIRequest {
+	optional string UNUSED_job_name = 1;
+	optional string interface_name = 2;
+	optional string method_name = 3;
+	optional uint32 version = 4;
+	optional CMsgWebAPIKey api_key = 5;
+	optional CMsgHttpRequest request = 6;
+	optional uint32 routing_app_id = 7;
+}
+
+message CMsgHttpResponse {
+	message ResponseHeader {
+		optional string name = 1;
+		optional string value = 2;
+	}
+
+	optional uint32 status_code = 1;
+	repeated CMsgHttpResponse.ResponseHeader headers = 2;
+	optional bytes body = 3;
+}
+
+message CMsgAMFindAccounts {
+	optional uint32 search_type = 1;
+	optional string search_string = 2;
+}
+
+message CMsgAMFindAccountsResponse {
+	repeated fixed64 steam_id = 1;
+}
+
+message CMsgNotifyWatchdog {
+	optional uint32 source = 1;
+	optional uint32 alert_type = 2;
+	optional uint32 alert_destination = 3;
+	optional bool critical = 4;
+	optional uint32 time = 5;
+	optional uint32 appid = 6;
+	optional string text = 7;
+}
+
+message CMsgAMGetLicenses {
+	optional fixed64 steamid = 1;
+}
+
+message CMsgPackageLicense {
+	optional uint32 package_id = 1;
+	optional uint32 time_created = 2;
+	optional uint32 owner_id = 3;
+}
+
+message CMsgAMGetLicensesResponse {
+	repeated CMsgPackageLicense license = 1;
+	optional uint32 result = 2;
+}
+
+message CMsgAMGetUserGameStats {
+	optional fixed64 steam_id = 1;
+	optional fixed64 game_id = 2;
+	repeated uint32 stats = 3;
+}
+
+message CMsgAMGetUserGameStatsResponse {
+	message Stats {
+		optional uint32 stat_id = 1;
+		optional uint32 stat_value = 2;
+	}
+
+	message Achievement_Blocks {
+		optional uint32 achievement_id = 1;
+		optional uint32 achievement_bit_id = 2;
+		optional fixed32 unlock_time = 3;
+	}
+
+	optional fixed64 steam_id = 1;
+	optional fixed64 game_id = 2;
+	optional int32 eresult = 3 [default = 2];
+	repeated CMsgAMGetUserGameStatsResponse.Stats stats = 4;
+	repeated CMsgAMGetUserGameStatsResponse.Achievement_Blocks achievement_blocks = 5;
+}
+
+message CMsgGCGetCommandList {
+	optional uint32 app_id = 1;
+	optional string command_prefix = 2;
+}
+
+message CMsgGCGetCommandListResponse {
+	repeated string command_name = 1;
+}
+
+message CGCMsgMemCachedGet {
+	repeated string keys = 1;
+}
+
+message CGCMsgMemCachedGetResponse {
+	message ValueTag {
+		optional bool found = 1;
+		optional bytes value = 2;
+	}
+
+	repeated CGCMsgMemCachedGetResponse.ValueTag values = 1;
+}
+
+message CGCMsgMemCachedSet {
+	message KeyPair {
+		optional string name = 1;
+		optional bytes value = 2;
+	}
+
+	repeated CGCMsgMemCachedSet.KeyPair keys = 1;
+}
+
+message CGCMsgMemCachedDelete {
+	repeated string keys = 1;
+}
+
+message CGCMsgMemCachedStats {
+}
+
+message CGCMsgMemCachedStatsResponse {
+	optional uint64 curr_connections = 1;
+	optional uint64 cmd_get = 2;
+	optional uint64 cmd_set = 3;
+	optional uint64 cmd_flush = 4;
+	optional uint64 get_hits = 5;
+	optional uint64 get_misses = 6;
+	optional uint64 delete_hits = 7;
+	optional uint64 delete_misses = 8;
+	optional uint64 bytes_read = 9;
+	optional uint64 bytes_written = 10;
+	optional uint64 limit_maxbytes = 11;
+	optional uint64 curr_items = 12;
+	optional uint64 evictions = 13;
+	optional uint64 bytes = 14;
+}
+
+message CGCMsgSQLStats {
+	optional uint32 schema_catalog = 1;
+}
+
+message CGCMsgSQLStatsResponse {
+	optional uint32 threads = 1;
+	optional uint32 threads_connected = 2;
+	optional uint32 threads_active = 3;
+	optional uint32 operations_submitted = 4;
+	optional uint32 prepared_statements_executed = 5;
+	optional uint32 non_prepared_statements_executed = 6;
+	optional uint32 deadlock_retries = 7;
+	optional uint32 operations_timed_out_in_queue = 8;
+	optional uint32 errors = 9;
+}
+
+message CMsgAMAddFreeLicense {
+	optional fixed64 steamid = 1;
+	optional uint32 ip_public = 2;
+	optional uint32 packageid = 3;
+	optional string store_country_code = 4;
+}
+
+message CMsgAMAddFreeLicenseResponse {
+	optional int32 eresult = 1 [default = 2];
+	optional int32 purchase_result_detail = 2;
+	optional fixed64 transid = 3;
+}
+
+message CGCMsgGetIPLocation {
+	repeated fixed32 ips = 1;
+}
+
+message CIPLocationInfo {
+	optional uint32 ip = 1;
+	optional float latitude = 2;
+	optional float longitude = 3;
+	optional string country = 4;
+	optional string state = 5;
+	optional string city = 6;
+}
+
+message CGCMsgGetIPLocationResponse {
+	repeated CIPLocationInfo infos = 1;
+}
+
+message CGCMsgSystemStatsSchema {
+	optional uint32 gc_app_id = 1;
+	optional bytes schema_kv = 2;
+}
+
+message CGCMsgGetSystemStats {
+}
+
+message CGCMsgGetSystemStatsResponse {
+	optional uint32 gc_app_id = 1;
+	optional bytes stats_kv = 2;
+	optional uint32 active_jobs = 3;
+	optional uint32 yielding_jobs = 4;
+	optional uint32 user_sessions = 5;
+	optional uint32 game_server_sessions = 6;
+	optional uint32 socaches = 7;
+	optional uint32 socaches_to_unload = 8;
+	optional uint32 socaches_loading = 9;
+	optional uint32 writeback_queue = 10;
+	optional uint32 steamid_locks = 11;
+	optional uint32 logon_queue = 12;
+	optional uint32 logon_jobs = 13;
+}
+
+message CMsgAMSendEmail {
+	message ReplacementToken {
+		optional string token_name = 1;
+		optional string token_value = 2;
+	}
+
+	message PersonaNameReplacementToken {
+		optional fixed64 steamid = 1;
+		optional string token_name = 2;
+	}
+
+	optional fixed64 steamid = 1;
+	optional uint32 email_msg_type = 2;
+	optional uint32 email_format = 3;
+	repeated CMsgAMSendEmail.PersonaNameReplacementToken persona_name_tokens = 5;
+	optional uint32 source_gc = 6;
+	repeated CMsgAMSendEmail.ReplacementToken tokens = 7;
+}
+
+message CMsgAMSendEmailResponse {
+	optional uint32 eresult = 1 [default = 2];
+}
+
+message CMsgGCGetEmailTemplate {
+	optional uint32 app_id = 1;
+	optional uint32 email_msg_type = 2;
+	optional int32 email_lang = 3;
+	optional int32 email_format = 4;
+}
+
+message CMsgGCGetEmailTemplateResponse {
+	optional uint32 eresult = 1 [default = 2];
+	optional bool template_exists = 2;
+	optional string template = 3;
+}
+
+message CMsgAMGrantGuestPasses2 {
+	optional fixed64 steam_id = 1;
+	optional uint32 package_id = 2;
+	optional int32 passes_to_grant = 3;
+	optional int32 days_to_expiration = 4;
+	optional int32 action = 5;
+}
+
+message CMsgAMGrantGuestPasses2Response {
+	optional int32 eresult = 1 [default = 2];
+	optional int32 passes_granted = 2 [default = 0];
+}
+
+message CGCSystemMsg_GetAccountDetails {
+	option (msgpool_soft_limit) = 128;
+	option (msgpool_hard_limit) = 512;
+
+	optional fixed64 steamid = 1;
+	optional uint32 appid = 2;
+}
+
+message CGCSystemMsg_GetAccountDetails_Response {
+	option (msgpool_soft_limit) = 128;
+	option (msgpool_hard_limit) = 512;
+
+	optional uint32 eresult_deprecated = 1 [default = 2];
+	optional string account_name = 2;
+	optional string persona_name = 3;
+	optional bool is_profile_public = 4;
+	optional bool is_inventory_public = 5;
+	optional bool is_vac_banned = 7;
+	optional bool is_cyber_cafe = 8;
+	optional bool is_school_account = 9;
+	optional bool is_limited = 10;
+	optional bool is_subscribed = 11;
+	optional uint32 package = 12;
+	optional bool is_free_trial_account = 13;
+	optional uint32 free_trial_expiration = 14;
+	optional bool is_low_violence = 15;
+	optional bool is_account_locked_down = 16;
+	optional bool is_community_banned = 17;
+	optional bool is_trade_banned = 18;
+	optional uint32 trade_ban_expiration = 19;
+	optional uint32 accountid = 20;
+	optional uint32 suspension_end_time = 21;
+	optional string currency = 22;
+	optional uint32 steam_level = 23;
+	optional uint32 friend_count = 24;
+	optional uint32 account_creation_time = 25;
+	optional bool is_steamguard_enabled = 27;
+	optional bool is_phone_verified = 28;
+	optional bool is_two_factor_auth_enabled = 29;
+	optional uint32 two_factor_enabled_time = 30;
+	optional uint32 phone_verification_time = 31;
+	optional uint64 phone_id = 33;
+	optional bool is_phone_identifying = 34;
+	optional uint32 rt_identity_linked = 35;
+	optional uint32 rt_birth_date = 36;
+	optional string txn_country_code = 37;
+}
+
+message CMsgGCCheckClanMembership {
+	optional fixed64 steamid = 1;
+	optional uint32 clanid = 2;
+}
+
+message CMsgGCCheckClanMembership_Response {
+	optional bool ismember = 1;
+}
+
+message CMsgGCGetPersonaNames {
+	repeated fixed64 steamids = 1;
+}
+
+message CMsgGCGetPersonaNames_Response {
+	message PersonaName {
+		optional fixed64 steamid = 1;
+		optional string persona_name = 2;
+	}
+
+	repeated CMsgGCGetPersonaNames_Response.PersonaName succeeded_lookups = 1;
+	repeated fixed64 failed_lookup_steamids = 2;
+}
+
+message CMsgGCCheckFriendship {
+	optional fixed64 steamid_left = 1;
+	optional fixed64 steamid_right = 2;
+}
+
+message CMsgGCCheckFriendship_Response {
+	optional bool success = 1;
+	optional bool found_friendship = 2;
+}
+
+message CMsgGCMsgMasterSetDirectory {
+	message SubGC {
+		optional uint32 dir_index = 1;
+		optional string name = 2;
+		optional string box = 3;
+		optional string command_line = 4;
+		optional string gc_binary = 5;
+	}
+
+	optional uint32 master_dir_index = 1;
+	repeated CMsgGCMsgMasterSetDirectory.SubGC dir = 2;
+}
+
+message CMsgGCMsgMasterSetDirectory_Response {
+	optional int32 eresult = 1 [default = 2];
+}
+
+message CMsgGCMsgWebAPIJobRequestForwardResponse {
+	optional uint32 dir_index = 1;
+}
+
+message CGCSystemMsg_GetPurchaseTrust_Request {
+	optional fixed64 steamid = 1;
+}
+
+message CGCSystemMsg_GetPurchaseTrust_Response {
+	optional bool has_prior_purchase_history = 1;
+	optional bool has_no_recent_password_resets = 2;
+	optional bool is_wallet_cash_trusted = 3;
+	optional uint32 time_all_trusted = 4;
+}
+
+message CMsgGCHAccountVacStatusChange {
+	optional fixed64 steam_id = 1;
+	optional uint32 app_id = 2;
+	optional uint32 rtime_vacban_starts = 3;
+	optional bool is_banned_now = 4;
+	optional bool is_banned_future = 5;
+}
+
+message CMsgGCHAccountTradeBanStatusChange {
+	optional fixed64 steamid = 1;
+	optional uint32 appid = 2;
+	optional bool is_banned = 3;
+	optional uint32 time_banned_until = 4;
+}
+
+message CMsgGCHAccountLockStatusChange {
+	optional fixed64 steamid = 1;
+	optional uint32 appid = 2;
+	optional bool is_locked = 3;
+}
+
+message CMsgGCHVacVerificationChange {
+	optional fixed64 steamid = 1;
+	optional uint32 appid = 2;
+	optional bool is_verified = 3;
+}
+
+message CMsgGCHAccountPhoneNumberChange {
+	optional fixed64 steamid = 1;
+	optional uint32 appid = 2;
+	optional uint64 phone_id = 3;
+	optional bool is_verified = 4;
+	optional bool is_identifying = 5;
+}
+
+message CMsgGCHAccountTwoFactorChange {
+	optional fixed64 steamid = 1;
+	optional uint32 appid = 2;
+	optional bool twofactor_enabled = 3;
+}
+
+message CMsgGCGetPartnerAccountLink {
+	optional fixed64 steamid = 1;
+}
+
+message CMsgGCGetPartnerAccountLink_Response {
+	optional uint32 pwid = 1;
+	optional uint32 nexonid = 2;
+}
+
+message CMsgGCRoutingInfo {
+	enum RoutingMethod {
+		RANDOM = 0;
+		DISCARD = 1;
+		CLIENT_STEAMID = 2;
+		PROTOBUF_FIELD_UINT64 = 3;
+		WEBAPI_PARAM_UINT64 = 4;
+	}
+
+	repeated uint32 dir_index = 1;
+	optional CMsgGCRoutingInfo.RoutingMethod method = 2 [default = RANDOM];
+	optional CMsgGCRoutingInfo.RoutingMethod fallback = 3 [default = DISCARD];
+	optional uint32 protobuf_field = 4;
+	optional string webapi_param = 5;
+}
+
+message CMsgGCMsgMasterSetWebAPIRouting {
+	message Entry {
+		optional string interface_name = 1;
+		optional string method_name = 2;
+		optional CMsgGCRoutingInfo routing = 3;
+	}
+
+	repeated CMsgGCMsgMasterSetWebAPIRouting.Entry entries = 1;
+}
+
+message CMsgGCMsgMasterSetClientMsgRouting {
+	message Entry {
+		optional uint32 msg_type = 1;
+		optional CMsgGCRoutingInfo routing = 2;
+	}
+
+	repeated CMsgGCMsgMasterSetClientMsgRouting.Entry entries = 1;
+}
+
+message CMsgGCMsgMasterSetWebAPIRouting_Response {
+	optional int32 eresult = 1 [default = 2];
+}
+
+message CMsgGCMsgMasterSetClientMsgRouting_Response {
+	optional int32 eresult = 1 [default = 2];
+}
+
+message CMsgGCMsgSetOptions {
+	message MessageRange {
+		required uint32 low = 1;
+		required uint32 high = 2;
+	}
+
+	enum Option {
+		NOTIFY_USER_SESSIONS = 0;
+		NOTIFY_SERVER_SESSIONS = 1;
+		NOTIFY_ACHIEVEMENTS = 2;
+		NOTIFY_VAC_ACTION = 3;
+	}
+
+	enum GCSQLVersion {
+		GCSQL_VERSION_BASELINE = 1;
+		GCSQL_VERSION_BOOLTYPE = 2;
+	}
+
+	repeated CMsgGCMsgSetOptions.Option options = 1;
+	repeated CMsgGCMsgSetOptions.MessageRange client_msg_ranges = 2;
+	optional CMsgGCMsgSetOptions.GCSQLVersion gcsql_version = 3 [default = GCSQL_VERSION_BASELINE];
+}
+
+message CMsgGCHUpdateSession {
+	message ExtraField {
+		optional string name = 1;
+		optional string value = 2;
+	}
+
+	optional fixed64 steam_id = 1;
+	optional uint32 app_id = 2;
+	optional bool online = 3;
+	optional fixed64 server_steam_id = 4;
+	optional uint32 server_addr = 5;
+	optional uint32 server_port = 6;
+	optional uint32 os_type = 7;
+	optional uint32 client_addr = 8;
+	repeated CMsgGCHUpdateSession.ExtraField extra_fields = 9;
+}
+
+message CMsgNotificationOfSuspiciousActivity {
+	message MultipleGameInstances {
+		optional uint32 app_instance_count = 1;
+		repeated fixed64 other_steamids = 2;
+	}
+
+	optional fixed64 steamid = 1;
+	optional uint32 appid = 2;
+	optional CMsgNotificationOfSuspiciousActivity.MultipleGameInstances multiple_instances = 3;
+}

--- a/dll/gc_tf2/base_gcmessages.proto
+++ b/dll/gc_tf2/base_gcmessages.proto
@@ -1,0 +1,598 @@
+import "steammessages.proto";
+
+option optimize_for = SPEED;
+option cc_generic_services = false;
+
+package gamecoordinator.tf2;
+
+enum EGCBaseMsg {
+	k_EMsgGCSystemMessage = 4001;
+	k_EMsgGCReplicateConVars = 4002;
+	k_EMsgGCConVarUpdated = 4003;
+	k_EMsgGCServerAvailable = 4506;
+	k_EMsgGCClientConnectToServer = 4507;
+	k_EMsgGCGameServerInfo = 4508;
+	k_EMsgGCError = 4509;
+	k_EMsgGCReplay_UploadedToYouTube = 4510;
+	k_EMsgGCLANServerAvailable = 4511;
+}
+
+enum EGCBaseProtoObjectTypes {
+	k_EProtoObjectPartyInvite = 1001;
+	k_EProtoObjectLobbyInvite = 1002;
+}
+
+enum GCGoodbyeReason {
+	GCGoodbyeReason_GC_GOING_DOWN = 1;
+	GCGoodbyeReason_NO_SESSION = 2;
+}
+
+message CGCStorePurchaseInit_LineItem {
+	optional uint32 item_def_id = 1;
+	optional uint32 quantity = 2;
+	optional uint32 cost_in_local_currency = 3;
+	optional uint32 purchase_type = 4;
+}
+
+message CMsgGCStorePurchaseInit {
+	optional string country = 1;
+	optional int32 language = 2;
+	optional int32 currency = 3;
+	repeated CGCStorePurchaseInit_LineItem line_items = 4;
+}
+
+message CMsgGCStorePurchaseInitResponse {
+	optional int32 result = 1;
+	optional uint64 txn_id = 2;
+}
+
+message CMsgSystemBroadcast {
+	optional string message = 1;
+}
+
+message CMsgClientHello {
+	optional uint32 version = 1;
+}
+
+message CMsgServerHello {
+	optional uint32 version = 1;
+}
+
+message CMsgClientWelcome {
+	optional uint32 version = 1;
+	optional bytes game_data = 2;
+	optional string txn_country_code = 3;
+}
+
+message CMsgServerWelcome {
+	optional uint32 min_allowed_version = 1;
+	optional uint32 active_version = 2;
+}
+
+message CMsgClientGoodbye {
+	optional GCGoodbyeReason reason = 1 [default = GCGoodbyeReason_GC_GOING_DOWN];
+}
+
+message CMsgServerGoodbye {
+	optional GCGoodbyeReason reason = 1 [default = GCGoodbyeReason_GC_GOING_DOWN];
+}
+
+message CMsgServerAvailable {
+}
+
+message CMsgLANServerAvailable {
+	optional fixed64 lobby_id = 1;
+}
+
+message CSOEconGameAccountClient {
+	optional uint32 additional_backpack_slots = 1 [default = 0];
+	optional bool trial_account = 2 [default = false];
+	optional bool need_to_choose_most_helpful_friend = 4;
+	optional bool in_coaches_list = 5;
+	optional fixed32 trade_ban_expiration = 6;
+	optional fixed32 duel_ban_expiration = 7;
+	optional uint32 preview_item_def = 8 [default = 0];
+	optional bool phone_verified = 19 [default = false];
+	optional uint32 skill_rating_6v6 = 20;
+	optional uint32 skill_rating_9v9 = 21;
+	optional bool competitive_access = 23 [default = false];
+	optional uint32 matchmaking_ranked_ban_expiration = 18;
+	optional uint32 matchmaking_ranked_low_priority_expiration = 24;
+	optional uint32 matchmaking_ranked_ban_last_duration = 25;
+	optional uint32 matchmaking_ranked_low_priority_last_duration = 26;
+	optional uint32 matchmaking_casual_ban_expiration = 27;
+	optional uint32 matchmaking_casual_low_priority_expiration = 28;
+	optional uint32 matchmaking_casual_ban_last_duration = 29;
+	optional uint32 matchmaking_casual_low_priority_last_duration = 30;
+	optional bool phone_identifying = 31 [default = false];
+	optional bool disable_party_quest_progress = 32 [default = false];
+	optional uint32 quest_reward_credits = 33;
+	optional uint32 matchmaking_last_casual_excessive_reports_auto_ban_time = 34;
+	optional uint32 matchmaking_last_comp_excessive_reports_auto_ban_time = 35;
+}
+
+message CSOItemCriteriaCondition {
+	optional int32 op = 1;
+	optional string field = 2;
+	optional bool required = 3;
+	optional float float_value = 4;
+	optional string string_value = 5;
+}
+
+message CSOItemCriteria {
+	optional uint32 item_level = 1;
+	optional int32 item_quality = 2;
+	optional bool item_level_set = 3;
+	optional bool item_quality_set = 4;
+	optional uint32 initial_inventory = 5;
+	optional uint32 initial_quantity = 6;
+	optional bool ignore_enabled_flag = 8;
+	repeated CSOItemCriteriaCondition conditions = 9;
+	optional bool recent_only = 10;
+	optional string tags = 11;
+	optional string equip_regions = 12;
+}
+
+message CSOItemRecipe {
+	optional uint32 def_index = 1;
+	optional string name = 2;
+	optional string n_a = 3;
+	optional string desc_inputs = 4;
+	optional string desc_outputs = 5;
+	optional string di_a = 6;
+	optional string di_b = 7;
+	optional string di_c = 8;
+	optional string do_a = 9;
+	optional string do_b = 10;
+	optional string do_c = 11;
+	optional bool requires_all_same_class = 12;
+	optional bool requires_all_same_slot = 13;
+	optional int32 class_usage_for_output = 14;
+	optional int32 slot_usage_for_output = 15;
+	optional int32 set_for_output = 16;
+	repeated CSOItemCriteria input_items_criteria = 20;
+	repeated CSOItemCriteria output_items_criteria = 21;
+	repeated uint32 input_item_dupe_counts = 22;
+}
+
+message CMsgDevNewItemRequest {
+	optional fixed64 receiver = 1;
+	optional CSOItemCriteria criteria = 2;
+}
+
+message CMsgDevDebugRollLootRequest {
+	optional fixed64 receiver = 1;
+	optional string loot_list_name = 2;
+}
+
+message CMsgIncrementKillCountAttribute {
+	optional uint64 killer_steam_id = 1;
+	optional uint64 victim_steam_id = 2;
+	optional uint64 item_id = 3;
+	optional uint32 event_type = 4;
+	optional uint32 increment_value = 5;
+}
+
+message CMsgIncrementKillCountAttribute_Multiple {
+	repeated CMsgIncrementKillCountAttribute msgs = 1;
+}
+
+message CMsgTrackUniquePlayerPairEvent {
+	optional uint64 killer_steam_id = 1;
+	optional uint64 victim_steam_id = 2;
+	optional uint64 item_id = 3;
+	optional uint32 event_type = 4;
+}
+
+message CMsgApplyStrangeCountTransfer {
+	optional uint64 tool_item_id = 1;
+	optional uint64 item_src_item_id = 2;
+	optional uint64 item_dest_item_id = 3;
+}
+
+message CMsgApplyStrangePart {
+	optional uint64 strange_part_item_id = 1;
+	optional uint64 item_item_id = 2;
+}
+
+message CMsgApplyStrangeRestriction {
+	optional uint64 strange_part_item_id = 1;
+	optional uint64 item_item_id = 2;
+	optional uint32 strange_attr_index = 3;
+}
+
+message CMsgApplyUpgradeCard {
+	optional uint64 upgrade_card_item_id = 1;
+	optional uint64 subject_item_id = 2;
+}
+
+message CSOEconItemAttribute {
+	optional uint32 def_index = 1;
+	optional uint32 value = 2;
+	optional bytes value_bytes = 3;
+}
+
+message CSOEconItemEquipped {
+	optional uint32 new_class = 1;
+	optional uint32 new_slot = 2;
+}
+
+message CSOEconItem {
+	optional uint64 id = 1;
+	optional uint32 account_id = 2;
+	optional uint32 inventory = 3;
+	optional uint32 def_index = 4;
+	optional uint32 quantity = 5;
+	optional uint32 level = 6;
+	optional uint32 quality = 7;
+	optional uint32 flags = 8 [default = 0];
+	optional uint32 origin = 9;
+	optional string custom_name = 10;
+	optional string custom_desc = 11;
+	repeated CSOEconItemAttribute attribute = 12;
+	optional CSOEconItem interior_item = 13;
+	optional bool in_use = 14 [default = false];
+	optional uint32 style = 15 [default = 0];
+	optional uint64 original_id = 16 [default = 0];
+	optional bool contains_equipped_state = 17;
+	repeated CSOEconItemEquipped equipped_state = 18;
+	optional bool contains_equipped_state_v2 = 19;
+}
+
+message CMsgAdjustItemEquippedState {
+	optional uint64 item_id = 1;
+	optional uint32 new_class = 2;
+	optional uint32 new_slot = 3;
+}
+
+message CMsgSortItems {
+	optional uint32 sort_type = 1;
+}
+
+message CSOEconClaimCode {
+	optional uint32 account_id = 1;
+	optional uint32 code_type = 2;
+	optional uint32 time_acquired = 3;
+	optional string code = 4;
+}
+
+message CMsgStoreGetUserData {
+	optional fixed32 price_sheet_version = 1;
+}
+
+message CMsgStoreGetUserDataResponse {
+	optional int32 result = 1;
+	optional int32 currency = 2;
+	optional string country = 3;
+	optional fixed32 price_sheet_version = 4;
+	optional uint64 experiment_data = 5 [default = 0];
+	optional int32 featured_item_idx = 6;
+	optional bool show_hat_descriptions = 7 [default = true];
+	optional bytes price_sheet = 8;
+	optional int32 default_item_sort = 9 [default = 0];
+	repeated uint32 popular_items = 10;
+}
+
+message CMsgUpdateItemSchema {
+	optional bytes items_game = 1;
+	optional fixed32 item_schema_version = 2;
+	optional string items_game_url = 3;
+	optional bytes signature = 4;
+}
+
+message CMsgGCError {
+	optional string error_text = 1;
+}
+
+message CMsgRequestInventoryRefresh {
+}
+
+message CMsgConVarValue {
+	optional string name = 1;
+	optional string value = 2;
+}
+
+message CMsgReplicateConVars {
+	repeated CMsgConVarValue convars = 1;
+}
+
+message CMsgUseItem {
+	optional uint64 item_id = 1;
+	optional fixed64 target_steam_id = 2;
+	repeated uint32 gift__potential_targets = 3;
+	optional uint32 duel__class_lock = 4;
+	optional fixed64 initiator_steam_id = 5;
+	optional bool itempack__ack_immediately = 6;
+}
+
+message CMsgReplayUploadedToYouTube {
+	optional string youtube_url = 1;
+	optional string youtube_account_name = 2;
+	optional uint64 session_id = 3;
+}
+
+message CMsgConsumableExhausted {
+	optional int32 item_def_id = 1;
+}
+
+message CMsgItemAcknowledged {
+	optional uint32 account_id = 1;
+	optional uint32 inventory = 2;
+	optional uint32 def_index = 3;
+	optional uint32 quality = 4;
+	optional uint32 rarity = 5;
+	optional uint32 origin = 6;
+	optional uint32 is_strange = 7;
+	optional uint32 is_unusual = 8;
+	optional float wear = 9;
+}
+
+message CMsgSetPresetItemPosition {
+	optional uint32 class_id = 1;
+	optional uint32 preset_id = 2;
+	optional uint32 slot_id = 3;
+	optional uint64 item_id = 4;
+}
+
+message CMsgSetItemPositions {
+	message ItemPosition {
+		optional uint64 item_id = 1;
+		optional uint32 position = 2;
+	}
+
+	repeated CMsgSetItemPositions.ItemPosition item_positions = 1;
+}
+
+message CSOEconItemPresetInstance {
+	optional uint32 class_id = 2 [(key_field) = true];
+	optional uint32 preset_id = 3 [(key_field) = true];
+	optional uint32 slot_id = 4 [(key_field) = true];
+	optional uint64 item_id = 5;
+}
+
+message CMsgSelectPresetForClass {
+	optional uint32 class_id = 1;
+	optional uint32 preset_id = 2;
+}
+
+message CSOClassPresetClientData {
+	optional uint32 account_id = 1;
+	optional uint32 class_id = 2;
+	optional uint32 active_preset_id = 3;
+}
+
+message CMsgGCReportAbuse {
+	optional fixed64 target_steam_id = 1;
+	optional string description = 4;
+	optional uint64 gid = 5;
+	optional uint32 abuse_type = 2;
+	optional uint32 content_type = 3;
+	optional fixed32 target_game_server_ip = 6;
+	optional uint32 target_game_server_port = 7;
+}
+
+message CMsgGCReportAbuseResponse {
+	optional fixed64 target_steam_id = 1;
+	optional uint32 result = 2;
+	optional string error_message = 3;
+}
+
+message CMsgGCNameItemNotification {
+	optional fixed64 player_steamid = 1;
+	optional uint32 item_def_index = 2;
+	optional string item_name_custom = 3;
+}
+
+message CMsgGCClientDisplayNotification {
+	optional string notification_title_localization_key = 1;
+	optional string notification_body_localization_key = 2;
+	repeated string body_substring_keys = 3;
+	repeated string body_substring_values = 4;
+}
+
+message CMsgGCShowItemsPickedUp {
+	optional fixed64 player_steamid = 1;
+}
+
+message CMsgUpdatePeriodicEvent {
+	optional uint32 account_id = 1;
+	optional uint32 event_type = 2;
+	optional uint32 amount = 3;
+}
+
+message CMsgGCIncrementKillCountResponse {
+	optional uint32 killer_account_id = 1 [(key_field) = true];
+	optional uint32 num_kills = 2;
+	optional uint32 item_def = 3;
+	optional uint32 level_type = 4;
+}
+
+message CMsgGCRemoveStrangePart {
+	optional uint64 item_id = 1;
+	optional uint32 strange_part_score_type = 2;
+}
+
+message CMsgGCRemoveUpgradeCard {
+	optional uint64 item_id = 1;
+	optional uint32 attribute_index = 2;
+}
+
+message CMsgGCRemoveCustomizationAttributeSimple {
+	optional uint64 item_id = 1;
+}
+
+message CMsgGCResetStrangeScores {
+	optional uint64 item_id = 1;
+}
+
+message CMsgGCItemPreviewItemBoughtNotification {
+	optional uint32 item_def_index = 1;
+}
+
+message CMsgGCStorePurchaseCancel {
+	optional uint64 txn_id = 1;
+}
+
+message CMsgGCStorePurchaseCancelResponse {
+	optional uint32 result = 1;
+}
+
+message CMsgGCStorePurchaseFinalize {
+	optional uint64 txn_id = 1;
+}
+
+message CMsgGCStorePurchaseFinalizeResponse {
+	optional uint32 result = 1;
+	repeated uint64 item_ids = 2;
+}
+
+message CMsgGCBannedWordListRequest {
+	optional uint32 ban_list_group_id = 1;
+	optional uint32 word_id = 2;
+}
+
+message CMsgGCGiftedItems {
+	optional uint64 gifter_steam_id = 1;
+	optional bool was_random_person = 2;
+	repeated uint32 recipient_account_ids = 3;
+}
+
+message CMsgGCCollectItem {
+	optional uint64 collection_item_id = 1;
+	optional uint64 subject_item_id = 2;
+}
+
+message CMsgGCClientMarketDataRequest {
+	optional uint32 user_currency = 1;
+}
+
+message CMsgGCClientMarketDataEntry {
+	optional uint32 item_def_index = 1;
+	optional uint32 item_quality = 2;
+	optional uint32 item_sell_listings = 3;
+	optional uint32 price_in_local_currency = 4;
+}
+
+message CMsgGCClientMarketData {
+	repeated CMsgGCClientMarketDataEntry entries = 1;
+}
+
+message CMsgApplyToolToItem {
+	optional uint64 tool_item_id = 1;
+	optional uint64 subject_item_id = 2;
+}
+
+message CMsgApplyToolToBaseItem {
+	optional uint64 tool_item_id = 1;
+	optional uint32 baseitem_def_index = 2;
+}
+
+message CMsgRecipeComponent {
+	optional uint64 subject_item_id = 1;
+	optional uint64 attribute_index = 2;
+}
+
+message CMsgFulfillDynamicRecipeComponent {
+	optional uint64 tool_item_id = 1;
+	repeated CMsgRecipeComponent consumption_components = 2;
+}
+
+message CMsgSetItemEffectVerticalOffset {
+	optional uint64 item_id = 1;
+	optional float offset = 2;
+}
+
+message CMsgSetHatEffectUseHeadOrigin {
+	optional uint64 item_id = 1;
+	optional bool use_head = 2;
+}
+
+message CMsgDeliverGiftResponseGiver {
+	optional uint32 response_code = 1;
+	optional string receiver_account_name = 2;
+}
+
+message CSOEconGameAccountForGameServers {
+	optional bool disable_party_quest_progress = 6 [default = false];
+}
+
+message CWorkshop_PopulateItemDescriptions_Request {
+	message SingleItemDescription {
+		optional uint32 gameitemid = 1;
+		optional string item_description = 2;
+	}
+
+	message ItemDescriptionsLanguageBlock {
+		optional string language = 1;
+		repeated CWorkshop_PopulateItemDescriptions_Request.SingleItemDescription descriptions = 2;
+	}
+
+	optional uint32 appid = 1;
+	repeated CWorkshop_PopulateItemDescriptions_Request.ItemDescriptionsLanguageBlock languages = 2;
+}
+
+message CWorkshop_GetContributors_Request {
+	optional uint32 appid = 1;
+	optional uint32 gameitemid = 2;
+}
+
+message CWorkshop_GetContributors_Response {
+	repeated fixed64 contributors = 1;
+}
+
+message CWorkshop_SetItemPaymentRules_Request {
+	message WorkshopItemPaymentRule {
+		optional uint64 workshop_file_id = 1;
+		optional float revenue_percentage = 2;
+		optional string rule_description = 3;
+	}
+
+	message WorkshopDirectPaymentRule {
+		optional uint64 workshop_file_id = 1;
+		optional string rule_description = 2;
+	}
+
+	message PartnerItemPaymentRule {
+		optional uint32 account_id = 1;
+		optional float revenue_percentage = 2;
+		optional string rule_description = 3;
+	}
+
+	optional uint32 appid = 1;
+	optional uint32 gameitemid = 2;
+	repeated CWorkshop_SetItemPaymentRules_Request.WorkshopItemPaymentRule associated_workshop_files = 3;
+	repeated CWorkshop_SetItemPaymentRules_Request.PartnerItemPaymentRule partner_accounts = 4;
+	optional CWorkshop_SetItemPaymentRules_Request.WorkshopDirectPaymentRule associated_workshop_file_for_direct_payments = 7;
+}
+
+message CWorkshop_SetItemPaymentRules_Response {
+}
+
+message CWorkshop_AddSpecialPayment_Request {
+	optional uint32 appid = 1;
+	optional uint32 gameitemid = 2;
+	optional string date = 3;
+	optional uint64 payment_us_usd = 4;
+	optional uint64 payment_row_usd = 5;
+}
+
+message CWorkshop_AddSpecialPayment_Response {
+}
+
+message CWorkshop_GetSpecialPayments_Request {
+	optional uint32 appid = 1;
+	optional uint32 gameitemid = 2;
+	optional string date = 3;
+}
+
+message CWorkshop_GetSpecialPayments_Response {
+	message SpecialPayment {
+		optional uint32 appid = 1;
+		optional uint32 gameitemid = 2;
+		optional string date = 3;
+		optional uint64 net_payment_us_usd = 4;
+		optional uint64 net_payment_row_usd = 5;
+	}
+
+	repeated CWorkshop_GetSpecialPayments_Response.SpecialPayment special_payments = 1;
+}

--- a/dll/gc_tf2/econ_gcmessages.proto
+++ b/dll/gc_tf2/econ_gcmessages.proto
@@ -1,0 +1,370 @@
+import "steammessages.proto";
+
+option optimize_for = SPEED;
+option cc_generic_services = false;
+
+package gamecoordinator.tf2;
+
+enum EGCItemMsg {
+	k_EMsgGCBase = 1000;
+	k_EMsgGCSetSingleItemPosition = 1001;
+	k_EMsgGCCraft = 1002;
+	k_EMsgGCCraftResponse = 1003;
+	k_EMsgGCDelete = 1004;
+	k_EMsgGCVerifyCacheSubscription = 1005;
+	k_EMsgGCNameItem = 1006;
+	k_EMsgGCUnlockCrate = 1007;
+	k_EMsgGCUnlockCrateResponse = 1008;
+	k_EMsgGCPaintItem = 1009;
+	k_EMsgGCPaintItemResponse = 1010;
+	k_EMsgGCGoldenWrenchBroadcast = 1011;
+	k_EMsgGCMOTDRequest = 1012;
+	k_EMsgGCMOTDRequestResponse = 1013;
+	k_EMsgGCNameBaseItem = 1019;
+	k_EMsgGCNameBaseItemResponse = 1020;
+	k_EMsgGCRemoveSocketItem_DEPRECATED = 1021;
+	k_EMsgGCRemoveSocketItemResponse_DEPRECATED = 1022;
+	k_EMsgGCCustomizeItemTexture = 1023;
+	k_EMsgGCCustomizeItemTextureResponse = 1024;
+	k_EMsgGCUseItemRequest = 1025;
+	k_EMsgGCUseItemResponse = 1026;
+	k_EMsgGCRespawnPostLoadoutChange = 1029;
+	k_EMsgGCRemoveItemName = 1030;
+	k_EMsgGCRemoveItemPaint = 1031;
+	k_EMsgGCGiftWrapItem = 1032;
+	k_EMsgGCGiftWrapItemResponse = 1033;
+	k_EMsgGCDeliverGift = 1034;
+	k_EMsgGCDeliverGiftResponseReceiver = 1036;
+	k_EMsgGCUnwrapGiftRequest = 1037;
+	k_EMsgGCUnwrapGiftResponse = 1038;
+	k_EMsgGCSetItemStyle = 1039;
+	k_EMsgGCUsedClaimCodeItem = 1040;
+	k_EMsgGCSortItems = 1041;
+	k_EMsgGC_RevolvingLootList_DEPRECATED = 1042;
+	k_EMsgGCLookupAccount = 1043;
+	k_EMsgGCLookupAccountResponse = 1044;
+	k_EMsgGCLookupAccountName = 1045;
+	k_EMsgGCLookupAccountNameResponse = 1046;
+	k_EMsgGCUpdateItemSchema = 1049;
+	k_EMsgGCRequestInventoryRefresh = 1050;
+	k_EMsgGCRemoveCustomTexture = 1051;
+	k_EMsgGCRemoveCustomTextureResponse = 1052;
+	k_EMsgGCRemoveMakersMark = 1053;
+	k_EMsgGCRemoveMakersMarkResponse = 1054;
+	k_EMsgGCRemoveUniqueCraftIndex = 1055;
+	k_EMsgGCRemoveUniqueCraftIndexResponse = 1056;
+	k_EMsgGCSaxxyBroadcast = 1057;
+	k_EMsgGCBackpackSortFinished = 1058;
+	k_EMsgGCAdjustItemEquippedState = 1059;
+	k_EMsgGCCollectItem = 1061;
+	k_EMsgGCItemAcknowledged = 1062;
+	k_EMsgGCPresets_SelectPresetForClass = 1063;
+	k_EMsgGCPresets_SetItemPosition = 1064;
+	k_EMsgGC_ReportAbuse = 1065;
+	k_EMsgGC_ReportAbuseResponse = 1066;
+	k_EMsgGCPresets_SelectPresetForClassReply = 1067;
+	k_EMsgGCNameItemNotification = 1068;
+	k_EMsgGCClientDisplayNotification = 1069;
+	k_EMsgGCApplyStrangePart = 1070;
+	k_EMsgGC_IncrementKillCountAttribute = 1071;
+	k_EMsgGC_IncrementKillCountResponse = 1072;
+	k_EMsgGCRemoveStrangePart = 1073;
+	k_EMsgGCResetStrangeScores = 1074;
+	k_EMsgGCGiftedItems = 1075;
+	k_EMsgGCApplyUpgradeCard = 1077;
+	k_EMsgGCRemoveUpgradeCard = 1078;
+	k_EMsgGCApplyStrangeRestriction = 1079;
+	k_EMsgGCClientRequestMarketData = 1080;
+	k_EMsgGCClientRequestMarketDataResponse = 1081;
+	k_EMsgGCApplyXifier = 1082;
+	k_EMsgGCApplyXifierResponse = 1083;
+	k_EMsgGC_TrackUniquePlayerPairEvent = 1084;
+	k_EMsgGCFulfillDynamicRecipeComponent = 1085;
+	k_EMsgGCFulfillDynamicRecipeComponentResponse = 1086;
+	k_EMsgGCSetItemEffectVerticalOffset = 1087;
+	k_EMsgGCSetHatEffectUseHeadOrigin = 1088;
+	k_EMsgGCItemEaterRecharger = 1089;
+	k_EMsgGCItemEaterRechargerResponse = 1090;
+	k_EMsgGCApplyBaseItemXifier = 1091;
+	k_EMsgGCApplyClassTransmogrifier = 1092;
+	k_EMsgGCApplyHalloweenSpellbookPage = 1093;
+	k_EMsgGCRemoveKillStreak = 1094;
+	k_EMsgGCRemoveKillStreakResponse = 1095;
+	k_EMsgGCTFSpecificItemBroadcast = 1096;
+	k_EMsgGC_IncrementKillCountAttribute_Multiple = 1097;
+	k_EMsgGCDeliverGiftResponseGiver = 1098;
+	k_EMsgGCSetItemPositions = 1100;
+	k_EMsgGCLookupMultipleAccountNames = 1101;
+	k_EMsgGCLookupMultipleAccountNamesResponse = 1102;
+	k_EMsgGCTradingBase = 1500;
+	k_EMsgGCTrading_InitiateTradeRequest = 1501;
+	k_EMsgGCTrading_InitiateTradeResponse = 1502;
+	k_EMsgGCTrading_StartSession = 1503;
+	k_EMsgGCTrading_SessionClosed = 1509;
+	k_EMsgGCTrading_CancelSession = 1510;
+	k_EMsgGCTrading_InitiateTradeRequestResponse = 1514;
+	k_EMsgGCServerBrowser_FavoriteServer = 1601;
+	k_EMsgGCServerBrowser_BlacklistServer = 1602;
+	k_EMsgGCServerRentalsBase = 1700;
+	k_EMsgGCItemPreviewCheckStatus = 1701;
+	k_EMsgGCItemPreviewStatusResponse = 1702;
+	k_EMsgGCItemPreviewRequest = 1703;
+	k_EMsgGCItemPreviewRequestResponse = 1704;
+	k_EMsgGCItemPreviewExpire = 1705;
+	k_EMsgGCItemPreviewExpireNotification = 1706;
+	k_EMsgGCItemPreviewItemBoughtNotification = 1708;
+	k_EMsgGCDev_NewItemRequest = 2001;
+	k_EMsgGCDev_NewItemRequestResponse = 2002;
+	k_EMsgGCDev_DebugRollLootRequest = 2003;
+	k_EMsgGCStoreGetUserData = 2500;
+	k_EMsgGCStoreGetUserDataResponse = 2501;
+	k_EMsgGCStorePurchaseInit_DEPRECATED = 2502;
+	k_EMsgGCStorePurchaseInitResponse_DEPRECATED = 2503;
+	k_EMsgGCStorePurchaseFinalize = 2512;
+	k_EMsgGCStorePurchaseFinalizeResponse = 2513;
+	k_EMsgGCStorePurchaseCancel = 2514;
+	k_EMsgGCStorePurchaseCancelResponse = 2515;
+	k_EMsgGCStorePurchaseQueryTxn = 2508;
+	k_EMsgGCStorePurchaseQueryTxnResponse = 2509;
+	k_EMsgGCStorePurchaseInit = 2510;
+	k_EMsgGCStorePurchaseInitResponse = 2511;
+	k_EMsgGCToGCDirtySDOCache = 2516;
+	k_EMsgGCToGCDirtyMultipleSDOCache = 2517;
+	k_EMsgGCToGCUpdateSQLKeyValue = 2518;
+	k_EMsgGCToGCBroadcastConsoleCommand = 2521;
+	k_EMsgGCServerVersionUpdated = 2522;
+	k_EMsgGCApplyAutograph = 2523;
+	k_EMsgGCToGCWebAPIAccountChanged = 2524;
+	k_EMsgGCRequestAnnouncements = 2525;
+	k_EMsgGCRequestAnnouncementsResponse = 2526;
+	k_EMsgGCRequestPassportItemGrant = 2527;
+	k_EMsgGCClientVersionUpdated = 2528;
+	k_EMsgGCItemPurgatory_FinalizePurchase = 2531;
+	k_EMsgGCItemPurgatory_FinalizePurchaseResponse = 2532;
+	k_EMsgGCItemPurgatory_RefundPurchase = 2533;
+	k_EMsgGCItemPurgatory_RefundPurchaseResponse = 2534;
+	k_EMsgGCToGCPlayerStrangeCountAdjustments = 2535;
+	k_EMsgGCRequestStoreSalesData = 2536;
+	k_EMsgGCRequestStoreSalesDataResponse = 2537;
+	k_EMsgGCRequestStoreSalesDataUpToDateResponse = 2538;
+	k_EMsgGCToGCPingRequest = 2539;
+	k_EMsgGCToGCPingResponse = 2540;
+	k_EMsgGCToGCGetUserSessionServer = 2541;
+	k_EMsgGCToGCGetUserSessionServerResponse = 2542;
+	k_EMsgGCToGCGetUserServerMembers = 2543;
+	k_EMsgGCToGCGetUserServerMembersResponse = 2544;
+	k_EMsgGCToGCGrantSelfMadeItemToAccount = 2555;
+	k_EMsgGCToGCThankedByNewUser = 2556;
+	k_EMsgGCShuffleCrateContents = 2557;
+	k_EMsgGCQuestObjective_Progress = 2558;
+	k_EMsgGCQuestCompleted = 2559;
+	k_EMsgGCApplyDuckToken = 2560;
+	k_EMsgGCQuestObjective_PointsChange = 2562;
+	k_EMsgGCQuestObjective_RequestLoanerItems = 2564;
+	k_EMsgGCQuestObjective_RequestLoanerResponse = 2565;
+	k_EMsgGCApplyStrangeCountTransfer = 2566;
+	k_EMsgGCCraftCollectionUpgrade = 2567;
+	k_EMsgGCCraftHalloweenOffering = 2568;
+	k_EMsgGCQuestDiscard_Request = 2569;
+	k_EMsgGCRemoveGiftedBy = 2570;
+	k_EMsgGCRemoveGiftedByResponse = 2571;
+	k_EMsgGCRemoveFestivizer = 2572;
+	k_EMsgGCRemoveFestivizerResponse = 2573;
+	k_EMsgGCCraftCommonStatClock = 2574;
+}
+
+enum EGCMsgResponse {
+	k_EGCMsgResponseOK = 0;
+	k_EGCMsgResponseDenied = 1;
+	k_EGCMsgResponseServerError = 2;
+	k_EGCMsgResponseTimeout = 3;
+	k_EGCMsgResponseInvalid = 4;
+	k_EGCMsgResponseNoMatch = 5;
+	k_EGCMsgResponseUnknownError = 6;
+	k_EGCMsgResponseNotLoggedOn = 7;
+	k_EGCMsgFailedToCreate = 8;
+}
+
+enum EUnlockStyle {
+	k_UnlockStyle_Succeeded = 0;
+	k_UnlockStyle_Failed_PreReq = 1;
+	k_UnlockStyle_Failed_CantAfford = 2;
+	k_UnlockStyle_Failed_CantCommit = 3;
+	k_UnlockStyle_Failed_CantLockCache = 4;
+	k_UnlockStyle_Failed_CantAffordAttrib = 5;
+	k_UnlockStyle_Failed_CantAffordGem = 6;
+}
+
+enum EItemPurgatoryResponse_Finalize {
+	k_ItemPurgatoryResponse_Finalize_Succeeded = 0;
+	k_ItemPurgatoryResponse_Finalize_Failed_Incomplete = 1;
+	k_ItemPurgatoryResponse_Finalize_Failed_ItemsNotInPurgatory = 2;
+	k_ItemPurgatoryResponse_Finalize_Failed_CouldNotFindItems = 3;
+	k_ItemPurgatoryResponse_Finalize_Failed_NoSOCache = 4;
+	k_ItemPurgatoryResponse_Finalize_BackpackFull = 5;
+}
+
+enum EItemPurgatoryResponse_Refund {
+	k_ItemPurgatoryResponse_Refund_Succeeded = 0;
+	k_ItemPurgatoryResponse_Refund_Failed_ItemNotInPurgatory = 1;
+	k_ItemPurgatoryResponse_Refund_Failed_CouldNotFindItem = 2;
+	k_ItemPurgatoryResponse_Refund_Failed_NoSOCache = 3;
+	k_ItemPurgatoryResponse_Refund_Failed_NoDetail = 4;
+	k_ItemPurgatoryResponse_Refund_Failed_NexonWebAPI = 5;
+}
+
+message CMsgApplyAutograph {
+	optional uint64 autograph_item_id = 1;
+	optional uint64 item_item_id = 2;
+}
+
+message CMsgEconPlayerStrangeCountAdjustment {
+	message CStrangeCountAdjustment {
+		optional uint32 event_type = 1;
+		optional uint64 item_id = 2;
+		optional uint32 adjustment = 3;
+	}
+
+	optional uint32 account_id = 1;
+	repeated CMsgEconPlayerStrangeCountAdjustment.CStrangeCountAdjustment strange_count_adjustments = 2;
+}
+
+message CMsgRequestItemPurgatory_FinalizePurchase {
+	repeated uint64 item_ids = 1;
+}
+
+message CMsgRequestItemPurgatory_FinalizePurchaseResponse {
+	optional uint32 result = 1;
+}
+
+message CMsgRequestItemPurgatory_RefundPurchase {
+	optional uint64 item_id = 1;
+}
+
+message CMsgRequestItemPurgatory_RefundPurchaseResponse {
+	optional uint32 result = 1;
+}
+
+message CMsgCraftingResponse {
+	repeated uint64 item_ids = 1;
+}
+
+message CMsgGCRequestStoreSalesData {
+	optional uint32 version = 1;
+	optional uint32 currency = 2;
+}
+
+message CMsgGCRequestStoreSalesDataResponse {
+	message Price {
+		optional uint32 item_def = 1;
+		optional uint32 price = 2;
+	}
+
+	repeated CMsgGCRequestStoreSalesDataResponse.Price sale_price = 1;
+	optional uint32 version = 2;
+	optional uint32 expiration_time = 3;
+}
+
+message CMsgGCRequestStoreSalesDataUpToDateResponse {
+	optional uint32 version = 1;
+	optional uint32 expiration_time = 2;
+}
+
+message CMsgGCToGCPingRequest {
+}
+
+message CMsgGCToGCPingResponse {
+}
+
+message CMsgGCToGCGetUserSessionServer {
+	optional uint32 account_id = 1;
+}
+
+message CMsgGCToGCGetUserSessionServerResponse {
+	optional fixed64 server_steam_id = 1;
+}
+
+message CMsgGCToGCGetUserServerMembers {
+	optional uint32 account_id = 1;
+	optional uint32 max_spectators = 2;
+}
+
+message CMsgGCToGCGetUserServerMembersResponse {
+	repeated uint32 member_account_id = 1;
+}
+
+message CMsgLookupMultipleAccountNames {
+	repeated uint32 accountids = 1 [packed = true];
+}
+
+message CMsgLookupMultipleAccountNamesResponse {
+	message Account {
+		optional uint32 accountid = 1;
+		optional string persona = 2;
+	}
+
+	repeated CMsgLookupMultipleAccountNamesResponse.Account accounts = 1;
+}
+
+message CMsgGCToGCGrantSelfMadeItemToAccount {
+	optional uint32 item_def_index = 1;
+	optional uint32 accountid = 2;
+}
+
+message CMsgGCToGCThankedByNewUser {
+	optional uint32 new_user_accountid = 1;
+	optional uint32 thanked_user_accountid = 2;
+}
+
+message CMsgGCShuffleCrateContents {
+	optional uint64 crate_item_id = 1;
+	optional string user_code_string = 2;
+}
+
+message CMsgGCQuestObjective_Progress {
+	optional uint64 quest_id = 1;
+	optional uint32 quest_attrib_index = 2;
+	optional uint32 delta = 3;
+	optional fixed64 owner_steamid = 4;
+}
+
+message CMsgGCQuestObjective_PointsChange {
+	optional uint64 quest_id = 1;
+	optional fixed64 owner_steamid = 4;
+	optional bool update_base_points = 5 [default = false];
+	optional uint32 points_0 = 6;
+	optional uint32 points_1 = 7;
+	optional uint32 points_2 = 8;
+}
+
+message CMsgGCQuestComplete_Request {
+	optional uint64 quest_id = 1;
+}
+
+message CMsgGCQuestCompleted {
+}
+
+message CMsgGCQuestObjective_RequestLoanerItems {
+	optional uint64 quest_id = 1;
+}
+
+message CMsgGCQuestObjective_RequestLoanerResponse {
+}
+
+message CMsgCraftCollectionUpgrade {
+	repeated uint64 item_id = 1;
+}
+
+message CMsgCraftHalloweenOffering {
+	optional uint64 tool_id = 1;
+	repeated uint64 item_id = 2;
+}
+
+message CMsgCraftCommonStatClock {
+	optional uint64 tool_id = 1;
+	repeated uint64 item_id = 2;
+}
+
+message CMsgGCQuestDiscard_Request {
+	optional uint64 quest_id = 1;
+}

--- a/dll/gc_tf2/gcsdk_gcmessages.proto
+++ b/dll/gc_tf2/gcsdk_gcmessages.proto
@@ -1,0 +1,188 @@
+import "steammessages.proto";
+
+option optimize_for = SPEED;
+option cc_generic_services = false;
+
+package gamecoordinator.tf2;
+
+enum PartnerAccountType {
+	PARTNER_NONE = 0;
+	PARTNER_PERFECT_WORLD = 1;
+	PARTNER_NEXON = 2;
+}
+
+enum GCConnectionStatus {
+	GCConnectionStatus_HAVE_SESSION = 0;
+	GCConnectionStatus_GC_GOING_DOWN = 1;
+	GCConnectionStatus_NO_SESSION = 2;
+	GCConnectionStatus_NO_SESSION_IN_LOGON_QUEUE = 3;
+	GCConnectionStatus_NO_STEAM = 4;
+	GCConnectionStatus_SUSPENDED = 5;
+}
+
+message CMsgSOIDOwner {
+	optional uint32 type = 1;
+	optional uint64 id = 2;
+}
+
+message CMsgSOSingleObject {
+	optional fixed64 owner = 1;
+	optional int32 type_id = 2;
+	optional bytes object_data = 3;
+	optional fixed64 version = 4;
+	optional CMsgSOIDOwner owner_soid = 5;
+	optional uint32 service_id = 6;
+}
+
+message CMsgSOMultipleObjects {
+	message SingleObject {
+		optional int32 type_id = 1;
+		optional bytes object_data = 2;
+	}
+
+	optional fixed64 owner = 1;
+	repeated CMsgSOMultipleObjects.SingleObject objects = 2;
+	optional fixed64 version = 3;
+	optional CMsgSOIDOwner owner_soid = 6;
+	optional uint32 service_id = 7;
+}
+
+message CMsgSOCacheSubscribed {
+	message SubscribedType {
+		optional int32 type_id = 1;
+		repeated bytes object_data = 2;
+	}
+
+	optional fixed64 owner = 1;
+	repeated CMsgSOCacheSubscribed.SubscribedType objects = 2;
+	optional fixed64 version = 3;
+	optional CMsgSOIDOwner owner_soid = 4;
+	optional uint32 service_id = 5;
+	repeated uint32 service_list = 6;
+	optional fixed64 sync_version = 7;
+}
+
+message CMsgSOCacheSubscribedUpToDate {
+	optional fixed64 version = 1;
+	optional CMsgSOIDOwner owner_soid = 2;
+	optional uint32 service_id = 3;
+	repeated uint32 service_list = 4;
+	optional fixed64 sync_version = 5;
+}
+
+message CMsgSOCacheUnsubscribed {
+	optional fixed64 owner = 1;
+}
+
+message CMsgSOCacheSubscriptionCheck {
+	optional fixed64 owner = 1;
+	optional fixed64 version = 2;
+	optional CMsgSOIDOwner owner_soid = 3;
+	optional uint32 service_id = 4;
+	repeated uint32 service_list = 5;
+	optional fixed64 sync_version = 6;
+}
+
+message CMsgSOCacheSubscriptionRefresh {
+	optional fixed64 owner = 1;
+	optional CMsgSOIDOwner owner_soid = 2;
+}
+
+message CMsgSOCacheVersion {
+	optional fixed64 version = 1;
+}
+
+message CMsgGCMultiplexMessage {
+	optional uint32 msgtype = 1;
+	optional bytes payload = 2;
+	repeated fixed64 steamids = 3;
+}
+
+message CGCToGCMsgMasterAck {
+	optional uint32 dir_index = 1;
+	optional string machine_name = 3;
+	optional string process_name = 4;
+	repeated uint32 type_instances = 5;
+}
+
+message CGCToGCMsgMasterAck_Response {
+	optional int32 eresult = 1 [default = 2];
+}
+
+message CGCToGCMsgMasterStartupComplete {
+	message GCInfo {
+		optional uint32 dir_index = 1;
+		optional string machine_name = 2;
+	}
+
+	repeated CGCToGCMsgMasterStartupComplete.GCInfo gc_info = 1;
+}
+
+message CGCToGCMsgRouted {
+	optional uint32 msg_type = 1;
+	optional fixed64 sender_id = 2;
+	optional bytes net_message = 3;
+}
+
+message CGCToGCMsgRoutedReply {
+	optional uint32 msg_type = 1;
+	optional bytes net_message = 2;
+}
+
+message CMsgGCUpdateSubGCSessionInfo {
+	message CMsgUpdate {
+		optional fixed64 steamid = 1;
+		optional fixed32 ip = 2;
+		optional bool trusted = 3;
+	}
+
+	repeated CMsgGCUpdateSubGCSessionInfo.CMsgUpdate updates = 1;
+}
+
+message CMsgGCRequestSubGCSessionInfo {
+	optional fixed64 steamid = 1;
+}
+
+message CMsgGCRequestSubGCSessionInfoResponse {
+	optional fixed32 ip = 1;
+	optional bool trusted = 2;
+}
+
+message CMsgGCToGCIncrementRecruitmentLevel {
+	optional fixed64 steamid = 1;
+}
+
+message CMsgSOCacheHaveVersion {
+	optional CMsgSOIDOwner soid = 1;
+	optional fixed64 version = 2;
+	optional uint32 service_id = 3;
+}
+
+message CMsgConnectionStatus {
+	optional GCConnectionStatus status = 1 [default = GCConnectionStatus_HAVE_SESSION];
+	optional uint32 client_session_need = 2;
+	optional int32 queue_position = 3;
+	optional int32 queue_size = 4;
+	optional int32 wait_seconds = 5;
+	optional int32 estimated_wait_seconds_remaining = 6;
+}
+
+message CMsgGCToGCSOCacheSubscribe {
+	message CMsgHaveVersions {
+		optional uint32 service_id = 1;
+		optional uint64 version = 2;
+	}
+
+	optional fixed64 subscriber = 1;
+	optional fixed64 subscribe_to = 2;
+	optional fixed64 sync_version = 3;
+	repeated CMsgGCToGCSOCacheSubscribe.CMsgHaveVersions have_versions = 4;
+}
+
+message CMsgGCToGCSOCacheUnsubscribe {
+	optional fixed64 subscriber = 1;
+	optional fixed64 unsubscribe_from = 2;
+}
+
+message CMsgGCClientPing {
+}

--- a/dll/gc_tf2/gcsystemmsgs.proto
+++ b/dll/gc_tf2/gcsystemmsgs.proto
@@ -1,0 +1,180 @@
+option optimize_for = SPEED;
+option cc_generic_services = false;
+
+package gamecoordinator.tf2;
+
+enum EGCSystemMsg {
+	k_EGCMsgInvalid = 0;
+	k_EGCMsgMulti = 1;
+	k_EGCMsgGenericReply = 10;
+	k_EGCMsgSystemBase = 50;
+	k_EGCMsgAchievementAwarded = 51;
+	k_EGCMsgConCommand = 52;
+	k_EGCMsgStartPlaying = 53;
+	k_EGCMsgStopPlaying = 54;
+	k_EGCMsgStartGameserver = 55;
+	k_EGCMsgStopGameserver = 56;
+	k_EGCMsgWGRequest = 57;
+	k_EGCMsgWGResponse = 58;
+	k_EGCMsgGetUserGameStatsSchema = 59;
+	k_EGCMsgGetUserGameStatsSchemaResponse = 60;
+	k_EGCMsgGetUserStatsDEPRECATED = 61;
+	k_EGCMsgGetUserStatsResponse = 62;
+	k_EGCMsgAppInfoUpdated = 63;
+	k_EGCMsgValidateSession = 64;
+	k_EGCMsgValidateSessionResponse = 65;
+	k_EGCMsgLookupAccountFromInput = 66;
+	k_EGCMsgSendHTTPRequest = 67;
+	k_EGCMsgSendHTTPRequestResponse = 68;
+	k_EGCMsgPreTestSetup = 69;
+	k_EGCMsgRecordSupportAction = 70;
+	k_EGCMsgGetAccountDetails_DEPRECATED = 71;
+	k_EGCMsgReceiveInterAppMessage = 73;
+	k_EGCMsgFindAccounts = 74;
+	k_EGCMsgPostAlert = 75;
+	k_EGCMsgGetLicenses = 76;
+	k_EGCMsgGetUserStats = 77;
+	k_EGCMsgGetCommands = 78;
+	k_EGCMsgGetCommandsResponse = 79;
+	k_EGCMsgAddFreeLicense = 80;
+	k_EGCMsgAddFreeLicenseResponse = 81;
+	k_EGCMsgGetIPLocation = 82;
+	k_EGCMsgGetIPLocationResponse = 83;
+	k_EGCMsgSystemStatsSchema = 84;
+	k_EGCMsgGetSystemStats = 85;
+	k_EGCMsgGetSystemStatsResponse = 86;
+	k_EGCMsgSendEmail = 87;
+	k_EGCMsgSendEmailResponse = 88;
+	k_EGCMsgGetEmailTemplate = 89;
+	k_EGCMsgGetEmailTemplateResponse = 90;
+	k_EGCMsgGrantGuestPass = 91;
+	k_EGCMsgGrantGuestPassResponse = 92;
+	k_EGCMsgGetAccountDetails = 93;
+	k_EGCMsgGetAccountDetailsResponse = 94;
+	k_EGCMsgGetPersonaNames = 95;
+	k_EGCMsgGetPersonaNamesResponse = 96;
+	k_EGCMsgMultiplexMsg = 97;
+	k_EGCMsgWebAPIRegisterInterfaces = 101;
+	k_EGCMsgWebAPIJobRequest = 102;
+	k_EGCMsgWebAPIJobRequestHttpResponse = 104;
+	k_EGCMsgWebAPIJobRequestForwardResponse = 105;
+	k_EGCMsgMemCachedGet = 200;
+	k_EGCMsgMemCachedGetResponse = 201;
+	k_EGCMsgMemCachedSet = 202;
+	k_EGCMsgMemCachedDelete = 203;
+	k_EGCMsgMemCachedStats = 204;
+	k_EGCMsgMemCachedStatsResponse = 205;
+	k_EGCMsgSQLStats = 210;
+	k_EGCMsgSQLStatsResponse = 211;
+	k_EGCMsgMasterSetDirectory = 220;
+	k_EGCMsgMasterSetDirectoryResponse = 221;
+	k_EGCMsgMasterSetWebAPIRouting = 222;
+	k_EGCMsgMasterSetWebAPIRoutingResponse = 223;
+	k_EGCMsgMasterSetClientMsgRouting = 224;
+	k_EGCMsgMasterSetClientMsgRoutingResponse = 225;
+	k_EGCMsgSetOptions = 226;
+	k_EGCMsgSetOptionsResponse = 227;
+	k_EGCMsgSystemBase2 = 500;
+	k_EGCMsgGetPurchaseTrustStatus = 501;
+	k_EGCMsgGetPurchaseTrustStatusResponse = 502;
+	k_EGCMsgUpdateSession = 503;
+	k_EGCMsgGCAccountVacStatusChange = 504;
+	k_EGCMsgCheckFriendship = 505;
+	k_EGCMsgCheckFriendshipResponse = 506;
+	k_EGCMsgGetPartnerAccountLink = 507;
+	k_EGCMsgGetPartnerAccountLinkResponse = 508;
+	k_EGCMsgVSReportedSuspiciousActivity = 509;
+	k_EGCMsgAccountTradeBanStatusChange = 510;
+	k_EGCMsgAccountLockStatusChange = 511;
+	k_EGCMsgDPPartnerMicroTxns = 512;
+	k_EGCMsgDPPartnerMicroTxnsResponse = 513;
+	k_EGCMsgGetIPASN = 514;
+	k_EGCMsgGetIPASNResponse = 515;
+	k_EGCMsgGetAppFriendsList = 516;
+	k_EGCMsgGetAppFriendsListResponse = 517;
+	k_EGCMsgVacVerificationChange = 518;
+	k_EGCMsgAccountPhoneNumberChange = 519;
+	k_EGCMsgAccountTwoFactorChange = 520;
+	k_EGCMsgCheckClanMembership = 521;
+	k_EGCMsgCheckClanMembershipResponse = 522;
+	k_EGCMsgInviteUserToLobby = 523;
+	k_EGCMsgGetGamePersonalDataCategoriesRequest = 524;
+	k_EGCMsgGetGamePersonalDataCategoriesResponse = 525;
+	k_EGCMsgGetGamePersonalDataEntriesRequest = 526;
+	k_EGCMsgGetGamePersonalDataEntriesResponse = 527;
+	k_EGCMsgTerminateGamePersonalDataEntriesRequest = 528;
+	k_EGCMsgTerminateGamePersonalDataEntriesResponse = 529;
+}
+
+enum ESOMsg {
+	k_ESOMsg_Create = 21;
+	k_ESOMsg_Update = 22;
+	k_ESOMsg_Destroy = 23;
+	k_ESOMsg_CacheSubscribed = 24;
+	k_ESOMsg_CacheUnsubscribed = 25;
+	k_ESOMsg_UpdateMultiple = 26;
+	k_ESOMsg_CacheSubscriptionCheck = 27;
+	k_ESOMsg_CacheSubscriptionRefresh = 28;
+	k_ESOMsg_CacheSubscribedUpToDate = 29;
+}
+
+enum EGCBaseClientMsg {
+	k_EMsgGCPingRequest = 3001;
+	k_EMsgGCPingResponse = 3002;
+	k_EMsgGCClientWelcome = 4004;
+	k_EMsgGCServerWelcome = 4005;
+	k_EMsgGCClientHello = 4006;
+	k_EMsgGCServerHello = 4007;
+	k_EMsgGCClientGoodbye = 4008;
+	k_EMsgGCServerGoodbye = 4009;
+}
+
+enum EGCToGCMsg {
+	k_EGCToGCMsgMasterAck = 150;
+	k_EGCToGCMsgMasterAckResponse = 151;
+	k_EGCToGCMsgRouted = 152;
+	k_EGCToGCMsgRoutedReply = 153;
+	k_EMsgGCUpdateSubGCSessionInfo = 154;
+	k_EMsgGCRequestSubGCSessionInfo = 155;
+	k_EMsgGCRequestSubGCSessionInfoResponse = 156;
+	k_EGCToGCMsgMasterStartupComplete = 157;
+	k_EMsgGCToGCSOCacheSubscribe = 158;
+	k_EMsgGCToGCSOCacheUnsubscribe = 159;
+}
+
+message CCommunity_GamePersonalDataCategoryInfo {
+	optional string type = 1;
+	optional string localization_token = 2;
+	optional string template_file = 3;
+}
+
+message CCommunity_GetGamePersonalDataCategories_Request {
+	optional uint32 appid = 1;
+}
+
+message CCommunity_GetGamePersonalDataCategories_Response {
+	repeated CCommunity_GamePersonalDataCategoryInfo categories = 1;
+	optional string app_assets_basename = 2;
+}
+
+message CCommunity_GetGamePersonalDataEntries_Request {
+	optional uint32 appid = 1;
+	optional uint64 steamid = 2;
+	optional string type = 3;
+	optional string continue_token = 4;
+}
+
+message CCommunity_GetGamePersonalDataEntries_Response {
+	optional uint32 gceresult = 1;
+	repeated string entries = 2;
+	optional string continue_token = 3;
+}
+
+message CCommunity_TerminateGamePersonalDataEntries_Request {
+	optional uint32 appid = 1;
+	optional uint64 steamid = 2;
+}
+
+message CCommunity_TerminateGamePersonalDataEntries_Response {
+	optional uint32 gceresult = 1;
+}

--- a/dll/gc_tf2/tf_gcmessages.proto
+++ b/dll/gc_tf2/tf_gcmessages.proto
@@ -1,0 +1,1650 @@
+import "steammessages.proto";
+import "base_gcmessages.proto";
+
+option optimize_for = SPEED;
+option cc_generic_services = false;
+
+package gamecoordinator.tf2;
+
+enum ETFGCMsg {
+	k_EMsgGCReportWarKill = 5001;
+	k_EMsgGCKickPlayer_DEPRECATED = 5020;
+	k_EMsgGCStartedTraining_DEPRECATED = 5021;
+	k_EMsgGCFreeTrial_ChooseMostHelpfulFriend = 5022;
+	k_EMsgGCRequestTF2Friends = 5023;
+	k_EMsgGCRequestTF2FriendsResponse = 5024;
+	k_EMsgGCReplay_SubmitContestEntry = 5026;
+	k_EMsgGCReplay_SubmitContestEntryResponse = 5027;
+	k_EMsgGCSaxxy_Awarded = 5029;
+	k_EMsgGCFreeTrial_ThankedBySomeone = 5028;
+	k_EMsgGCFreeTrial_ThankedSomeone = 5030;
+	k_EMsgGCFreeTrial_ConvertedToPremium = 5031;
+	k_EMsgGCMeetThePyroSilliness_BananaCraft_DEPRECATED = 5032;
+	k_EMsgGCMVMARG_HighFiveSuccessResponse_DEPRECATED = 5033;
+	k_EMsgGCMVMARG_HighFiveOnClient_DEPRECATED = 5034;
+	k_EMsgGCCoaching_AddToCoaches = 5200;
+	k_EMsgGCCoaching_AddToCoachesResponse = 5201;
+	k_EMsgGCCoaching_RemoveFromCoaches = 5202;
+	k_EMsgGCCoaching_RemoveFromCoachesResponse = 5203;
+	k_EMsgGCCoaching_FindCoach = 5204;
+	k_EMsgGCCoaching_FindCoachResponse = 5205;
+	k_EMsgGCCoaching_AskCoach = 5206;
+	k_EMsgGCCoaching_AskCoachResponse = 5207;
+	k_EMsgGCCoaching_CoachJoinGame = 5208;
+	k_EMsgGCCoaching_CoachJoining = 5209;
+	k_EMsgGCCoaching_CoachJoined = 5210;
+	k_EMsgGCCoaching_LikeCurrentCoach = 5211;
+	k_EMsgGCCoaching_RemoveCurrentCoach = 5212;
+	k_EMsgGCCoaching_AlreadyRatedCoach = 5213;
+	k_EMsgGC_Duel_Request = 5500;
+	k_EMsgGC_Duel_Response = 5501;
+	k_EMsgGC_Duel_Results = 5502;
+	k_EMsgGC_Duel_Status = 5503;
+	k_EMsgGC_Halloween_ReservedItem_DEPRECATED = 5600;
+	k_EMsgGC_Halloween_GrantItem_DEPRECATED = 5601;
+	k_EMsgGC_Halloween_GrantItemResponse_DEPRECATED = 5604;
+	k_EMsgGC_Halloween_Cheat_QueryResponse_DEPRECATED = 5605;
+	k_EMsgGC_Halloween_ItemClaimed_DEPRECATED = 5606;
+	k_EMsgGC_Halloween_ReservedItem = 5607;
+	k_EMsgGC_Halloween_GrantItem = 5608;
+	k_EMsgGC_Halloween_GrantItemResponse = 5609;
+	k_EMsgGC_Halloween_Cheat_QueryResponse_DEPRECATED_2 = 5610;
+	k_EMsgGC_Halloween_ItemClaimed_DEPRECATED_2 = 5611;
+	k_EMsgGC_Halloween_ServerBossEvent = 5612;
+	k_EMsgGC_Halloween_Merasmus2012 = 5613;
+	k_EMsgGC_Halloween_UpdateMerasmusLootLevel = 5614;
+	k_EMsgGC_GameServer_LevelInfo = 5700;
+	k_EMsgGC_GameServer_AuthChallenge = 5701;
+	k_EMsgGC_GameServer_AuthChallengeResponse = 5702;
+	k_EMsgGC_GameServer_CreateIdentity = 5703;
+	k_EMsgGC_GameServer_CreateIdentityResponse = 5704;
+	k_EMsgGC_GameServer_List = 5705;
+	k_EMsgGC_GameServer_ListResponse = 5706;
+	k_EMsgGC_GameServer_AuthResult = 5707;
+	k_EMsgGC_GameServer_ResetIdentity = 5708;
+	k_EMsgGC_GameServer_ResetIdentityResponse = 5709;
+	k_EMsgGC_Client_UseServerModificationItem = 5710;
+	k_EMsgGC_Client_UseServerModificationItem_Response = 5711;
+	k_EMsgGC_GameServer_UseServerModificationItem = 5712;
+	k_EMsgGC_GameServer_UseServerModificationItem_Response = 5713;
+	k_EMsgGC_GameServer_ServerModificationItemExpired = 5714;
+	k_EMsgGC_GameServer_ModificationItemState = 5715;
+	k_EMsgGC_GameServer_AckPolicy = 5716;
+	k_EMsgGC_GameServer_AckPolicyResponse = 5717;
+	k_EMsgGC_QP_ScoreServers = 5800;
+	k_EMsgGC_QP_ScoreServersResponse = 5801;
+	k_EMsgGC_QP_PlayerJoining = 5802;
+	k_EMsgGC_PickupItemEligibility_Query_DEPRECATED = 6000;
+	k_EMsgGC_PickupItemEligibility_Query_DEPRECATED_2 = 6001;
+	k_EMsgGC_IncrementKillCountAttribute_DEPRECATED = 6100;
+	k_EMsgGC_IncrementKillCountResponse_DEPRECATED = 6101;
+	k_EMsgGCAbandonCurrentGame = 6235;
+	k_EMsgForceSOCacheResend = 6237;
+	k_EMsgGCRequestChatChannelList = 6260;
+	k_EMsgGCRequestChatChannelListResponse = 6261;
+	k_EMsgGCReadyUp = 6270;
+	k_EMsgGCKickedFromMatchmakingQueue = 6271;
+	k_EMsgGCLeaverDetected = 6272;
+	k_EMsgGCLeaverDetectedResponse = 6287;
+	k_EMsgGCExitMatchmaking = 6289;
+	k_EMsgGCMatchmakingProgress = 6293;
+	k_EMsgGCMvMVictoryInfo = 6294;
+	k_EMsgGCGameServerMatchmakingStatus = 6295;
+	k_EMsgGCMvMVictory = 6297;
+	k_EMsgGCMvMVictoryReply = 6298;
+	k_EMsgGCGameServerKickingLobby = 6299;
+	k_EMsgGCLeaveGameAndPrepareToJoinParty = 6300;
+	k_EMsgGC_UpdatePeriodicEvent = 6400;
+	k_EMsgGC_DuckLeaderboard_IndividualUpdate = 6401;
+	k_EMsgGC_Client2GCEconPreviewDataBlockRequest = 6402;
+	k_EMsgGC_Client2GCEconPreviewDataBlockResponse = 6403;
+	k_EMsgGC_ClientVerificationChallenge = 6500;
+	k_EMsgGC_ClientVerificationChallengeResponse = 6501;
+	k_EMsgGC_ClientVerificationVerboseResponse = 6502;
+	k_EMsgGC_ClientSetItemSlotAttribute = 6503;
+	k_EMsgGC_War_IndividualUpdate = 6505;
+	k_EMsgGC_War_JoinWar = 6506;
+	k_EMsgGC_War_RequestGlobalStats = 6507;
+	k_EMsgGC_War_GlobalStatsResponse = 6508;
+	k_EMsgGC_WorldItemPlacement_Attribute = 6510;
+	k_EMsgGC_WorldItemPlacement_Update = 6511;
+	k_EMsgGC_Match_Result = 6512;
+	k_EMsgGCVoteKickPlayerRequest = 6513;
+	k_EMsgGCVoteKickPlayerRequestResponse = 6514;
+	k_EMsgGC_DailyCompetitiveStatsRollup = 6516;
+	k_EMsgGC_DailyCompetitiveStatsRollup_Response = 6517;
+	k_EMsgGC_WorldStatusBroadcast = 6518;
+	k_EMsgGC_ReportPlayer = 6519;
+	k_EMsgGC_Match_ResultResponse = 6520;
+	k_EMsgGCGameServerKickingLobbyResponse = 6521;
+	k_EMsgGCPlayerLeftMatch = 6522;
+	k_EMsgGCPlayerLeftMatchResponse = 6523;
+	k_EMsgGCRequestMatchMakerStats = 6524;
+	k_EMsgGCMatchMakerStatsResponse = 6525;
+	k_EMsgGCMatchHistoryLoad = 6526;
+	k_EMsgGC_AcknowledgeXP = 6527;
+	k_EMsgGCDataCenterPing_Update = 6528;
+	k_EMsgGC_NotificationAcknowledge = 6529;
+	k_EMsgGC_NotificationAcknowledgeReply = 6530;
+	k_EMsgGC_KickPlayerFromLobby = 6531;
+	k_EMsgGC_SurveyQuestionRequest = 6534;
+	k_EMsgGC_SurveyQuestionResponse = 6535;
+	k_EMsgGC_TFClientInit = 6536;
+	k_EMsgGC_NewMatchForLobbyRequest = 6537;
+	k_EMsgGC_NewMatchForLobbyResponse = 6538;
+	k_EMsgGC_ChangeMatchPlayerTeamsRequest = 6539;
+	k_EMsgGC_ChangeMatchPlayerTeamsResponse = 6540;
+	k_EMsgGC_QuestIdentify = 6541;
+	k_EMsgGC_QuestDevGive = 6542;
+	k_EMsgGCQuestComplete_Debug = 6544;
+	k_EMsgGC_QuestMapDebug = 6545;
+	k_EMsgGC_QuestMapUnlockNode = 6547;
+	k_EMsgGC_QuestMapPurchaseReward = 6549;
+	k_EMsgGC_SetDisablePartyQuestProgress = 6550;
+	k_EMsgGCQuestProgressReport = 6553;
+	k_EMsgGCParty_SetOptions = 6554;
+	k_EMsgGCParty_SetOptionsResponse = 6555;
+	k_EMsgGCParty_QueueForMatch = 6556;
+	k_EMsgGCParty_QueueForMatchResponse = 6557;
+	k_EMsgGCParty_RemoveFromQueue = 6558;
+	k_EMsgGCParty_RemoveFromQueueResponse = 6559;
+	k_EMsgGCParty_InvitePlayer = 6560;
+	k_EMsgGCParty_RequestJoinPlayer = 6561;
+	k_EMsgGCParty_SendChat = 6562;
+	k_EMsgGCParty_ChatMsg = 6563;
+	k_EMsgGCQuestNodeTurnIn = 6564;
+	k_EMsgGCConsumePaintKit = 6565;
+	k_EMsgGC_Painkit_DevGrant = 6566;
+	k_EMsgGCParty_QueueForStandby = 6567;
+	k_EMsgGCParty_QueueForStandbyResponse = 6568;
+	k_EMsgGCParty_RemoveFromStandbyQueue = 6569;
+	k_EMsgGCParty_RemoveFromStandbyQueueResponse = 6570;
+	k_EMsgGCParty_ClearPendingPlayer = 6571;
+	k_EMsgGCParty_ClearPendingPlayerResponse = 6572;
+	k_EMsgGCParty_ClearOtherPartyRequest = 6573;
+	k_EMsgGCParty_ClearOtherPartyRequestResponse = 6574;
+	k_EMsgGCParty_PromoteToLeader = 6575;
+	k_EMsgGCParty_KickMember = 6576;
+	k_EMsgGCQuestStrangeEvent = 6577;
+	k_EMsgGC_AcceptLobbyInvite = 6578;
+	k_EMsgGC_AcceptLobbyInviteReply = 6579;
+	k_EMsgGC_SDRTicket = 6580;
+	k_EMsgGC_ProcessMatchVoteKick = 6581;
+	k_EMsgGC_ProcessMatchVoteKickResponse = 6582;
+	k_EMsgGCToGC_SendAccountBannedNotifications = 6584;
+	k_EMsgGCToGC_SendNotification = 6585;
+	k_EMsgGCParty_MMError = 6586;
+	k_EMsgGCDev_GrantWarKill = 10001;
+}
+
+enum EServerModificationItemType {
+	kGameServerModificationItem_Halloween = 1;
+}
+
+enum ETFSyncedMMMenuStep {
+	k_eTFSyncedMMMenuStep_Invalid = -1;
+	k_eTFSyncedMMMenuStep_None = 0;
+	k_eTFSyncedMMMenuStep_Configuring_Mode = 1;
+	k_eTFSyncedMMMenuStep_MvM_Selecting_Mode = 2;
+	k_eTFSyncedMMMenuStep_MvM_Selecting_Tour = 3;
+	k_eTFSyncedMMMenuStep_MvM_Selecting_Missions = 4;
+}
+
+enum ETFMatchGroup {
+	option allow_alias = true;
+	k_eTFMatchGroup_Invalid = -1;
+	k_eTFMatchGroup_MvM_Practice = 0;
+	k_eTFMatchGroup_MvM_MannUp = 1;
+	k_eTFMatchGroup_First = 0;
+	k_eTFMatchGroup_MvM_Default = 0;
+	k_eTFMatchGroup_MvM_First = 0;
+	k_eTFMatchGroup_MvM_Last = 1;
+	k_eTFMatchGroup_Ladder_6v6 = 2;
+	k_eTFMatchGroup_Ladder_9v9 = 3;
+	k_eTFMatchGroup_Ladder_12v12 = 4;
+	k_eTFMatchGroup_Ladder_Default = 2;
+	k_eTFMatchGroup_Ladder_First = 2;
+	k_eTFMatchGroup_Ladder_Last = 4;
+	k_eTFMatchGroup_Casual_6v6 = 5;
+	k_eTFMatchGroup_Casual_9v9 = 6;
+	k_eTFMatchGroup_Casual_12v12 = 7;
+	k_eTFMatchGroup_Casual_Default = 7;
+	k_eTFMatchGroup_Casual_First = 5;
+	k_eTFMatchGroup_Casual_Last = 7;
+	k_eTFMatchGroup_Event_Placeholder = 8;
+	k_eTFMatchGroup_Event_Default = 8;
+	k_eTFMatchGroup_Event_First = 8;
+	k_eTFMatchGroup_Event_Last = 8;
+}
+
+enum ETFPartyChatType {
+	k_eTFPartyChatType_Invalid = 0;
+	k_eTFPartyChatType_MemberChat = 1;
+	k_eTFPartyChatType_Synthetic_MemberJoin = 1000;
+	k_eTFPartyChatType_Synthetic_MemberLeave = 1001;
+	k_eTFPartyChatType_Synthetic_SendFailed = 1002;
+	k_eTFPartyChatType_Synthetic_MemberOnline = 1003;
+	k_eTFPartyChatType_Synthetic_MemberOffline = 1004;
+}
+
+enum TF_GC_GameState {
+	TF_GC_GAMESTATE_STATE_INIT = 0;
+	TF_GC_GAMESTATE_WAIT_FOR_PLAYERS_TO_LOAD = 1;
+	TF_GC_GAMESTATE_STRATEGY_TIME = 3;
+	TF_GC_GAMESTATE_GAME_IN_PROGRESS = 5;
+	TF_GC_GAMESTATE_POST_GAME = 6;
+	TF_GC_GAMESTATE_DISCONNECT = 7;
+	TF_GC_GAMESTATE_LAST = 8;
+}
+
+enum TF_GC_TEAM {
+	TF_GC_TEAM_DEFENDERS = 0;
+	TF_GC_TEAM_INVADERS = 1;
+	TF_GC_TEAM_BROADCASTER = 2;
+	TF_GC_TEAM_SPECTATOR = 3;
+	TF_GC_TEAM_PLAYER_POOL = 4;
+	TF_GC_TEAM_NOTEAM = 5;
+}
+
+enum TFMatchLeaveReason {
+	TFMatchLeaveReason_UNSPECIFIED = 0;
+	TFMatchLeaveReason_VOTE_KICK = 1;
+	TFMatchLeaveReason_IDLE = 2;
+	TFMatchLeaveReason_ADMIN_KICK = 3;
+	TFMatchLeaveReason_AWOL = 4;
+	TFMatchLeaveReason_NO_SHOW = 5;
+	TFMatchLeaveReason_GC_REMOVED = 6;
+}
+
+enum TFVoteKickReason {
+	TFVoteKickReason_Invalid = -1;
+	TFVoteKickReason_Other = 0;
+	TFVoteKickReason_Cheating = 1;
+	TFVoteKickReason_Idle = 2;
+	TFVoteKickReason_Scamming = 3;
+}
+
+enum ServerMatchmakingState {
+	ServerMatchmakingState_INVALID = 0;
+	ServerMatchmakingState_NOT_PARTICIPATING = 1;
+	ServerMatchmakingState_EMPTY = 2;
+	ServerMatchmakingState_ACTIVE_MATCH_REQUESTING_LATE_JOIN = 3;
+	ServerMatchmakingState_ACTIVE_MATCH = 4;
+}
+
+enum SurveyQuestionType {
+	QUESTION_MATCH_QUALITY = 0;
+	QUESTION_MAP_QUALITY = 1;
+	QUESTION_COMP_INQUIRY = 2;
+	QUESTION_CASUAL_INQUIRY = 3;
+	QUESTION_RANDOM_CRIT = 4;
+}
+
+message CMsgTFGoldenWrenchBroadcast {
+	optional int32 wrench_number = 1;
+	optional bool deleted = 2;
+	optional string user_name = 3;
+}
+
+message CMsgTFSaxxyBroadcast {
+	optional int32 category_number = 1;
+	optional string user_name = 2;
+}
+
+message CMsgGCTFSpecificItemBroadcast {
+	optional uint32 item_def_index = 1;
+	optional bool was_destruction = 2;
+	optional string user_name = 3;
+}
+
+message CMsgTFWorldStatus {
+	optional bool beta_stress_test_event_active = 1 [default = false];
+	optional ETFMatchGroup event_match_group = 2 [default = k_eTFMatchGroup_Invalid];
+	optional fixed32 event_expire_time = 3 [default = 0];
+	optional uint32 active_client_version = 4;
+	repeated ETFMatchGroup disabled_match_groups = 5;
+}
+
+message CSOTFDuelSummary {
+	optional uint32 account_id = 1 [(key_field) = true];
+	optional uint32 duel_wins = 2;
+	optional uint32 duel_losses = 3;
+	optional uint32 last_duel_account_id = 4;
+	optional uint32 last_duel_timestamp = 5;
+	optional uint32 last_duel_status = 6;
+}
+
+message CSOTFMapContribution {
+	optional uint32 account_id = 1 [(key_field) = true];
+	optional uint32 def_index = 2 [(key_field) = true];
+	optional uint32 contribution_level = 3;
+}
+
+message CMsgTFFreeTrialChooseMostHelpfulFriend {
+	optional uint32 account_id_friend = 1;
+}
+
+message CMsgTFRequestTF2Friends {
+	repeated uint32 account_ids = 1;
+}
+
+message CMsgTFRequestTF2FriendsResponse {
+	repeated uint32 account_ids = 1;
+}
+
+message CSOTFPlayerInfo {
+	optional uint32 num_new_users_helped = 1;
+}
+
+message CMsgTFThankedBySomeone {
+	optional uint64 thanker_steam_id = 1;
+}
+
+message CMsgTFThankedSomeone {
+}
+
+message CMsgTFFreeTrialConvertedToPremium {
+}
+
+message CMsgSaxxyAwarded {
+	optional uint32 category = 1;
+	repeated string winner_names = 2;
+}
+
+message CMsgReplaySubmitContestEntry {
+	optional string youtube_url = 1;
+	optional uint32 category = 2;
+}
+
+message CMsgReplaySubmitContestEntryResponse {
+	optional bool success = 1;
+}
+
+message CReplayCachedContestData {
+	optional fixed32 timestamp = 1;
+	optional uint32 num_votes_last_day = 2;
+	repeated uint32 video_entry_ids = 3;
+	optional uint32 num_flags_last_day = 4;
+}
+
+message CMsgTFCoaching_AddToCoaches {
+}
+
+message CMsgTFCoaching_RemoveFromCoaches {
+}
+
+message CMsgTFCoaching_FindCoach {
+	optional uint32 account_id_friend_as_coach = 1;
+}
+
+message CMsgTFCoaching_FindCoachResponse {
+	optional bool found_coach = 1;
+	optional uint32 num_likes = 2;
+	optional string coach_name = 3;
+}
+
+message CMsgTFCoaching_AskCoach {
+	optional uint32 account_id_student = 1;
+	optional bool student_is_friend = 2;
+}
+
+message CMsgTFCoaching_AskCoachResponse {
+	optional bool accept_coaching_assignment = 1;
+}
+
+message CMsgTFCoaching_CoachJoinGame {
+	optional bool join_game = 1;
+	optional uint32 server_address = 2;
+	optional uint32 server_port = 3;
+	optional uint32 account_id_student = 4;
+}
+
+message CMsgTFCoaching_CoachJoining {
+	optional uint32 account_id_coach = 1;
+	optional uint32 account_id_student = 2;
+}
+
+message CMsgTFCoaching_CoachJoined {
+	optional uint32 account_id_coach = 1;
+}
+
+message CMsgTFCoaching_LikeCurrentCoach {
+	optional bool like_coach = 1;
+}
+
+message CMsgTFCoaching_RemoveCurrentCoach {
+	optional uint32 account_id_coach = 1;
+}
+
+message CMsgTFQuickplay_ScoreServers {
+	message ServerInfo {
+		optional uint32 server_address = 1;
+		optional uint32 server_port = 2;
+		optional uint32 num_users = 3;
+		optional uint64 steam_id = 4;
+		optional uint32 max_users = 5;
+		optional float user_score = 6;
+	}
+
+	repeated CMsgTFQuickplay_ScoreServers.ServerInfo servers = 1;
+}
+
+message CMsgTFQuickplay_ScoreServersResponse {
+	message ServerInfo {
+		optional uint32 server_address = 1;
+		optional uint32 server_port = 2;
+		optional float total_score = 3;
+		optional uint64 steam_id = 4;
+		optional uint32 options_score = 5;
+	}
+
+	repeated CMsgTFQuickplay_ScoreServersResponse.ServerInfo servers = 1;
+}
+
+message CMsgTFQuickplay_PlayerJoining {
+	optional uint32 account_id = 1;
+}
+
+message CMsgGC_GameServer_LevelInfo {
+	optional bool level_loaded = 1;
+	optional string level_name = 2;
+}
+
+message CMsgGC_GameServer_AuthChallenge {
+	optional string challenge_string = 1;
+}
+
+message CMsgGC_GameServer_AuthResult {
+	optional bool authenticated = 1;
+	optional int32 game_server_standing = 2;
+	optional int32 game_server_standing_trend = 3;
+	optional bool is_valve_server = 4;
+	optional string message = 5;
+}
+
+message CMsgGC_GameServer_AuthChallengeResponse {
+	optional uint32 game_server_account_id = 1;
+	optional bytes hashed_challenge_string = 2;
+}
+
+message CMsgGC_GameServer_CreateIdentity {
+	optional uint32 account_id = 1;
+}
+
+message CMsgGC_GameServer_CreateIdentityResponse {
+	enum EStatus {
+		kStatus_GenericFailure = 0;
+		kStatus_TooMany = -1;
+		kStatus_NoPrivs = -2;
+		kStatus_Created = 1;
+	}
+
+	optional bool account_created = 1;
+	optional uint32 game_server_account_id = 2;
+	optional string game_server_identity_token = 3;
+	optional CMsgGC_GameServer_CreateIdentityResponse.EStatus status = 4 [default = kStatus_GenericFailure];
+}
+
+message CMsgGC_GameServer_List {
+	optional uint32 account_id = 1;
+}
+
+message CMsgGC_GameServer_ListResponse {
+	message GameServerIdentity {
+		optional uint32 game_server_account_id = 1;
+		optional string game_server_identity_token = 2;
+		optional int32 game_server_standing = 3;
+		optional int32 game_server_standing_trend = 4;
+	}
+
+	repeated CMsgGC_GameServer_ListResponse.GameServerIdentity owned_game_servers = 1;
+}
+
+message CMsgGC_GameServer_ResetIdentity {
+	optional uint32 game_server_account_id = 1;
+}
+
+message CMsgGC_GameServer_ResetIdentityResponse {
+	optional bool game_server_identity_token_reset = 1;
+	optional uint32 game_server_account_id = 2;
+	optional string game_server_identity_token = 3;
+}
+
+message CMsgGC_GameServer_AckPolicy {
+}
+
+message CMsgGC_GameServer_AckPolicyResponse {
+	optional uint32 result = 1;
+	optional string message = 2;
+}
+
+message CMsgGC_Client_UseServerModificationItem {
+	optional uint64 item_id = 1;
+}
+
+message CMsgGC_Client_UseServerModificationItem_Response {
+	enum EServerModificationItemResponse {
+		kServerModificationItemResponse_AlreadyInUse = 1;
+		kServerModificationItemResponse_NotOnAuthenticatedServer = 2;
+		kServerModificationItemResponse_ServerReject = 3;
+		kServerModificationItemResponse_InternalError = 4;
+		kServerModificationItemResponse_EventAlreadyActive = 5;
+	}
+
+	optional CMsgGC_Client_UseServerModificationItem_Response.EServerModificationItemResponse response_code = 1 [default = kServerModificationItemResponse_AlreadyInUse];
+}
+
+message CMsgGC_GameServer_UseServerModificationItem {
+	optional EServerModificationItemType modification_type = 1 [default = kGameServerModificationItem_Halloween];
+}
+
+message CMsgGC_GameServer_UseServerModificationItem_Response {
+	enum EServerModificationItemServerResponse {
+		kServerModificationItemServerResponse_Accepted = 1;
+		kServerModificationItemServerResponse_NoVoteCalled = 2;
+		kServerModificationItemServerResponse_VoteFailed = 3;
+	}
+
+	optional EServerModificationItemType modification_type = 1 [default = kGameServerModificationItem_Halloween];
+	optional CMsgGC_GameServer_UseServerModificationItem_Response.EServerModificationItemServerResponse server_response_code = 2 [default = kServerModificationItemServerResponse_Accepted];
+}
+
+message CMsgGC_GameServer_ServerModificationItemExpired {
+	optional EServerModificationItemType modification_type = 1 [default = kGameServerModificationItem_Halloween];
+}
+
+message CMsgGC_GameServer_ServerModificationItem {
+	optional EServerModificationItemType modification_type = 1 [default = kGameServerModificationItem_Halloween];
+	optional bool active = 2;
+}
+
+message CMsgGC_Halloween_ReservedItem {
+	repeated float x = 1;
+	repeated float y = 2;
+	repeated float z = 3;
+	optional uint32 spawn_meta_info = 7;
+}
+
+message CMsgGC_Halloween_GrantItem {
+	optional uint32 recipient_account_id = 1;
+	optional uint32 level_id = 2;
+	optional bool flagged = 3;
+}
+
+message CMsgGC_Halloween_GrantItemResponse {
+	optional uint32 recipient_account_id = 1;
+}
+
+message CMsgGC_Halloween_ItemClaimed {
+}
+
+message CMsgGC_PickupItemEligibility_Query {
+	optional uint32 account_id = 1;
+	optional uint32 seconds_ago = 2;
+}
+
+message CMsgGC_PickupItemEligibility_QueryResponse {
+	optional uint32 account_id = 1;
+	optional bool was_eligible = 2;
+	optional uint32 level_id = 3;
+}
+
+message CSOTFPartyMember {
+	message Activity {
+		optional fixed64 lobby_id = 1;
+		optional ETFMatchGroup lobby_match_group = 2 [default = k_eTFMatchGroup_Invalid];
+		optional bool multiqueue_blocked = 3;
+		optional bool online = 4;
+		optional uint32 client_version = 5;
+	}
+
+	optional bool owns_ticket = 2;
+	optional uint32 completed_missions = 3;
+	optional uint32 badge_level = 4;
+	optional bool competitive_access = 9;
+	optional uint32 experience = 14;
+	optional CTFPerPlayerMatchCriteriaProto player_criteria = 16;
+	optional CSOTFPartyMember.Activity activity = 17;
+	optional bool casual_banned = 18;
+	optional bool ranked_banned = 19;
+	optional bool casual_low_priority = 20;
+	optional bool ranked_low_priority = 21;
+	optional bool lobby_standby = 22;
+}
+
+message TFPendingPartyMember {
+	enum EType {
+		Invited = 0;
+		RequestedToJoin = 1;
+	}
+
+	optional fixed64 steamid = 1;
+	optional TFPendingPartyMember.EType type = 2 [default = Invited];
+	optional fixed64 inviter = 3;
+}
+
+message TFSyncedMMUIState {
+	optional ETFSyncedMMMenuStep menu_step = 1 [default = k_eTFSyncedMMMenuStep_None];
+	optional ETFMatchGroup match_group = 2 [default = k_eTFMatchGroup_Invalid];
+}
+
+message CTFGroupMatchCriteriaProto {
+	optional bool late_join_ok = 5;
+	optional uint32 custom_ping_tolerance = 13 [default = 0];
+	optional string mvm_mannup_tour = 10;
+	repeated string mvm_mannup_missions = 15;
+	repeated string mvm_bootcamp_missions = 16;
+	optional CTFCasualMatchCriteria casual_criteria = 12;
+}
+
+message CTFCasualMatchCriteria {
+	repeated fixed32 selected_maps_bits = 3;
+}
+
+message CTFPerPlayerMatchCriteriaProto {
+	optional bool mvm_squad_surplus = 1;
+}
+
+message CTFPartyOptions {
+	optional bool overwrite_existing = 1;
+	optional CTFGroupMatchCriteriaProto group_criteria = 2;
+	optional CTFPerPlayerMatchCriteriaProto player_criteria = 3;
+	optional TFSyncedMMUIState player_uistate = 5;
+}
+
+message CMsgPartySetOptions {
+	optional fixed64 party_id = 1;
+	optional CTFPartyOptions options = 2;
+}
+
+message CMsgPartySetOptionsResponse {
+}
+
+message CMsgPartyQueueForMatch {
+	optional fixed64 party_id = 1;
+	optional CTFPartyOptions final_options = 2;
+	optional ETFMatchGroup match_group = 3 [default = k_eTFMatchGroup_Invalid];
+}
+
+message CMsgPartyQueueForMatchResponse {
+}
+
+message CMsgPartyQueueForStandby {
+	optional fixed64 party_id = 1;
+	optional fixed64 party_lobby_id = 2;
+}
+
+message CMsgPartyQueueForStandbyResponse {
+}
+
+message CMsgPartyRemoveFromQueue {
+	optional fixed64 party_id = 1;
+	optional ETFMatchGroup match_group = 2 [default = k_eTFMatchGroup_Invalid];
+}
+
+message CMsgPartyRemoveFromQueueResponse {
+}
+
+message CMsgPartyRemoveFromStandbyQueue {
+	optional fixed64 party_id = 1;
+}
+
+message CMsgPartyRemoveFromStandbyQueueResponse {
+}
+
+message CMsgPartyInvitePlayer {
+	optional fixed64 party_id = 1;
+	optional fixed64 player_id = 2;
+	optional bool expecting_request_to_join = 3;
+}
+
+message CMsgPartyRequestJoinPlayer {
+	optional fixed64 current_party_id = 1;
+	optional fixed64 join_player_id = 2;
+	optional fixed64 join_party_id = 3;
+	optional bool expecting_invite = 4;
+}
+
+message CMsgPartyClearPendingPlayer {
+	optional fixed64 party_id = 1;
+	optional fixed64 pending_player_id = 2;
+}
+
+message CMsgPartyMMError {
+	enum Type {
+		QUEUE_KICK_NO_PING = 1;
+		QUEUE_KICK_AUTH = 2;
+	}
+
+	optional CMsgPartyMMError.Type type = 1 [default = QUEUE_KICK_NO_PING];
+}
+
+message CMsgPartyClearPendingPlayerResponse {
+}
+
+message CMsgPartyClearOtherPartyRequest {
+	optional fixed64 other_party_id = 1;
+}
+
+message CMsgPartyClearOtherPartyRequestResponse {
+}
+
+message CMsgPartyPromoteToLeader {
+	optional fixed64 party_id = 1;
+	optional fixed64 new_leader_id = 2;
+}
+
+message CMsgPartyKickMember {
+	optional fixed64 party_id = 1;
+	optional fixed64 target_id = 2;
+}
+
+message CMsgPartySendChat {
+	optional fixed64 party_id = 1;
+	optional string msg = 2;
+}
+
+message CMsgPartyChatMsg {
+	optional ETFPartyChatType type = 1 [default = k_eTFPartyChatType_Invalid];
+	optional fixed64 actor_id = 2;
+	optional string msg = 3;
+}
+
+message CSOTFParty {
+	message QueueEntry {
+		optional ETFMatchGroup match_group = 1 [default = k_eTFMatchGroup_Invalid];
+		optional fixed32 queued_time = 2;
+	}
+
+	optional uint64 party_id = 1 [(key_field) = true];
+	optional fixed64 leader_id = 2;
+	repeated fixed64 member_ids = 3;
+	repeated CSOTFPartyMember members = 13;
+	optional uint64 associated_lobby_id = 35;
+	optional ETFMatchGroup associated_lobby_match_group = 40 [default = k_eTFMatchGroup_Invalid];
+	repeated CSOTFParty.QueueEntry matchmaking_queues = 43;
+	optional CTFGroupMatchCriteriaProto group_criteria = 37;
+	optional uint32 casual_banned_time = 18;
+	optional uint32 casual_low_priority_time = 20;
+	optional uint32 ranked_banned_time = 41;
+	optional uint32 ranked_low_priority_time = 42;
+	optional TFSyncedMMUIState leader_ui_state = 44;
+	repeated TFPendingPartyMember pending_members = 39;
+}
+
+message CSOTFPartyInvite {
+	message PartyMember {
+		optional fixed64 steamid = 2;
+	}
+
+	enum Type {
+		PENDING_INVITE = 1;
+		PENDING_JOIN_REQUEST = 2;
+	}
+
+	optional uint64 group_id = 1 [(key_field) = true];
+	optional fixed64 inviter = 2;
+	repeated CSOTFPartyInvite.PartyMember members = 4;
+	optional CSOTFPartyInvite.Type type = 5 [default = PENDING_INVITE];
+}
+
+message CTFLobbyPlayerProto {
+	enum ConnectState {
+		INVALID = 0;
+		RESERVATION_PENDING = 1;
+		RESERVED = 2;
+		CONNECTED = 3;
+		DISCONNECTED = 5;
+	}
+
+	enum Type {
+		INVALID_PLAYER = 0;
+		MATCH_PLAYER = 1;
+		STANDBY_PLAYER = 2;
+		OBSERVING_PLAYER = 3;
+	}
+
+	optional fixed64 id = 1 [(key_field) = true];
+	optional TF_GC_TEAM team = 3 [default = TF_GC_TEAM_DEFENDERS];
+	optional CTFLobbyPlayerProto.ConnectState connect_state = 13 [default = INVALID];
+	optional string name = 6;
+	optional uint64 original_party_id = 12;
+	optional bool squad_surplus = 14;
+	optional uint32 badge_level = 15;
+	optional uint32 last_connect_time = 17;
+	optional CTFLobbyPlayerProto.Type type = 19 [default = INVALID_PLAYER];
+	optional double normalized_rating = 20;
+	optional double normalized_uncertainty = 22;
+	optional uint32 rank = 21;
+	optional bool chat_suspension = 23;
+}
+
+message CTFLobbyInviteProto {
+	optional fixed64 lobby_id = 1 [(key_field) = true];
+	optional ETFMatchGroup match_group = 2 [default = k_eTFMatchGroup_Invalid];
+}
+
+message CSOTFGameServerLobby {
+	enum State {
+		UNKNOWN = 0;
+		SERVERSETUP = 1;
+		RUN = 2;
+	}
+
+	enum WarMatch {
+		NOPE = 0;
+		INVADERS_ARE_PYRO = 1;
+		INVADERS_ARE_HEAVY = 2;
+	}
+
+	optional uint64 lobby_id = 1 [(key_field) = true];
+	repeated CTFLobbyPlayerProto members = 2;
+	optional fixed64 server_id = 6 [default = 0];
+	optional CSOTFGameServerLobby.State state = 4 [default = UNKNOWN];
+	optional string connect = 5;
+	optional TF_GC_GameState game_state = 22 [default = TF_GC_GAMESTATE_STATE_INIT];
+	optional double initial_average_mm_rating = 32;
+	optional string mannup_tour_name = 42;
+	optional string map_name = 38;
+	optional string mission_name = 39;
+	optional uint32 match_group = 41;
+	optional uint64 match_id = 30 [default = 0];
+	optional uint32 formed_time = 36;
+	optional uint32 flags = 43;
+	optional bool late_join_eligible = 44;
+	optional uint32 fixed_match_size = 45;
+	optional CSOTFGameServerLobby.WarMatch is_war_match = 46 [default = NOPE];
+	repeated uint32 next_maps_for_vote = 47;
+	optional uint32 lobby_mm_version = 48;
+	repeated CTFLobbyPlayerProto pending_members = 49;
+}
+
+message CMsgExitMatchmaking {
+	optional bool explicit_abandon = 1;
+	optional uint64 party_id = 2;
+	optional uint64 lobby_id = 3;
+}
+
+message CMsgAcceptLobbyInvite {
+	optional uint64 invited_lobby_id = 1;
+	optional uint64 abandoning_match_id = 2;
+	repeated uint64 abandoning_invite_lobby_ids = 3;
+}
+
+message CMsgAcceptLobbyInviteReply {
+}
+
+message CMsgMatchmakingSearchCountRequest {
+}
+
+message CMsgMatchmakingSearchCountResponse {
+	repeated uint32 searching_players_by_group = 1;
+}
+
+message CMsgKickedFromMatchmakingQueue {
+}
+
+message CMsgGameServerMatchmakingStatus {
+	message Player {
+		optional fixed64 steam_id = 1;
+		optional CMsgGameServerMatchmakingStatus.PlayerConnectState connect_state = 2 [default = INVALID];
+	}
+
+	enum PlayerConnectState {
+		INVALID = 0;
+		CONNECTED = 1;
+		RESERVED = 2;
+	}
+
+	enum Event {
+		None = 0;
+		MvMVictory = 1;
+		MvMDefeat = 2;
+		AcknowledgePlayers = 3;
+	}
+
+	optional uint32 server_version = 16 [default = 1225];
+	optional ServerMatchmakingState matchmaking_state = 1 [default = ServerMatchmakingState_INVALID];
+	optional string map = 3;
+	optional string tags = 4;
+	optional uint32 bot_count = 5;
+	optional uint32 num_spectators = 6;
+	optional uint32 max_players = 7;
+	optional uint32 slots_free = 8;
+	optional uint32 server_region = 9;
+	optional float server_loadavg = 10;
+	optional bool server_trusted = 11;
+	optional bool server_dedicated = 12;
+	optional uint32 strict = 17;
+	optional string fake_ip = 25;
+	repeated CMsgGameServerMatchmakingStatus.Player players = 13;
+	optional TF_GC_GameState game_state = 14 [default = TF_GC_GAMESTATE_STATE_INIT];
+	optional CMsgGameServerMatchmakingStatus.Event event = 15 [default = None];
+	optional uint32 mvm_wave = 18;
+	optional uint32 mvm_credits_acquired = 19;
+	optional uint32 mvm_credits_dropped = 20;
+	optional sint32 match_group = 23 [default = -1];
+	optional uint32 lobby_mm_version = 24;
+}
+
+message CMsgMatchmakingProgress {
+	optional uint32 avg_wait_time_new = 4;
+	optional uint32 avg_wait_time_join_late = 5;
+	optional uint32 your_wait_time = 6;
+	optional uint32 matching_worldwide_searching_players = 8;
+	optional uint32 matching_near_you_searching_players = 9;
+	optional uint32 total_worldwide_searching_players = 13;
+	optional uint32 total_near_you_searching_players = 14;
+	optional uint32 matching_worldwide_active_players = 15;
+	optional uint32 matching_near_you_active_players = 16;
+	optional uint32 total_worldwide_active_players = 17;
+	optional uint32 total_near_you_active_players = 18;
+	optional uint32 matching_worldwide_empty_gameservers = 19;
+	optional uint32 matching_near_you_empty_gameservers = 20;
+	optional uint32 total_worldwide_empty_gameservers = 21;
+	optional uint32 total_near_you_empty_gameservers = 22;
+	optional uint32 urgency_pct = 1;
+}
+
+message CMsgMvMVictoryInfo {
+	message Item {
+		optional CMsgMvMVictoryInfo.GrantReason grant_reason = 1 [default = INVALID];
+		optional bytes item_data = 2;
+		optional fixed64 squad_surplus_claimer_steam_id = 3;
+	}
+
+	message Player {
+		optional fixed64 steam_id = 1;
+		optional bool badge_granted = 3;
+		optional bool badge_progress_updated = 4;
+		optional bool badge_leveled = 5;
+		optional uint32 badge_level = 6;
+		optional uint32 badge_progress_bits = 7;
+		repeated CMsgMvMVictoryInfo.Item items = 8;
+		optional bool voucher_missing = 9;
+		optional uint32 badge_points = 10;
+	}
+
+	enum GrantReason {
+		INVALID = 0;
+		BADGE_LEVELED = 1;
+		SQUAD_SURPLUS = 2;
+		MANN_UP = 3;
+		HELP_A_NOOB = 4;
+	}
+
+	repeated CMsgMvMVictoryInfo.Player players = 1;
+	optional string tour_name = 2;
+	optional string mission_name = 3;
+}
+
+message CGCMsgTFHelloResponse {
+	optional uint32 version_check = 1;
+	repeated uint64 version_checksum = 2;
+	optional uint32 version_verbose = 3;
+}
+
+message CGCMsgTFSync {
+	optional bytes version_checksum = 1;
+	optional uint32 version_check = 2;
+	optional uint32 version_check_ex = 3;
+	optional uint32 version_check_ex2 = 4;
+	optional bytes version_checksum_ex = 5;
+}
+
+message CGCMsgTFSyncEx {
+	optional string version_checksum = 1;
+	optional bytes version_checksum_ex = 2;
+	optional uint32 version_check = 3;
+}
+
+message CMsgMvMVictory {
+	message Player {
+		optional fixed64 steam_id = 1;
+		optional bool squad_surplus = 2;
+	}
+
+	optional uint32 legacy_mission_index = 1;
+	optional string tour_name_mannup = 5;
+	optional string mission_name = 6;
+	repeated CMsgMvMVictory.Player players = 2;
+	optional uint64 lobby_id = 3;
+	optional fixed32 event_time = 4;
+}
+
+message CMsgMvMMannUpVictoryReply {
+}
+
+message CMsgGameServerKickingLobby {
+	optional uint64 lobby_id = 3;
+	optional uint64 match_id = 4;
+}
+
+message CMsgGameServerKickingLobbyResponse {
+}
+
+message CMsgLeaveGameAndPrepareToJoinParty {
+	optional fixed64 party_id = 1;
+}
+
+message CMsgPlayerLeftMatch {
+	optional fixed64 steam_id = 1;
+	optional TFMatchLeaveReason leave_reason = 2 [default = TFMatchLeaveReason_UNSPECIFIED];
+	optional bool was_abandon = 3;
+	optional uint64 lobby_id = 4;
+	optional uint64 match_id = 5;
+	repeated CMsgTFXPSource xp_breakdown = 6;
+}
+
+message CMsgPlayerLeftMatchResponse {
+}
+
+message CMsgProcessMatchVoteKick {
+	message Vote {
+		optional fixed64 steam_id = 1;
+		optional bool vote_yay = 2;
+	}
+
+	optional fixed64 match_id = 1;
+	optional fixed64 initiator_steam_id = 2;
+	optional fixed64 target_steam_id = 3;
+	optional TFVoteKickReason reason = 4 [default = TFVoteKickReason_Invalid];
+	repeated CMsgProcessMatchVoteKick.Vote votes = 5;
+	optional bool default_pass = 6;
+}
+
+message CMsgProcessMatchVoteKickResponse {
+	optional bool rip = 1;
+}
+
+message CMsgHalloween_ServerBossEvent {
+	optional uint32 event_counter = 1;
+	optional uint32 timestamp = 2;
+	optional uint32 boss_type = 3;
+	optional uint32 boss_level = 4;
+	optional uint32 event_type = 5;
+	optional uint32 players_involved = 6;
+	optional float elapsed_time = 7;
+}
+
+message CMsgHalloween_Merasmus2012 {
+	optional uint32 event_counter = 1;
+	optional fixed32 time_submitted = 2;
+	optional bool is_valve_server = 3;
+	optional uint32 boss_level = 4;
+	optional uint32 spawned_health = 5;
+	optional uint32 remaining_health = 6;
+	optional uint32 life_time = 7;
+	optional uint32 bomb_kills = 8;
+	optional uint32 staff_kills = 9;
+	optional uint32 pvp_kills = 10;
+	optional uint32 prophunt_time1 = 11;
+	optional uint32 prophunt_time2 = 12;
+	optional uint32 dmg_scout = 13;
+	optional uint32 dmg_sniper = 14;
+	optional uint32 dmg_soldier = 15;
+	optional uint32 dmg_demo = 16;
+	optional uint32 dmg_medic = 17;
+	optional uint32 dmg_heavy = 18;
+	optional uint32 dmg_pyro = 19;
+	optional uint32 dmg_spy = 20;
+	optional uint32 dmg_engineer = 21;
+	optional uint32 scout_count = 22;
+	optional uint32 sniper_count = 23;
+	optional uint32 solider_count = 24;
+	optional uint32 demo_count = 25;
+	optional uint32 medic_count = 26;
+	optional uint32 heavy_count = 27;
+	optional uint32 pyro_count = 28;
+	optional uint32 spy_count = 29;
+	optional uint32 engineer_count = 30;
+}
+
+message CMsgUpdateHalloweenMerasmusLootLevel {
+	message Player {
+		optional fixed64 steam_id = 1;
+	}
+
+	repeated CMsgUpdateHalloweenMerasmusLootLevel.Player players = 1;
+	optional uint32 merasmus_level = 2;
+}
+
+message CAttribute_String {
+	optional string value = 1;
+}
+
+message CAttribute_DynamicRecipeComponent {
+	optional uint32 def_index = 1;
+	optional uint32 item_quality = 2;
+	optional uint32 component_flags = 3;
+	optional string attributes_string = 4;
+	optional uint32 num_required = 5;
+	optional uint32 num_fulfilled = 6;
+}
+
+message CAttribute_DynamicRecipeComponent_COMPAT_NEVER_SERIALIZE_THIS_OUT {
+	optional uint32 def_index = 1;
+	optional uint32 item_def = 2;
+	optional uint32 item_quality = 3;
+	optional uint32 component_flags = 4;
+	optional uint32 item_flags = 5;
+	optional string attributes_string = 6;
+	optional uint32 num_required = 7;
+	optional uint32 item_count = 8;
+	optional uint32 num_fulfilled = 9;
+	optional uint32 items_fulfilled = 10;
+}
+
+message CAttribute_ItemSlotCriteria {
+	optional string tags = 1;
+}
+
+message CMsgSetItemSlotAttribute {
+	optional uint64 item_id = 1;
+	optional uint64 slot_item_original_id = 2;
+	optional uint32 slot_index = 3;
+}
+
+message CSOWarData {
+	optional uint32 account_id = 1 [(key_field) = true];
+	optional uint32 war_id = 2 [(key_field) = true];
+	optional uint32 affiliation = 3;
+	optional uint32 points_scored = 4;
+}
+
+message CGCMsgGC_War_IndividualUpdate {
+	optional fixed64 steam_id = 1;
+	optional uint32 war_id = 2;
+	optional uint32 score = 3;
+}
+
+message CGCMsgGC_War_JoinWar {
+	optional uint32 affiliation = 1;
+	optional uint32 war_id = 2;
+}
+
+message CGCMsgGC_War_RequestGlobalStats {
+	optional uint32 war_id = 1;
+}
+
+message CGCMsgGC_War_GlobalStatsResponse {
+	message SideScore {
+		optional uint32 side = 1;
+		optional uint64 score = 2;
+	}
+
+	repeated CGCMsgGC_War_GlobalStatsResponse.SideScore side_scores = 1;
+	optional uint32 war_id = 2;
+}
+
+message CGCMsgGC_PlayerDuckLeaderboard_IndividualUpdate {
+	optional uint32 score = 2;
+	optional uint32 type = 3;
+	optional bytes score_id = 4;
+	optional uint32 score_check = 5;
+}
+
+message CAttribute_WorldItemPlacement {
+	optional uint64 original_item_id = 1;
+	optional float pos_x = 2;
+	optional float pos_y = 3;
+	optional float pos_z = 4;
+	optional float ang_x = 5;
+	optional float ang_y = 6;
+	optional float ang_z = 7;
+}
+
+message CGCMsg_WorldItemPlacement_Update {
+	optional uint64 original_item_id = 1;
+	optional float pos_x = 2;
+	optional float pos_y = 3;
+	optional float pos_z = 4;
+	optional float ang_x = 5;
+	optional float ang_y = 6;
+	optional float ang_z = 7;
+	optional bool force_remove_all = 8;
+	optional string attrib_name = 9;
+}
+
+message CMsgAcknowledgeXP {
+	optional int32 match_group = 1;
+	optional uint32 predicted_experience = 2;
+}
+
+message CMsgTFXPSource {
+	enum XPSourceType {
+		SOURCE_SCORE = 0;
+		SOURCE_OBJECTIVE_BONUS = 1;
+		SOURCE_COMPLETED_MATCH = 2;
+		SOURCE_COMPETITIVE_ABANDON = 3;
+		SOURCE_COMPETITIVE_WIN = 4;
+		SOURCE_COMPETITIVE_LOSS = 5;
+		SOURCE_AUTOBALANCE_BONUS = 6;
+		SOURCE_PRESTIGE_BONUS = 7;
+	}
+
+	optional CMsgTFXPSource.XPSourceType type = 1 [default = SOURCE_SCORE, (key_field) = true];
+	optional int32 amount = 2;
+	optional int32 match_group = 3;
+	optional uint32 account_id = 4 [(key_field) = true];
+	optional uint64 match_id = 5 [(key_field) = true];
+}
+
+message CMsgTFXPSourceBreakdown {
+	repeated CMsgTFXPSource sources = 1;
+}
+
+message CMsgTFClientInit {
+	optional uint32 client_version = 1;
+	optional int32 language = 2;
+}
+
+message CMsgGCNotification {
+	enum NotificationType {
+		NOTIFICATION_REPORTED_PLAYER_BANNED = 0;
+		NOTIFICATION_CUSTOM_STRING = 1;
+		NOTIFICATION_MM_BAN_DUE_TO_EXCESSIVE_REPORTS = 2;
+		NOTIFICATION_REPORTED_PLAYER_WAS_BANNED = 3;
+		NOTIFICATION_SUPPORT_MESSAGE = 4;
+		NOTIFICATION_NUM_TYPES = 5;
+	}
+
+	optional uint64 notification_id = 1 [(key_field) = true];
+	optional uint32 account_id = 2;
+	optional fixed32 expiration_time = 3;
+	optional CMsgGCNotification.NotificationType type = 4 [default = NOTIFICATION_CUSTOM_STRING];
+	optional string notification_string = 5;
+}
+
+message CMsgGCNotificationQueue {
+	repeated CMsgGCNotification notifications = 1;
+}
+
+message CMsgNotificationAcknowledge {
+	optional uint32 account_id = 1;
+	optional uint64 notification_id = 2;
+}
+
+message CMsgNotificationAcknowledgeReply {
+}
+
+message CMsgGC_Match_Result {
+	message Player {
+		optional fixed64 steam_id = 1;
+		optional uint64 original_party_id = 2;
+		optional uint32 team = 3;
+		optional uint32 score = 4;
+		optional uint32 ping = 5;
+		optional uint32 flags = 6;
+		optional uint32 rank = 9;
+		optional uint32 classes_played = 10;
+		optional uint32 kills = 11;
+		optional uint32 deaths = 12;
+		optional uint32 damage = 13;
+		optional uint32 healing = 14;
+		optional uint32 support = 15;
+		optional uint32 score_medal = 16;
+		optional uint32 kills_medal = 17;
+		optional uint32 damage_medal = 18;
+		optional uint32 healing_medal = 19;
+		optional uint32 support_medal = 20;
+		repeated CMsgTFXPSource xp_breakdown = 21;
+		optional uint32 leave_time = 22;
+		optional TFMatchLeaveReason leave_reason = 23 [default = TFMatchLeaveReason_UNSPECIFIED];
+		optional uint32 connect_time = 24;
+	}
+
+	enum Status {
+		MATCH_SUCCEEDED = 0;
+		MATCH_FAILED_GC = 1;
+		MATCH_FAILED_TRUSTED = 2;
+		MATCH_FAILED_ABANDON = 3;
+		MATCH_FAILED_UNKNOWN = 5;
+		MATCH_FAILED_TIMEOUT = 6;
+		MATCH_FINISHED_ABANDON = 7;
+	}
+
+	optional uint64 match_id = 1 [(key_field) = true];
+	optional int32 match_group = 2;
+	optional CMsgGC_Match_Result.Status status = 3 [default = MATCH_SUCCEEDED];
+	optional uint32 duration = 4;
+	optional uint32 red_score = 5;
+	optional uint32 blue_score = 6;
+	optional uint32 winning_team = 7;
+	optional uint32 map_index = 8;
+	optional uint32 game_type = 9 [default = 0];
+	repeated CMsgGC_Match_Result.Player players = 10;
+	optional uint32 win_reason = 13;
+	optional uint32 flags = 14;
+	optional uint32 bots = 16;
+}
+
+message CMsgGC_Match_ResultResponse {
+}
+
+message CEconItemPreviewDataBlock {
+	optional CSOEconItem econitem = 1;
+}
+
+message CMsgGC_Client2GCEconPreviewDataBlockRequest {
+	optional uint64 param_s = 1;
+	optional uint64 param_a = 2;
+	optional uint64 param_d = 3;
+	optional uint64 param_m = 4;
+}
+
+message CMsgGC_Client2GCEconPreviewDataBlockResponse {
+	optional CEconItemPreviewDataBlock iteminfo = 1;
+}
+
+message CSOTFLadderPlayerStats {
+	optional uint32 account_id = 1 [(key_field) = true];
+	optional int32 match_group = 2 [(key_field) = true];
+	optional uint32 season_id = 3 [(key_field) = true];
+	optional uint32 games = 9;
+	optional uint32 score = 10;
+	optional uint32 kills = 11;
+	optional uint32 deaths = 12;
+	optional uint32 damage = 13;
+	optional uint32 healing = 14;
+	optional uint32 support = 15;
+	optional uint32 score_bronze = 16;
+	optional uint32 score_silver = 17;
+	optional uint32 score_gold = 18;
+	optional uint32 kills_bronze = 19;
+	optional uint32 kills_silver = 20;
+	optional uint32 kills_gold = 21;
+	optional uint32 damage_bronze = 22;
+	optional uint32 damage_silver = 23;
+	optional uint32 damage_gold = 24;
+	optional uint32 healing_bronze = 25;
+	optional uint32 healing_silver = 26;
+	optional uint32 healing_gold = 27;
+	optional uint32 support_bronze = 28;
+	optional uint32 support_silver = 29;
+	optional uint32 support_gold = 30;
+}
+
+message CSOTFRatingData {
+	optional uint32 account_id = 1 [(key_field) = true];
+	optional int32 rating_type = 2 [(key_field) = true];
+	optional uint32 rating_primary = 3;
+	optional uint32 rating_secondary = 4;
+	optional uint32 rating_tertiary = 5;
+}
+
+message CMsgGC_TFVoteKickPlayerRequest {
+	optional uint64 target_id = 2;
+	optional uint64 voter_id = 3;
+	optional TFVoteKickReason reason = 4 [default = TFVoteKickReason_Invalid];
+	optional uint64 match_id = 5;
+}
+
+message CMsgGC_VoteKickPlayerRequestResponse {
+	optional bool allowed = 1;
+	optional bool voter_inhibit = 3;
+	optional bool target_inhibit = 4;
+}
+
+message CMsgGC_DailyCompetitiveStatsRollup {
+}
+
+message CMsgGC_DailyCompetitiveStatsRollup_Response {
+	message RankBucketEntry {
+		optional uint32 rank = 1;
+		optional uint32 records = 2;
+		optional uint32 avg_score = 3;
+		optional uint32 stdev_score = 4;
+		optional uint32 avg_kills = 5;
+		optional uint32 stdev_kills = 6;
+		optional uint32 avg_damage = 7;
+		optional uint32 stdev_damage = 8;
+		optional uint32 avg_healing = 9;
+		optional uint32 stdev_healing = 10;
+		optional uint32 avg_support = 11;
+		optional uint32 stdev_support = 12;
+	}
+
+	repeated CMsgGC_DailyCompetitiveStatsRollup_Response.RankBucketEntry rankdata = 1;
+}
+
+message CMsgGC_ReportPlayer {
+	enum EReason {
+		kReason_INVALID = 0;
+		kReason_CHEATING = 1;
+		kReason_IDLE = 2;
+		kReason_HARASSMENT = 3;
+		kReason_GRIEFING = 4;
+		kReason_COUNT = 5;
+	}
+
+	optional uint32 account_id_target = 1;
+	optional CMsgGC_ReportPlayer.EReason reason = 2 [default = kReason_INVALID];
+}
+
+message CSOTFMatchResultPlayerStats {
+	optional uint64 match_id = 1 [(key_field) = true];
+	optional uint32 account_id = 2 [(key_field) = true];
+	optional int32 match_group = 3 [(key_field) = true];
+	optional uint32 endtime = 4;
+	optional uint32 season_id = 5;
+	optional uint32 status = 6;
+	optional uint32 original_party_id = 7;
+	optional uint32 team = 8;
+	optional uint32 score = 9;
+	optional uint32 ping = 10;
+	optional uint32 flags = 11;
+	optional uint32 display_rating = 12;
+	optional int32 display_rating_change = 13;
+	optional uint32 rank = 14;
+	optional uint32 classes_played = 15;
+	optional uint32 kills = 16;
+	optional uint32 deaths = 17;
+	optional uint32 damage = 18;
+	optional uint32 healing = 19;
+	optional uint32 support = 20;
+	optional uint32 score_medal = 21;
+	optional uint32 kills_medal = 22;
+	optional uint32 damage_medal = 23;
+	optional uint32 healing_medal = 24;
+	optional uint32 support_medal = 25;
+	optional uint32 map_index = 26;
+	optional uint32 winning_team = 27;
+}
+
+message CMsgGCRequestMatchMakerStats {
+}
+
+message CMsgGCDataCenterPopulation {
+	optional string name = 1;
+	optional float health_ratio = 2;
+}
+
+message CMsgGCMatchGroupDataCenterPopulation {
+	repeated CMsgGCDataCenterPopulation data_center_population = 1;
+}
+
+message CMsgGCMatchMakerStatsResponse {
+	repeated uint32 map_count = 1;
+	repeated CMsgGCMatchGroupDataCenterPopulation matchgroup_data_center_population = 2;
+}
+
+message CMsgGCMatchHistoryLoad {
+	optional ETFMatchGroup match_group = 1 [default = k_eTFMatchGroup_Invalid];
+}
+
+message CMsgGCDataCenterPing_Update {
+	message PingEntry {
+		optional string name = 1;
+		optional uint32 ping = 2;
+		optional CMsgGCDataCenterPing_Update.Status ping_status = 3 [default = Normal];
+	}
+
+	enum Status {
+		Invalid = 0;
+		Normal = 1;
+		Unreachable = 2;
+		FallbackToDCPing = 3;
+	}
+
+	repeated CMsgGCDataCenterPing_Update.PingEntry pingdata = 1;
+}
+
+message CMsgGC_KickPlayerFromLobby {
+	optional uint64 targetID = 1;
+}
+
+message CMsgGCSurveyRequest {
+	optional SurveyQuestionType question_type = 1 [default = QUESTION_MATCH_QUALITY];
+	optional uint64 match_id = 2;
+}
+
+message CMsgGCSurveyResponse {
+	optional SurveyQuestionType question_type = 1 [default = QUESTION_MATCH_QUALITY];
+	optional uint64 match_id = 2;
+	optional int32 response = 3;
+}
+
+message CSOQuestMapNode {
+	optional uint32 account_id = 1 [(key_field) = true];
+	optional uint32 defindex = 3 [(key_field) = true];
+	optional uint32 node_id = 4;
+	optional bool star_0_earned = 6 [default = false];
+	optional bool star_1_earned = 7 [default = false];
+	optional bool star_2_earned = 8 [default = false];
+	optional bool loot_claimed = 9 [default = false];
+	optional uint32 selected_quest_def = 10 [default = 0];
+	optional uint32 map_cycle = 11;
+}
+
+message CSOQuest {
+	optional uint32 account_id = 1;
+	optional uint64 quest_id = 2 [(key_field) = true];
+	optional uint32 defindex = 3;
+	optional bool active = 4 [default = false];
+	optional uint32 points_0 = 5;
+	optional uint32 points_1 = 6;
+	optional uint32 points_2 = 7;
+	optional uint32 quest_map_node_source_id = 8;
+	optional uint32 map_cycle = 9;
+}
+
+message CSOQuestMapRewardPurchase {
+	optional uint32 account_id = 1;
+	optional uint32 defindex = 2 [(key_field) = true];
+	optional uint32 count = 3;
+	optional uint32 map_cycle = 4;
+	optional uint32 purchase_id = 5;
+}
+
+message CMsgGCQuestIdentify {
+	optional uint64 quest_id = 1;
+}
+
+message CMsgGCQuestDevGive {
+	optional uint32 quest_def_index = 1;
+}
+
+message CMsgGCQuestNodeTurnIn {
+	optional uint32 node_defindex = 1;
+}
+
+message CMsgGCQuestMapUnlockNode {
+	optional uint32 node_defindex = 1;
+	optional uint32 quest_defindex = 2;
+}
+
+message CMsgGCNewMatchForLobbyRequest {
+	optional uint64 current_match_id = 1;
+	optional uint32 next_map_id = 2;
+	optional uint64 lobby_id = 3;
+}
+
+message CMsgGCNewMatchForLobbyResponse {
+	optional bool success = 1;
+}
+
+message CMsgGCChangeMatchPlayerTeamsRequest {
+	message Member {
+		optional uint64 member_id = 1;
+		optional TF_GC_TEAM new_team = 2 [default = TF_GC_TEAM_NOTEAM];
+	}
+
+	optional uint64 match_id = 1;
+	optional uint64 lobby_id = 2;
+	repeated CMsgGCChangeMatchPlayerTeamsRequest.Member member = 3;
+}
+
+message CMsgGCChangeMatchPlayerTeamsResponse {
+	optional bool success = 1;
+}
+
+message CMsgGCQuestComplete_Debug {
+	optional uint64 quest_id = 1;
+	optional uint32 points_type = 2;
+}
+
+message CMsgGCQuestMap_Debug {
+	optional uint32 reset_operation = 1;
+	optional uint32 give_credit = 2;
+	optional CMsgGCQuestMapUnlockNode unlock_node = 3;
+}
+
+message CMsgGCQuestMapPurchaseReward {
+	optional uint32 store_item_defindex = 1;
+}
+
+message CMsgGCQuestResponse {
+	optional bool success = 1 [default = false];
+}
+
+message CMsgGCSetDisablePartyQuestProgress {
+	optional bool state = 1;
+}
+
+message CMsgQuestProgressReport {
+	optional uint64 quest_id = 1;
+	optional bool star_0_earned = 2;
+	optional bool star_1_earned = 3;
+	optional bool star_2_earned = 4;
+	repeated uint64 items_earned = 5;
+	optional uint32 reward_credits_earned = 6;
+	optional bool contract_completed = 7;
+}
+
+message CMsgConsumePaintkit {
+	optional fixed64 source_id = 1;
+	optional uint32 target_defindex = 2;
+}
+
+message CMsgPainkitDevGrant {
+	optional uint32 paintkit_defindex = 1;
+	optional float wear = 2;
+	optional uint32 item_defindex = 3;
+}
+
+message GCQuestStrangeEvent {
+	optional uint32 owner_account_id = 1;
+	optional uint32 scorer_account_id = 2;
+	optional uint64 quest_id = 3;
+	optional uint32 strange_event_id = 4;
+	optional uint32 score = 5;
+}
+
+message CMsgSDRTicket {
+	optional bytes serialized_ticket = 1;
+}
+
+message CMsgAuthorizeServerItemRetrieval {
+	repeated uint64 item_id = 1;
+}
+
+message CMsgGCToGCSendAccountBannedNotifications {
+	optional uint32 banned_accountid = 1;
+	optional uint32 report_period_begin = 2;
+	optional uint32 report_period_end = 3;
+}
+
+message CMsgGCToGCSendNotification {
+	optional CMsgGCNotification notification = 1;
+}

--- a/dll/net.proto
+++ b/dll/net.proto
@@ -336,6 +336,11 @@ message GameServer_Items_Messages {
     message Attribute {
         uint32 def = 1;
         float value = 2;
+        bytes value_bytes = 3;
+    }
+    message EquipState {
+        uint32 class_id = 1;
+        uint32 slot_id = 2;
     }
     message Item {
         uint64 id = 1;
@@ -350,6 +355,9 @@ message GameServer_Items_Messages {
         string custom_name = 10;
         string custom_desc = 11;
         uint64 original_id = 12;
+        bool in_use = 13;
+        uint32 style = 14;
+        repeated EquipState equip_states = 15;
     }
     message InventoryRequest {
         uint64 steam_api_call = 1;
@@ -358,9 +366,12 @@ message GameServer_Items_Messages {
         uint64 steam_api_call = 1;
         repeated Item items = 2;
     }
-    message InventoryPosUpdate {
-        uint64 item_id = 1;
-        uint32 item_inv_pos = 2;
+    message ItemUpdate {
+        uint64 id = 1;
+        optional uint32 inv_pos = 2;
+        optional uint32 style = 3;
+        optional bool has_equip_states = 4;
+        repeated EquipState equip_states = 5;
     }
     message ItemDeletion {
         uint64 item_id = 1;
@@ -369,7 +380,7 @@ message GameServer_Items_Messages {
     enum Types {
         Request_Inventory = 0;
         Response_Inventory = 1;
-        Request_UpdateInventoryPos = 2;
+        Request_UpdateItem = 2;
         Request_DeleteItem = 3;
         Request_Respawn = 4;
     }
@@ -379,7 +390,7 @@ message GameServer_Items_Messages {
     oneof data_messages {
         InventoryRequest inventory_request = 3;
         InventoryResponse inventory_response = 4;
-        InventoryPosUpdate inventory_pos_update = 5;
+        ItemUpdate item_update = 5;
         ItemDeletion item_deletion = 6;
     }
 }

--- a/dll/steam_game_coordinator.cpp
+++ b/dll/steam_game_coordinator.cpp
@@ -17,9 +17,16 @@
 
 #include "dll/steam_game_coordinator.h"
 #include "dll/dll.h"
+#include <steammessages.pb.h>
+#include <tf2/base_gcmessages.pb.h>
+#include <tf2/econ_gcmessages.pb.h>
+#include <tf2/gcsdk_gcmessages.pb.h>
+#include <tf2/gcsystemmsgs.pb.h>
+#include <tf2/tf_gcmessages.pb.h>
+
+using namespace gamecoordinator::tf2;
 
 constexpr int GC_MIN_VERSION = 20091217;
-constexpr int GC_MAX_VERSION = 20110413;
 
 #pragma pack( push, 1 )
 //-----------------------------------------------------------------------------
@@ -63,15 +70,15 @@ static void ser_varstring(std::string &buf, const std::string &input)
     uint16 len = static_cast<uint16>(input.size());
     if (len != 0) {
         ser_var<uint16>(buf, len + 1);
-        buf.append(input);
-        buf.push_back('\0');
+        buf.append(input + '\0');
     } else {
         ser_var<uint16>(buf, 0);
     }
 }
 
 template <class T>
-static T deser_var(const char *&p) {
+static T deser_var(const char *&p)
+{
     T output;
     memcpy(&output, p, sizeof(T));
     p += sizeof(T);
@@ -80,7 +87,7 @@ static T deser_var(const char *&p) {
 
 bool Steam_Game_Coordinator::gc_enabled()
 {
-    return (gc_version >= GC_MIN_VERSION && gc_version <= GC_MAX_VERSION);
+    return (gc_version >= GC_MIN_VERSION && gc_profile != GC_PROFILE_INVALID);
 }
 
 Steam_User_Items *Steam_Game_Coordinator::client_items()
@@ -90,7 +97,7 @@ Steam_User_Items *Steam_Game_Coordinator::client_items()
 
 Steam_GameServer_Items *Steam_Game_Coordinator::server_items()
 {
-    return get_steam_client()->steam_gameserver_items;;
+    return get_steam_client()->steam_gameserver_items;
 }
 
 void Steam_Game_Coordinator::parse_gc_config()
@@ -101,12 +108,35 @@ void Steam_Game_Coordinator::parse_gc_config()
         return;
 
     try {
+        std::string gc_profile_name = gc_json.value("gc_profile", std::string());
+        std::transform(gc_profile_name.begin(), gc_profile_name.end(), gc_profile_name.begin(),
+            [](auto c) { return std::tolower(c); });
+        if (gc_profile_name == "tf2") {
+            gc_profile = GC_PROFILE_TF2;
+        } else if (gc_profile_name == "portal2") {
+            // Portal 2 is pretty much entirely compatible with TF2 protobuf structs so we can just
+            // make it an alias for TF2 profile.
+            //gc_profile = GC_PROFILE_PORTAL2;
+            gc_profile = GC_PROFILE_TF2;
+            is_portal2 = true;
+        } else {
+            gc_profile = GC_PROFILE_INVALID;
+        }
+
         gc_version = gc_json.value("gc_version", 0);
     } catch (std::exception &e) {
         const char *errorMessage = e.what();
         PRINT_DEBUG("error parsing GC config: %s", errorMessage);
         gc_version = 0;
+        gc_profile = GC_PROFILE_INVALID;
     }
+}
+
+bool Steam_Game_Coordinator::is_welcome_message(const GC_Message &message)
+{
+    uint32 msg_type = message.msg_type & (~protobuf_mask);
+    return (msg_type == 4004 ||
+        msg_type == 4005);
 }
 
 void Steam_Game_Coordinator::push_incoming(uint32 msg_type, const std::string &message, double delay)
@@ -140,6 +170,53 @@ GCMsgHdrEx_t Steam_Game_Coordinator::parse_msg_header(const char *&p)
     memcpy(reinterpret_cast<char *>(&hdr) + write_offset, p, hdr_size);
     p += hdr_size;
     return hdr;
+}
+
+std::string Steam_Game_Coordinator::build_protomsg_header(uint32 msg_type, JobID_t target_job, JobID_t source_job)
+{
+    std::string message;
+    ProtoBufMsgHeader_t hdr{};
+    hdr.m_EMsgFlagged = msg_type;
+
+    CMsgProtoBufHeader protohdr;
+    protohdr.set_client_steam_id(settings->get_local_steam_id().ConvertToUint64());
+    protohdr.set_client_session_id(1);
+    protohdr.set_source_app_id(settings->get_local_game_id().AppID());
+    protohdr.set_job_id_source(source_job);
+    protohdr.set_job_id_target(target_job);
+    hdr.m_cubProtoBufExtHdr = static_cast<uint32>(protohdr.ByteSizeLong());
+
+    ser_var<ProtoBufMsgHeader_t>(message, hdr);
+    protohdr.AppendToString(&message);
+
+    return message;
+}
+
+template <class T>
+std::tuple<ProtoBufMsgHeader_t, CMsgProtoBufHeader, T, bool> Steam_Game_Coordinator::parse_protomsg(const void *input, uint32 input_size)
+{
+    const char *p = reinterpret_cast<const char *>(input);
+    const char *end = p + input_size;
+
+    ProtoBufMsgHeader_t hdr{};
+    CMsgProtoBufHeader protohdr;
+    T protomsg;
+
+    if (input_size < sizeof(ProtoBufMsgHeader_t))
+        return { hdr, protohdr, protomsg, false };
+
+    hdr = deser_var<ProtoBufMsgHeader_t>(p);
+
+    if (!protohdr.ParseFromArray(p, hdr.m_cubProtoBufExtHdr))
+        return { hdr, protohdr, protomsg, false };
+
+    p += hdr.m_cubProtoBufExtHdr;
+
+    int protomsg_size = static_cast<int>(end - p);
+    if (!protomsg.ParseFromArray(p, protomsg_size))
+        return { hdr, protohdr, protomsg, false };
+
+    return { hdr, protohdr, protomsg, true };
 }
 
 uint64 Steam_Game_Coordinator::item_id_local_to_network(uint64 item_id)
@@ -176,6 +253,95 @@ uint64 Steam_Game_Coordinator::item_id_network_to_local(uint64 item_id)
     return item_id;
 }
 
+std::string Steam_Game_Coordinator::item_to_gcstruct(const Econ_Item &item, CSteamID steam_id)
+{
+    std::string message;
+
+    ser_var<uint64>(message, item.id);
+    ser_var<uint32>(message, steam_id.GetAccountID());
+    ser_var<uint16>(message, item.def);
+    ser_var<uint8>(message, item.level);
+    ser_var<uint8>(message, item.quality);
+    ser_var<uint32>(message, item.inv_pos);
+    ser_var<uint32>(message, item.quantity);
+
+    if (gc_version >= 20100428) {
+        // Strings are passed as UTF-8 which is good for us since we can just copy std::string as is.
+        ser_varstring(message, item.custom_name);
+
+        if (gc_version >= 20100930) {
+            ser_var<uint8>(message, item.flags);
+
+            if (gc_version >= 20101027) {
+                ser_var<uint8>(message, item.origin);
+                ser_varstring(message, item.custom_desc);
+                ser_var<bool>(message, item.in_use);
+            }
+        }
+    }
+
+    ser_var<uint16>(message, static_cast<uint16>(item.attributes.size()));
+
+    for (const Econ_Item_Attribute &attr : item.attributes) {
+        ser_var<uint16>(message, attr.def);
+        ser_var<float>(message, attr.value);
+    }
+
+    if (gc_version >= 20101217) {
+        ser_var<uint64>(message, item.original_id);
+    }
+
+    return message;
+}
+
+std::string Steam_Game_Coordinator::item_to_gcprotobuf(const Econ_Item &item, CSteamID steam_id)
+{
+    CSOEconItem proto_item;
+    proto_item.set_id(item.id);
+    proto_item.set_account_id(steam_id.GetAccountID());
+    proto_item.set_inventory(item.inv_pos);
+    proto_item.set_def_index(item.def);
+    proto_item.set_quantity(item.quantity);
+    proto_item.set_level(item.level);
+    proto_item.set_quality(item.quality);
+    proto_item.set_flags(item.flags);
+    proto_item.set_origin(item.origin);
+
+    if (!item.custom_name.empty())
+        proto_item.set_custom_name(item.custom_name);
+
+    if (!item.custom_desc.empty())
+        proto_item.set_custom_desc(item.custom_desc);
+
+    proto_item.set_in_use(item.in_use);
+    proto_item.set_style(item.style);
+    proto_item.set_original_id(item.original_id);
+
+    proto_item.set_contains_equipped_state(true);
+    proto_item.set_contains_equipped_state_v2(true);
+
+    for (const auto &[class_id, slot_id] : item.equip_states) {
+        auto proto_equip = proto_item.add_equipped_state();
+        proto_equip->set_new_class(class_id);
+        proto_equip->set_new_slot(slot_id);
+    }
+
+    for (const Econ_Item_Attribute &attr : item.attributes) {
+        auto proto_attr = proto_item.add_attribute();
+        proto_attr->set_def_index(attr.def);
+        if (gc_version < 20130319 || is_portal2) {
+            // Derp.
+            uint32 value;
+            memcpy(&value, &attr.value, sizeof(uint32));
+            proto_attr->set_value(value);
+        } else {
+            proto_attr->set_value_bytes(attr.value_bytes);
+        }
+    }
+
+    return proto_item.SerializeAsString();
+}
+
 void Steam_Game_Coordinator::handle_set_item_pos(const void *input, uint32 input_size)
 {
     if (is_server || input_size < 30)
@@ -185,9 +351,10 @@ void Steam_Game_Coordinator::handle_set_item_pos(const void *input, uint32 input
     GCMsgHdrEx_t hdr = parse_msg_header(p);
     uint64 item_id = deser_var<uint64>(p);
     uint32 inv_pos = deser_var<uint32>(p);
+    PRINT_DEBUG("%llu %u", item_id, inv_pos);
 
     if (const Econ_Item *item = set_item_pos(item_id, inv_pos, true)) {
-        on_item_pos_updated(settings->get_local_steam_id(), *item);
+        callback_item_updated(settings->get_local_steam_id(), *item);
     }
 }
 
@@ -199,10 +366,30 @@ void Steam_Game_Coordinator::handle_delete_item(const void *input, uint32 input_
     const char *p = reinterpret_cast<const char *>(input);
     GCMsgHdrEx_t hdr = parse_msg_header(p);
     uint64 item_id = deser_var<uint64>(p);
+    PRINT_DEBUG("%llu", item_id);
 
     if (delete_item(item_id, true)) {
-        on_item_deleted(settings->get_local_steam_id(), item_id);
+        callback_item_deleted(settings->get_local_steam_id(), item_id);
     }
+}
+
+void Steam_Game_Coordinator::handle_motd_request(const void *input, uint32 input_size)
+{
+    if (is_server || input_size < 24)
+        return;
+
+    const char *p = reinterpret_cast<const char *>(input);
+    GCMsgHdrEx_t hdr = parse_msg_header(p);
+    uint32 last_req_time = deser_var<uint32>(p);
+    uint16 language = deser_var<uint16>(p);
+    PRINT_DEBUG("%u %u", last_req_time, language);
+
+    uint32 msg_type = EGCItemMsg::k_EMsgGCMOTDRequestResponse;
+    std::string message = build_msg_header();
+    uint16 num_entries = 0;
+    ser_var<uint16>(message, num_entries);
+
+    push_incoming(msg_type, message);
 }
 
 void Steam_Game_Coordinator::handle_respawn(const void *input, uint32 input_size)
@@ -220,21 +407,300 @@ void Steam_Game_Coordinator::handle_respawn(const void *input, uint32 input_size
     network->sendToAllGameservers(&msg, true);
 }
 
-void Steam_Game_Coordinator::handle_motd_request(const void *input, uint32 input_size)
+void Steam_Game_Coordinator::handle_set_item_style(const void *input, uint32 input_size)
 {
-    if (is_server || input_size < 24)
+    if (is_server || input_size < 27)
         return;
 
     const char *p = reinterpret_cast<const char *>(input);
     GCMsgHdrEx_t hdr = parse_msg_header(p);
-    uint32 last_req_time = deser_var<uint32>(p);
-    uint16 language = deser_var<uint16>(p);
+    uint64 item_id = deser_var<uint64>(p);
+    uint8 style = deser_var<uint8>(p);
+    PRINT_DEBUG("%llu %u", item_id, style);
 
-    // k_EMsgGCMOTDRequestResponse
-    uint32 msg_type = 1013;
+    for (Econ_Item &item : items) {
+        if (item.id != item_id)
+            continue;
+
+        item.style = style;
+        save_items_to_file();
+
+        // Let the others know, too.
+        auto inventory_msg = new GameServer_Items_Messages::ItemUpdate();
+        inventory_msg->set_id(item_id);
+        inventory_msg->set_style(style);
+
+        auto gameserver_items_msg = new GameServer_Items_Messages();
+        gameserver_items_msg->set_type(GameServer_Items_Messages::Request_UpdateItem);
+        gameserver_items_msg->set_is_gc(true);
+        gameserver_items_msg->set_allocated_item_update(inventory_msg);
+
+        Common_Message msg{};
+        msg.set_allocated_gameserver_items_messages(gameserver_items_msg);
+        msg.set_source_id(settings->get_local_steam_id().ConvertToUint64());
+        network->sendToAll(&msg, true);
+
+        callback_item_updated(settings->get_local_steam_id(), item);
+        break;
+    }
+}
+
+void Steam_Game_Coordinator::handle_adjust_equip_state(const void *input, uint32 input_size)
+{
+    if (is_server)
+        return;
+
+    auto [hdr, protohdr, protomsg, success] = parse_protomsg<CMsgAdjustItemEquippedState>(input, input_size);
+    if (!success)
+        return;
+
+    uint64 item_id = protomsg.item_id();
+    uint32 new_class_id = protomsg.new_class();
+    uint32 new_slot_id = protomsg.new_slot();
+    PRINT_DEBUG("%llu %u %u", item_id, new_class_id, new_slot_id);
+
+    for (Econ_Item &item : items) {
+        if (item_id != UINT64_MAX && item.id == item_id) {
+            // Equip the item into this slot.
+            item.equip_states.insert_or_assign(new_class_id, new_slot_id);
+        } else {
+            // Unequip whatever else we had in this slot.
+            auto it = item.equip_states.find(new_class_id);
+            if (it == item.equip_states.end() || it->second != new_slot_id)
+                continue;
+
+            item.equip_states.erase(it);
+        }
+
+        // Let the others know, too.
+        auto inventory_msg = new GameServer_Items_Messages::ItemUpdate();
+        inventory_msg->set_id(item.id);
+        inventory_msg->set_has_equip_states(true);
+        for (const auto &[class_id, slot_id] : item.equip_states) {
+            auto new_state = inventory_msg->add_equip_states();
+            new_state->set_class_id(class_id);
+            new_state->set_slot_id(slot_id);
+        }
+
+        auto gameserver_items_msg = new GameServer_Items_Messages();
+        gameserver_items_msg->set_type(GameServer_Items_Messages::Request_UpdateItem);
+        gameserver_items_msg->set_is_gc(true);
+        gameserver_items_msg->set_allocated_item_update(inventory_msg);
+
+        Common_Message msg{};
+        msg.set_allocated_gameserver_items_messages(gameserver_items_msg);
+        msg.set_source_id(settings->get_local_steam_id().ConvertToUint64());
+        network->sendToAll(&msg, true);
+
+        callback_item_updated(settings->get_local_steam_id(), item);
+    }
+
+    save_items_to_file();
+}
+
+void Steam_Game_Coordinator::handle_set_multiple_item_pos(const void *input, uint32 input_size)
+{
+    if (is_server)
+        return;
+
+    auto [hdr, protohdr, protomsg, success] = parse_protomsg<CMsgSetItemPositions>(input, input_size);
+    if (!success)
+        return;
+
+    for (auto &entry : protomsg.item_positions()) {
+        uint64 item_id = entry.item_id();
+        uint32 inv_pos = entry.position();
+
+        if (const Econ_Item *item = set_item_pos(item_id, inv_pos, true, false)) {
+            callback_item_updated(settings->get_local_steam_id(), *item);
+        }
+    }
+
+    save_items_to_file();
+}
+
+void Steam_Game_Coordinator::callback_client_welcome()
+{
+    if (!gc_initialized)
+        return;
+
+    uint32 msg_type = EGCBaseClientMsg::k_EMsgGCClientWelcome | protobuf_mask;
+    std::string message = build_protomsg_header(msg_type);
+
+    CMsgClientWelcome protomsg;
+    protomsg.set_version(0);
+
+    protomsg.AppendToString(&message);
+    push_incoming(msg_type, message);
+}
+
+void Steam_Game_Coordinator::callback_server_welcome()
+{
+    if (!gc_initialized)
+        return;
+
+    uint32 msg_type = EGCBaseClientMsg::k_EMsgGCServerWelcome | protobuf_mask;
+    std::string message = build_protomsg_header(msg_type);
+
+    CMsgServerWelcome protomsg;
+    protomsg.set_min_allowed_version(0);
+    protomsg.set_active_version(0);
+
+    protomsg.AppendToString(&message);
+    push_incoming(msg_type, message);
+}
+
+void Steam_Game_Coordinator::callback_items_received(CSteamID steam_id, const std::vector<Econ_Item> &items)
+{
+    if (!gc_initialized)
+        return;
+
+    if (gc_version < 20110414) {
+        uint32 msg_type = ESOMsg::k_ESOMsg_CacheSubscribed;
+        std::string message = build_msg_header();
+
+        uint64 owner_id = steam_id.ConvertToUint64();
+        uint16 num_types = 1;
+
+        ser_var<uint64>(message, owner_id);
+        ser_var<uint16>(message, num_types);
+
+        // econ items (1)
+        uint32 object_type = 1;
+        uint16 num_objects = static_cast<uint16>(items.size());
+
+        ser_var<uint32>(message, object_type);
+        ser_var<uint16>(message, num_objects);
+
+        for (const Econ_Item &item : items) {
+            message.append(item_to_gcstruct(item, steam_id));
+        }
+
+        push_incoming(msg_type, message);
+    } else {
+        uint32 msg_type = ESOMsg::k_ESOMsg_CacheSubscribed | protobuf_mask;
+        std::string message = build_protomsg_header(msg_type);
+
+        CMsgSOCacheSubscribed protomsg;
+        protomsg.set_owner(steam_id.ConvertToUint64());
+        auto objects = protomsg.add_objects();
+        objects->set_type_id(1);
+
+        for (const Econ_Item &item : items) {
+            objects->add_object_data(item_to_gcprotobuf(item, steam_id));
+        }
+
+        protomsg.AppendToString(&message);
+        push_incoming(msg_type, message);
+    }
+}
+
+void Steam_Game_Coordinator::callback_items_removed(CSteamID steam_id)
+{
+    if (!gc_initialized)
+        return;
+
+    if (gc_version < 20110414) {
+        uint32 msg_type = ESOMsg::k_ESOMsg_CacheUnsubscribed;
+        std::string message = build_msg_header();
+        ser_var<uint64>(message, steam_id.ConvertToUint64());
+
+        push_incoming(msg_type, message);
+    } else {
+        uint32 msg_type = ESOMsg::k_ESOMsg_CacheUnsubscribed | protobuf_mask;
+        std::string message = build_protomsg_header(msg_type);
+
+        CMsgSOCacheUnsubscribed protomsg;
+        protomsg.set_owner(steam_id.ConvertToUint64());
+
+        protomsg.AppendToString(&message);
+        push_incoming(msg_type, message);
+    }
+}
+
+void Steam_Game_Coordinator::callback_item_updated(CSteamID steam_id, const Econ_Item &item)
+{
+    if (!gc_initialized)
+        return;
+
+    if (gc_version < 20110414) {
+        uint32 msg_type = ESOMsg::k_ESOMsg_Update;
+        std::string message = build_msg_header();
+
+        uint64 owner_id = steam_id.ConvertToUint64();
+        uint32 object_type = 1;
+        uint8 num_fields = 1;
+
+        ser_var<uint64>(message, owner_id);
+        ser_var<uint32>(message, object_type);
+        ser_var<uint64>(message, item.id);
+        ser_var<uint8>(message, num_fields);
+
+        uint8 field_idx = 5;
+        ser_var<uint8>(message, field_idx);
+        ser_var<uint32>(message, item.inv_pos);
+
+        if (gc_version >= 20101027) {
+            ser_var<bool>(message, item.in_use);
+        }
+
+        push_incoming(msg_type, message);
+    } else {
+        uint32 msg_type = ESOMsg::k_ESOMsg_Update | protobuf_mask;
+        std::string message = build_protomsg_header(msg_type);
+
+        CMsgSOSingleObject protomsg;
+        protomsg.set_owner(steam_id.ConvertToUint64());
+        protomsg.set_type_id(1);
+        protomsg.set_object_data(item_to_gcprotobuf(item, steam_id));
+
+        protomsg.AppendToString(&message);
+        push_incoming(msg_type, message);
+    }
+}
+
+void Steam_Game_Coordinator::callback_item_deleted(CSteamID steam_id, uint64 item_id)
+{
+    if (!gc_initialized)
+        return;
+
+    if (gc_version < 20110414) {
+        uint32 msg_type = ESOMsg::k_ESOMsg_Destroy;
+        std::string message = build_msg_header();
+
+        uint64 owner_id = steam_id.ConvertToUint64();
+        uint32 object_type = 1;
+
+        ser_var<uint64>(message, owner_id);
+        ser_var<uint32>(message, object_type);
+        ser_var<uint64>(message, item_id);
+
+        push_incoming(msg_type, message);
+    } else {
+        uint32 msg_type = ESOMsg::k_ESOMsg_Destroy | protobuf_mask;
+        std::string message = build_protomsg_header(msg_type);
+
+        CMsgSOSingleObject protomsg;
+        protomsg.set_owner(steam_id.ConvertToUint64());
+        protomsg.set_type_id(1);
+
+        CSOEconItem proto_item;
+        proto_item.set_id(item_id);
+        protomsg.set_object_data(proto_item.SerializeAsString());
+
+        protomsg.AppendToString(&message);
+        push_incoming(msg_type, message);
+    }
+}
+
+void Steam_Game_Coordinator::callback_respawn_request(CSteamID steam_id)
+{
+    if (!gc_initialized)
+        return;
+
+    uint32 msg_type = EGCItemMsg::k_EMsgGCRespawnPostLoadoutChange;
     std::string message = build_msg_header();
-    uint16 num_entries = 0;
-    ser_var<uint16>(message, num_entries);
+    ser_var<uint64>(message, steam_id.ConvertToUint64());
 
     push_incoming(msg_type, message);
 }
@@ -285,24 +751,41 @@ void Steam_Game_Coordinator::initialize_gc()
 
     gc_initialized = true;
 
-    // Servers don't need anything.
-    if (is_server)
+    if (is_server) {
+        callback_server_welcome();
+    } else {
+        callback_client_welcome();
+
+        // Load user's items.
+        const auto &items = load_items_from_file();
+        callback_items_received(settings->get_local_steam_id(), items);
+    }
+
+    // Wait a bit until after the game has received welcome message from us before posting anything else.
+    // This avoids a race condition that can cause the game to receive inventory before parsing item schema.
+    // For old versions of TF2, we can't do that because they instead have a different bug where receiving
+    // the inventory late causes erroneous "new items" notifications.
+    if (gc_version >= 20110414) {
+        delay_init = true;
+    }
+}
+
+void Steam_Game_Coordinator::shutdown_gc()
+{
+    if (!gc_initialized)
         return;
 
-    // Load user's items.
-    const auto &items = load_items_from_file();
-    on_items_received(settings->get_local_steam_id(), items);
-
-    // HACK: Put any messages from the initialization directly into the queue so that the initial
-    // IsMessageAvailable call reads it.
-    for (const GC_Message &msg : pending_messages) {
-        incoming_messages.push(msg);
-
-        GCMessageAvailable_t data{};
-        data.m_nMessageSize = static_cast<uint32>(msg.msg_body.size());
-        callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
-    }
+    items_loaded = false;
+    items.clear();
+    all_user_items.clear();
+    pending_items_requests.clear();
     pending_messages.clear();
+    while (incoming_messages.size())
+        incoming_messages.pop();
+
+    welcome_received = false;
+    delay_init = false;
+    gc_initialized = false;
 }
 
 const std::vector<Econ_Item> &Steam_Game_Coordinator::load_items_from_file()
@@ -337,15 +820,48 @@ const std::vector<Econ_Item> &Steam_Game_Coordinator::load_items_from_file()
             new_item.custom_name = it->value("custom_name", std::string());
             new_item.custom_desc = it->value("custom_desc", std::string());
             new_item.original_id = it->value("original_id", 0ull);
+            new_item.style = it->value("style", 0u);
             new_item.in_use = false;
+
+            if (it->contains("equip_states")) {
+                for (const auto &equip : it->at("equip_states")) {
+                    uint32 class_id = equip.value("class", 0u);
+                    uint32 slot_id = equip.value("slot", 0u);
+
+                    new_item.equip_states.insert({ class_id, slot_id });
+                }
+            }
 
             if (it->contains("attributes")) {
                 for (const auto &attr : it->at("attributes")) {
                     Econ_Item_Attribute new_attr{};
                     new_attr.def = attr.value("definition", 0u);
-                    new_attr.value = attr.value("value", 0.0f);
                     if (new_attr.def == 0) // 0 is not a valid attribute definition, however
                         continue;
+
+                    if (attr.contains("value")) {
+                        new_attr.type = Econ_Item_Attribute::ATTR_TYPE_DEFAULT;
+                        float value = attr.value("value", 0.0f);
+                        ser_var<float>(new_attr.value_bytes, value);
+                        new_attr.value = value;
+                    } else if (attr.contains("value_float")) {
+                        new_attr.type = Econ_Item_Attribute::ATTR_TYPE_FLOAT;
+                        float value = attr.value("value_float", 0.0f);
+                        ser_var<float>(new_attr.value_bytes, value);
+                        new_attr.value = value;
+                    } else if (attr.contains("value_int")) {
+                        new_attr.type = Econ_Item_Attribute::ATTR_TYPE_INT;
+                        uint32 value = attr.value("value_int", 0u);
+                        ser_var<uint32>(new_attr.value_bytes, value);
+                        memcpy(&new_attr.value, &value, sizeof(float));
+                    } else if (attr.contains("value_string")) {
+                        new_attr.type = Econ_Item_Attribute::ATTR_TYPE_STRING;
+                        std::string value = attr.value("value_string", std::string());
+                        new_attr.value_bytes = value + '\0';
+                        new_attr.value = 0.0f;
+                    } else {
+                        continue;
+                    }
 
                     new_item.attributes.push_back(new_attr);
                 }
@@ -392,11 +908,45 @@ void Steam_Game_Coordinator::save_items_to_file()
         json_item["custom_name"] = item.custom_name;
         json_item["custom_desc"] = item.custom_desc;
         json_item["original_id"] = item_id_network_to_local(item.original_id);
+        json_item["style"] = item.style;
+
+        for (auto &[class_id, slot_id] : item.equip_states) {
+            nlohmann::json json_equip;
+            json_equip["class"] = class_id;
+            json_equip["slot"] = slot_id;
+            json_item["equip_states"].push_back(json_equip);
+        }
 
         for (const Econ_Item_Attribute &attr : item.attributes) {
             nlohmann::json json_attr;
             json_attr["definition"] = attr.def;
-            json_attr["value"] = attr.value;
+
+            switch (attr.type) {
+                case Econ_Item_Attribute::ATTR_TYPE_DEFAULT: {
+                    float value;
+                    attr.value_bytes.copy(reinterpret_cast<char *>(&value), sizeof(float));
+                    json_attr["value"] = value;
+                    break;
+                }
+                case Econ_Item_Attribute::ATTR_TYPE_FLOAT: {
+                    float value;
+                    attr.value_bytes.copy(reinterpret_cast<char *>(&value), sizeof(float));
+                    json_attr["value_float"] = value;
+                    break;
+                }
+                case Econ_Item_Attribute::ATTR_TYPE_INT: {
+                    uint32 value;
+                    attr.value_bytes.copy(reinterpret_cast<char *>(&value), sizeof(uint32));
+                    json_attr["value_int"] = value;
+                    break;
+                }
+                case Econ_Item_Attribute::ATTR_TYPE_STRING: {
+                    const char *value = attr.value_bytes.c_str();
+                    json_attr["value_string"] = value;
+                    break;
+                }
+            }
+
             json_item["attributes"].push_back(json_attr);
         }
 
@@ -406,24 +956,26 @@ void Steam_Game_Coordinator::save_items_to_file()
     local_storage->write_json_file("", items_user_file, items_json);
 }
 
-const Econ_Item *Steam_Game_Coordinator::set_item_pos(uint64 item_id, uint32 inv_pos, bool is_gc)
+const Econ_Item *Steam_Game_Coordinator::set_item_pos(uint64 item_id, uint32 inv_pos, bool is_gc, bool save)
 {
     for (Econ_Item &item : items) {
         if (item.id != item_id)
             continue;
 
         item.inv_pos = inv_pos;
-        save_items_to_file();
+        if (save) {
+            save_items_to_file();
+        }
 
         // Let the others know, too.
-        auto inventory_msg = new GameServer_Items_Messages::InventoryPosUpdate();
-        inventory_msg->set_item_id(item_id);
-        inventory_msg->set_item_inv_pos(inv_pos);
+        auto inventory_msg = new GameServer_Items_Messages::ItemUpdate();
+        inventory_msg->set_id(item_id);
+        inventory_msg->set_inv_pos(inv_pos);
 
         auto gameserver_items_msg = new GameServer_Items_Messages();
-        gameserver_items_msg->set_type(GameServer_Items_Messages::Request_UpdateInventoryPos);
+        gameserver_items_msg->set_type(GameServer_Items_Messages::Request_UpdateItem);
         gameserver_items_msg->set_is_gc(is_gc);
-        gameserver_items_msg->set_allocated_inventory_pos_update(inventory_msg);
+        gameserver_items_msg->set_allocated_item_update(inventory_msg);
 
         Common_Message msg{};
         msg.set_allocated_gameserver_items_messages(gameserver_items_msg);
@@ -446,13 +998,13 @@ bool Steam_Game_Coordinator::delete_item(uint64 item_id, bool is_gc)
         save_items_to_file();
 
         // Let the others know, too.
-        auto drop_msg = new GameServer_Items_Messages::ItemDeletion();
-        drop_msg->set_item_id(item_id);
+        auto delete_msg = new GameServer_Items_Messages::ItemDeletion();
+        delete_msg->set_item_id(item_id);
 
         auto gameserver_items_msg = new GameServer_Items_Messages();
         gameserver_items_msg->set_type(GameServer_Items_Messages::Request_DeleteItem);
         gameserver_items_msg->set_is_gc(is_gc);
-        gameserver_items_msg->set_allocated_item_deletion(drop_msg);
+        gameserver_items_msg->set_allocated_item_deletion(delete_msg);
 
         Common_Message msg{};
         msg.set_allocated_gameserver_items_messages(gameserver_items_msg);
@@ -517,14 +1069,7 @@ void Steam_Game_Coordinator::remove_user_items(CSteamID steam_id)
         }
     }
 
-    if (gc_initialized) {
-        // k_ESOMsg_CacheUnsubscribed
-        uint32 msg_type = 25;
-        std::string message = build_msg_header();
-        ser_var<uint64>(message, steam_id.ConvertToUint64());
-
-        push_incoming(msg_type, message);
-    }
+    callback_items_removed(steam_id);
 }
 
 void Steam_Game_Coordinator::on_client_connected(CSteamID steam_id)
@@ -545,115 +1090,6 @@ void Steam_Game_Coordinator::on_client_disconnected(CSteamID steam_id)
     remove_user_items(steam_id);
 }
 
-void Steam_Game_Coordinator::on_items_received(CSteamID steam_id, const std::vector<Econ_Item> &items)
-{
-    if (!gc_initialized)
-        return;
-
-    // k_ESOMsg_CacheSubscribed
-    uint32 msg_type = 24;
-    std::string message = build_msg_header();
-
-    uint64 owner_id = steam_id.ConvertToUint64();
-    uint16 num_types = 1;
-
-    ser_var<uint64>(message, owner_id);
-    ser_var<uint16>(message, num_types);
-
-    // econ items (1)
-    uint32 object_type = 1;
-    uint16 num_items = static_cast<uint16>(items.size());
-
-    ser_var<uint32>(message, object_type);
-    ser_var<uint16>(message, num_items);
-
-    for (const Econ_Item &item : items) {
-        ser_var<uint64>(message, item.id);
-        ser_var<uint32>(message, steam_id.GetAccountID());
-        ser_var<uint16>(message, item.def);
-        ser_var<uint8>(message, item.level);
-        ser_var<uint8>(message, item.quality);
-        ser_var<uint32>(message, item.inv_pos);
-        ser_var<uint32>(message, item.quantity);
-
-        if (gc_version >= 20100428) {
-            // Strings are passed as UTF-8 which is good for us since we can just copy std::string as is.
-            ser_varstring(message, item.custom_name);
-
-            if (gc_version >= 20100930) {
-                ser_var<uint8>(message, item.flags);
-
-                if (gc_version >= 20101027) {
-                    ser_var<uint8>(message, item.origin);
-                    ser_varstring(message, item.custom_desc);
-                    ser_var<bool>(message, item.in_use);
-                }
-            }
-        }
-
-        ser_var<uint16>(message, static_cast<uint16>(item.attributes.size()));
-
-        for (const Econ_Item_Attribute &attr : item.attributes) {
-            ser_var<uint16>(message, attr.def);
-            ser_var<float>(message, attr.value);
-        }
-
-        if (gc_version >= 20101217) {
-            ser_var<uint64>(message, item.original_id);
-        }
-    }
-
-    push_incoming(msg_type, message);
-}
-
-void Steam_Game_Coordinator::on_item_pos_updated(CSteamID steam_id, const Econ_Item &item)
-{
-    if (!gc_initialized)
-        return;
-
-    // k_ESOMsg_Update
-    uint32 msg_type = 22;
-    std::string message = build_msg_header();
-
-    uint64 owner_id = steam_id.ConvertToUint64();
-    uint32 object_type = 1;
-    uint8 num_fields = 1;
-
-    ser_var<uint64>(message, owner_id);
-    ser_var<uint32>(message, object_type);
-    ser_var<uint64>(message, item.id);
-    ser_var<uint8>(message, num_fields);
-
-    uint8 field_idx = 5;
-    ser_var<uint8>(message, field_idx);
-    ser_var<uint32>(message, item.inv_pos);
-
-    if (gc_version >= 20101027) {
-        ser_var<bool>(message, item.in_use);
-    }
-
-    push_incoming(msg_type, message);
-}
-
-void Steam_Game_Coordinator::on_item_deleted(CSteamID steam_id, uint64 item_id)
-{
-    if (!gc_initialized)
-        return;
-
-    // k_ESOMsg_Destroy
-    uint32 msg_type = 23;
-    std::string message = build_msg_header();
-
-    uint64 owner_id = steam_id.ConvertToUint64();
-    uint32 object_type = 1;
-
-    ser_var<uint64>(message, owner_id);
-    ser_var<uint32>(message, object_type);
-    ser_var<uint64>(message, item_id);
-
-    push_incoming(msg_type, message);
-}
-
 // sends a message to the Game Coordinator
 EGCResults Steam_Game_Coordinator::SendMessage_( uint32 unMsgType, const void *pubData, uint32 cubData )
 {
@@ -664,21 +1100,33 @@ EGCResults Steam_Game_Coordinator::SendMessage_( uint32 unMsgType, const void *p
         return k_EGCResultOK;
 
     switch (unMsgType) {
-        case 1001:
+        case EGCItemMsg::k_EMsgGCSetSingleItemPosition:
             PRINT_DEBUG("k_EMsgGCSetSingleItemPosition");
             handle_set_item_pos(pubData, cubData);
             break;
-        case 1004:
+        case EGCItemMsg::k_EMsgGCDelete:
             PRINT_DEBUG("k_EMsgGCDelete");
             handle_delete_item(pubData, cubData);
             break;
-        case 1012:
+        case EGCItemMsg::k_EMsgGCMOTDRequest:
             PRINT_DEBUG("k_EMsgGCMOTDRequest");
             handle_motd_request(pubData, cubData);
             break;
-        case 1029:
+        case EGCItemMsg::k_EMsgGCRespawnPostLoadoutChange:
             PRINT_DEBUG("k_EMsgGCRespawnPostLoadoutChange");
             handle_respawn(pubData, cubData);
+            break;
+        case EGCItemMsg::k_EMsgGCSetItemStyle:
+            PRINT_DEBUG("k_EMsgGCSetItemStyle");
+            handle_set_item_style(pubData, cubData);
+            break;
+        case EGCItemMsg::k_EMsgGCAdjustItemEquippedState | protobuf_mask:
+            PRINT_DEBUG("k_EMsgGCAdjustItemEquippedState");
+            handle_adjust_equip_state(pubData, cubData);
+            break;
+        case EGCItemMsg::k_EMsgGCSetItemPositions | protobuf_mask:
+            PRINT_DEBUG("k_EMsgGCSetItemPositions");
+            handle_set_multiple_item_pos(pubData, cubData);
             break;
         default:
             break;
@@ -700,6 +1148,7 @@ bool Steam_Game_Coordinator::IsMessageAvailable( uint32 *pcubMsgSize )
 
     GC_Message &message = incoming_messages.front();
     *pcubMsgSize = static_cast<uint32>(message.msg_body.size());
+
     return true;
 }
 
@@ -724,11 +1173,16 @@ EGCResults Steam_Game_Coordinator::RetrieveMessage( uint32 *punMsgType, void *pu
         return k_EGCResultBufferTooSmall;
     }
 
+    if (is_welcome_message(message)) {
+        welcome_received = true;
+        welcome_time = std::chrono::high_resolution_clock::now();
+    }
+
     *punMsgType = message.msg_type;
     *pcubMsgSize = outsize;
     message.msg_body.copy(reinterpret_cast<char *>(pubDest), cubDest);
-
     incoming_messages.pop();
+
     return k_EGCResultOK;
 }
 
@@ -764,11 +1218,20 @@ void Steam_Game_Coordinator::network_callback_inventory_request(Common_Message *
         new_item->set_custom_name(item.custom_name);
         new_item->set_custom_desc(item.custom_desc);
         new_item->set_original_id(item.original_id);
+        new_item->set_in_use(item.in_use);
+        new_item->set_style(item.style);
 
-        for (const auto &attr : item.attributes) {
+        for (const auto &[class_id, slot_id] : item.equip_states) {
+            auto new_state = new_item->add_equip_states();
+            new_state->set_class_id(class_id);
+            new_state->set_slot_id(slot_id);
+        }
+
+        for (const Econ_Item_Attribute &attr : item.attributes) {
             auto new_attr = new_item->add_attributes();
             new_attr->set_def(attr.def);
             new_attr->set_value(attr.value);
+            new_attr->set_value_bytes(attr.value_bytes);
         }
     }
 
@@ -819,7 +1282,7 @@ void Steam_Game_Coordinator::network_callback_inventory_response(Common_Message 
     items.clear();
 
     for (const auto &item : response_msg.items()) {
-        Econ_Item new_item;
+        Econ_Item new_item{};
         new_item.id = item.id();
         new_item.def = item.def();
         new_item.level = item.level();
@@ -831,14 +1294,20 @@ void Steam_Game_Coordinator::network_callback_inventory_response(Common_Message 
         new_item.custom_name = item.custom_name();
         new_item.custom_desc = item.custom_desc();
         new_item.original_id = item.original_id();
-        new_item.in_use = false;
+        new_item.in_use = item.in_use();
+        new_item.style = item.style();
         if (new_item.id == 0)
             continue;
 
+        for (const auto &state : item.equip_states()) {
+            new_item.equip_states.insert({ state.class_id(), state.slot_id() });
+        }
+
         for (const auto &attr : item.attributes()) {
-            Econ_Item_Attribute new_attr;
+            Econ_Item_Attribute new_attr{};
             new_attr.def = attr.def();
             new_attr.value = attr.value();
+            new_attr.value_bytes = attr.value_bytes();
             if (new_attr.def == 0)
                 continue;
 
@@ -858,21 +1327,21 @@ void Steam_Game_Coordinator::network_callback_inventory_response(Common_Message 
     }
 
     if (is_gc) {
-        on_items_received(user_steamid, items);
+        callback_items_received(user_steamid, items);
     } else {
-        server_items()->on_items_received(user_steamid, items.size(), api_call, true);
+        server_items()->callback_items_received(user_steamid, items.size(), api_call, true);
     }
 
     PRINT_DEBUG("got player inventory: %u items", response_msg.items_size());
 }
 
-// user updated item inventory position
-void Steam_Game_Coordinator::network_callback_inventory_pos_update(Common_Message *msg)
+// user updated an item
+void Steam_Game_Coordinator::network_callback_item_update(Common_Message *msg)
 {
     uint64 user_steamid = msg->source_id();
 
-    PRINT_DEBUG("player updated item inventory position %llu", user_steamid);
-    if (!msg->gameserver_items_messages().has_inventory_pos_update()) {
+    PRINT_DEBUG("player updated an item %llu", user_steamid);
+    if (!msg->gameserver_items_messages().has_item_update()) {
         PRINT_DEBUG("error empty msg");
         return;
     }
@@ -883,9 +1352,8 @@ void Steam_Game_Coordinator::network_callback_inventory_pos_update(Common_Messag
     }
 
     bool is_gc = msg->gameserver_items_messages().is_gc();
-    const auto &inventory_msg = msg->gameserver_items_messages().inventory_pos_update();
-    uint64 item_id = inventory_msg.item_id();
-    uint32 item_inv_pos = inventory_msg.item_inv_pos();
+    const auto &inventory_msg = msg->gameserver_items_messages().item_update();
+    uint64 item_id = inventory_msg.id();
 
     auto &items = all_user_items.at(user_steamid);
 
@@ -893,15 +1361,30 @@ void Steam_Game_Coordinator::network_callback_inventory_pos_update(Common_Messag
         if (item.id != item_id)
             continue;
 
-        item.inv_pos = item_inv_pos;
-
-        if (is_gc) {
-            on_item_pos_updated(user_steamid, item);
-        } else {
-            server_items()->on_item_pos_updated(user_steamid, item_id, item_inv_pos);
+        if (inventory_msg.has_inv_pos()) {
+            item.inv_pos = inventory_msg.inv_pos();
+            PRINT_DEBUG("got updated item inventory pos: %llu 0x%08X", item_id, inventory_msg.inv_pos());
         }
 
-        PRINT_DEBUG("got updated item inventory position: %llu 0x%08X", item_id, item_inv_pos);
+        if (inventory_msg.has_style()) {
+            item.style = inventory_msg.style();
+            PRINT_DEBUG("got updated item style: %llu %u", item_id, inventory_msg.style());
+        }
+
+        if (inventory_msg.has_equip_states()) {
+            item.equip_states.clear();
+            for (const auto &state : inventory_msg.equip_states()) {
+                item.equip_states.insert({ state.class_id(), state.slot_id() });
+            }
+            PRINT_DEBUG("got updated item equip states: %llu", item_id);
+        }
+
+        if (is_gc) {
+            callback_item_updated(user_steamid, item);
+        } else if (inventory_msg.has_inv_pos()) {
+            server_items()->callback_item_pos_updated(user_steamid, item_id, inventory_msg.inv_pos());
+        }
+
         return;
     }
 
@@ -925,8 +1408,8 @@ void Steam_Game_Coordinator::network_callback_item_deletion(Common_Message *msg)
     }
 
     bool is_gc = msg->gameserver_items_messages().is_gc();
-    const auto &drop_msg = msg->gameserver_items_messages().item_deletion();
-    uint64 item_id = drop_msg.item_id();
+    const auto &delete_msg = msg->gameserver_items_messages().item_deletion();
+    uint64 item_id = delete_msg.item_id();
 
     auto &items = all_user_items.at(user_steamid);
 
@@ -937,9 +1420,9 @@ void Steam_Game_Coordinator::network_callback_item_deletion(Common_Message *msg)
         items.erase(it);
 
         if (is_gc) {
-            on_item_deleted(user_steamid, item_id);
+            callback_item_deleted(user_steamid, item_id);
         } else {
-            server_items()->on_item_deleted(user_steamid, item_id);
+            server_items()->callback_item_deleted(user_steamid, item_id);
         }
 
         PRINT_DEBUG("deleted player's inventory item: %llu", item_id);
@@ -952,19 +1435,14 @@ void Steam_Game_Coordinator::network_callback_item_deletion(Common_Message *msg)
 // user wants to respawn after loadout change
 void Steam_Game_Coordinator::network_callback_respawn_request(Common_Message *msg)
 {
-    if (!gc_initialized || !is_server)
+    if (!is_server)
         return;
 
     uint64 user_steamid = msg->source_id();
     if (!all_user_items.count(user_steamid))
         return;
 
-    // k_EMsgGCRespawnPostLoadoutChange
-    uint32 msg_type = 1029;
-    std::string message = build_msg_header();
-    ser_var<uint64>(message, user_steamid);
-
-    push_incoming(msg_type, message);
+    callback_respawn_request(user_steamid);
 }
 
 // only triggered when we have a message
@@ -984,9 +1462,9 @@ void Steam_Game_Coordinator::network_callback(Common_Message *msg)
             network_callback_inventory_response(msg);
         break;
 
-        // user updated item inventory position
-        case GameServer_Items_Messages::Request_UpdateInventoryPos:
-            network_callback_inventory_pos_update(msg);
+        // user updated an item
+        case GameServer_Items_Messages::Request_UpdateItem:
+            network_callback_item_update(msg);
         break;
 
         // user deleted an item
@@ -1005,18 +1483,21 @@ void Steam_Game_Coordinator::network_callback(Common_Message *msg)
         }
     } else if (msg->has_low_level()) {
         if (!is_server && gc_initialized) {
-            uint64 user_steamid = msg->source_id();
+            CSteamID user_steamid;
+            user_steamid.SetFromUint64(msg->source_id());
 
-            // Client needs to know other players' inventories as well since the game uses them to
-            // validate cosmetic items.
-            switch (msg->low_level().type()) {
-            case Low_Level::CONNECT:
-                request_user_items(user_steamid, generate_steam_api_call_id(), true);
-            break;
+            if (user_steamid.BIndividualAccount()) {
+                // Client needs to know other players' inventories as well since the game uses them to
+                // validate cosmetic items.
+                switch (msg->low_level().type()) {
+                case Low_Level::CONNECT:
+                    request_user_items(user_steamid, generate_steam_api_call_id(), true);
+                break;
 
-            case Low_Level::DISCONNECT:
-                remove_user_items(user_steamid);
-            break;
+                case Low_Level::DISCONNECT:
+                    remove_user_items(user_steamid);
+                break;
+                }
             }
         }
     }
@@ -1024,13 +1505,22 @@ void Steam_Game_Coordinator::network_callback(Common_Message *msg)
 
 void Steam_Game_Coordinator::RunCallbacks()
 {
+    if (delay_init && welcome_received && check_timedout(welcome_time, 0.2)) {
+        delay_init = false;
+    }
+
     for (auto it = pending_messages.begin(); it != pending_messages.end();) {
+        if (delay_init && !is_welcome_message(*it)) {
+            it++;
+            continue;
+        }
+
         if (check_timedout(it->created, it->post_in)) {
             incoming_messages.push(*it);
 
             GCMessageAvailable_t data{};
             data.m_nMessageSize = static_cast<uint32>(it->msg_body.size());
-            callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
+            callbacks->addCBResult(data.k_iCallback, &data, sizeof(data), 0.0);
 
             it = pending_messages.erase(it);
         } else {
@@ -1041,7 +1531,7 @@ void Steam_Game_Coordinator::RunCallbacks()
     for (auto it = pending_items_requests.begin(); it != pending_items_requests.end();) {
         if (check_timedout(it->created, 7.0)) {
             if (!it->is_gc) {
-                server_items()->on_items_received(it->steam_id, items.size(), it->steam_api_call, false);
+                server_items()->callback_items_received(it->steam_id, items.size(), it->steam_api_call, false);
             }
 
             PRINT_DEBUG("player inventory request timeout %llu", it->steam_id);

--- a/dll/steam_gameserver.cpp
+++ b/dll/steam_gameserver.cpp
@@ -70,7 +70,6 @@ bool Steam_GameServer::set_appid(int32 input_appid, const char *game_dir, bool a
     server_data.set_appid(appid);
     settings->set_game_id(CGameID(appid));
     network->setAppID(appid);
-    get_steam_client()->steam_gameserver_game_coordinator->initialize_gc();
 
     PRINT_DEBUG("set server appid to %u", appid);
     return true;
@@ -179,6 +178,8 @@ bool Steam_GameServer::InitGameServer( uint32 unIP, uint16 usGamePort, uint16 us
 
     if (!settings->disable_source_query)
         network->startQuery({ unIP, usQueryPort });
+
+    get_steam_client()->steam_gameserver_game_coordinator->initialize_gc();
 
     call_servers_connected = false;
     call_servers_disconnected = false;
@@ -290,12 +291,14 @@ void Steam_GameServer::LogOff()
 
         logged_in = false;
         settings->set_offline(true);
-
-        // Shutdown Source Query
-        network->shutDownQuery();
-        // And empty the queue if needed
-        outgoing_packets.clear();
     }
+
+    // Shutdown Source Query
+    network->shutDownQuery();
+    // And empty the queue if needed
+    outgoing_packets.clear();
+
+    get_steam_client()->steam_gameserver_game_coordinator->shutdown_gc();
 }
 
 
@@ -598,6 +601,8 @@ bool Steam_GameServer::BSetServerType( uint32 unServerFlags, uint32 unGameIP, ui
 
     if (!settings->disable_source_query && !network->isQueryAlive())
         network->startQuery({ unGameIP, usQueryPort });
+
+    get_steam_client()->steam_gameserver_game_coordinator->initialize_gc();
 
     return true;
 }

--- a/dll/steam_gameserver_items.cpp
+++ b/dll/steam_gameserver_items.cpp
@@ -34,7 +34,7 @@ Steam_GameServer_Items::~Steam_GameServer_Items()
 {
 }
 
-void Steam_GameServer_Items::on_items_received(CSteamID steam_id, size_t num_items, SteamAPICall_t api_call, bool success)
+void Steam_GameServer_Items::callback_items_received(CSteamID steam_id, size_t num_items, SteamAPICall_t api_call, bool success)
 {
     GSItemCount_t data{};
     data.m_OwnerID = steam_id;
@@ -49,7 +49,7 @@ void Steam_GameServer_Items::on_items_received(CSteamID steam_id, size_t num_ite
     callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
 }
 
-void Steam_GameServer_Items::on_item_pos_updated(CSteamID steam_id, uint64 item_id, uint32 inv_pos)
+void Steam_GameServer_Items::callback_item_pos_updated(CSteamID steam_id, uint64 item_id, uint32 inv_pos)
 {
     GSItemInventoryPosUpdated_t data{};
     data.m_SteamID = steam_id;
@@ -57,7 +57,7 @@ void Steam_GameServer_Items::on_item_pos_updated(CSteamID steam_id, uint64 item_
     callbacks->addCBResult(data.k_iCallback, &data, sizeof(data), 0.15);
 }
 
-void Steam_GameServer_Items::on_item_deleted(CSteamID steam_id, uint64 item_id)
+void Steam_GameServer_Items::callback_item_deleted(CSteamID steam_id, uint64 item_id)
 {
     GSItemDeleted_t data{};
     data.m_SteamID = steam_id;
@@ -181,7 +181,7 @@ bool Steam_GameServer_Items::GetItemAttribute( uint64 ulItemID, uint32 unAttribu
     PRINT_DEBUG("%llu %u", ulItemID, unAttributeIndex);
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
-    for (const auto &[steamID, items] : gc()->get_all_user_items()) {
+    for (const auto &[steam_id, items] : gc()->get_all_user_items()) {
         for (const Econ_Item &item : items) {
             if (item.id != ulItemID)
                 continue;

--- a/dll/steam_inventory.cpp
+++ b/dll/steam_inventory.cpp
@@ -165,7 +165,7 @@ bool Steam_Inventory::GetResultItems( SteamInventoryResult_t resultHandle,
                     pOutItemsArray->m_iDefinition = i->value("definition", static_cast<int32>(pOutItemsArray->m_itemId));
                     pOutItemsArray->m_unQuantity = i->value("quantity", static_cast<uint16>(1));
                 } catch (...) {
-                    pOutItemsArray->m_iDefinition = pOutItemsArray->m_itemId;
+                    pOutItemsArray->m_iDefinition = static_cast<int32>(pOutItemsArray->m_itemId);
                     pOutItemsArray->m_unQuantity = 1;
                 }
                 pOutItemsArray->m_unFlags = k_ESteamItemNoTrade;
@@ -181,7 +181,7 @@ bool Steam_Inventory::GetResultItems( SteamInventoryResult_t resultHandle,
                         pOutItemsArray->m_iDefinition = it->value("definition", static_cast<int32>(pOutItemsArray->m_itemId));
                         pOutItemsArray->m_unQuantity = it->value("quantity", static_cast<uint16>(1));
                     } catch (...) {
-                        pOutItemsArray->m_iDefinition = pOutItemsArray->m_itemId;
+                        pOutItemsArray->m_iDefinition = static_cast<int32>(pOutItemsArray->m_itemId);
                         pOutItemsArray->m_unQuantity = 1;
                     }
                     pOutItemsArray->m_unFlags = k_ESteamItemNoTrade;

--- a/post_build/steam_settings.EXAMPLE/gc.EXAMPLE.json
+++ b/post_build/steam_settings.EXAMPLE/gc.EXAMPLE.json
@@ -1,3 +1,4 @@
 {
+  "gc_profile": "tf2",
   "gc_version": 20091217
 }

--- a/premake5.lua
+++ b/premake5.lua
@@ -161,6 +161,7 @@ local function genproto()
     local protoc_exe = path.join(deps_dir, 'protobuf', deps_install_prefix, 'bin', 'protoc')
 
     local out_dir = 'proto_gen/' .. os_iden
+    local out_dir_tf2 = out_dir .. "/tf2"
 
     if os.target() == "windows" then
         protoc_exe = protoc_exe .. '.exe'
@@ -178,6 +179,12 @@ local function genproto()
         return
     end
 
+    local ok_mk, err_mk = os.mkdir(out_dir_tf2)
+    if not ok_mk then
+        error("Error: " .. err_mk)
+        return
+    end
+
     if os.target() == "linux" then
         local ok_chmod, err_chmod = os.chmod(protoc_exe, "777")
         if not ok_chmod then
@@ -190,6 +197,12 @@ local function genproto()
         protoc_exe = 'wine ' .. protoc_exe
     end
 
+    if not os.execute(protoc_exe .. ' dll/gc_steam/steammessages.proto -I./dll/gc_steam --cpp_out=' .. out_dir ) then
+        return
+    end
+    if not os.execute(protoc_exe .. ' dll/gc_tf2/*.proto -I./dll/gc_steam -I./dll/gc_tf2 --cpp_out=' .. out_dir_tf2 ) then
+        return
+    end
     return os.execute(protoc_exe .. ' dll/net.proto -I./dll/ --cpp_out=' .. out_dir)
 end
 
@@ -302,7 +315,7 @@ local deps_link = {
 }
 -- add protobuf libs
 table_append(deps_link, {
-    lib_prefix .. "protobuf-lite"                 .. static_postfix,
+    lib_prefix .. "protobuf"                      .. static_postfix,
     "absl_bad_any_cast_impl"                      .. static_postfix,
     "absl_bad_optional_access"                    .. static_postfix,
     "absl_bad_variant_access"                     .. static_postfix,


### PR DESCRIPTION
This further extends GC implementation, it should now work for Team Fortress 2 versions past Hatless Update as well as Portal 2. I've also added preliminary support for GC profiles as groundwork for potential CS:GO and Dota 2 support.

Currently, the only things that are implemented are static item properties and equipping/unequipping items. Nothing else works - anything that dynamically changes item properties (like Strange weapons), loadout presets, crafting, unboxing, matchmaking, etc.