### PR TITLE
SteamGameServer_Init old version, callback fix

### DIFF
--- a/dll/callsystem.cpp
+++ b/dll/callsystem.cpp
@@ -220,6 +220,11 @@ void SteamCallResults::setCbAll(void (*cb_all)(std::vector<char> result, int cal
     this->cb_all = cb_all;
 }
 
+void SteamCallResults::clear()
+{
+    callresults.clear();
+}
+
 void SteamCallResults::runCallResults()
 {
     unsigned long current_size = static_cast<unsigned long>(callresults.size());

--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -454,7 +454,7 @@ STEAMAPI_API void S_CALLTYPE SteamAPI_Shutdown()
         return;
     }
 
-    get_steam_client()->clientShutdown();
+    get_steam_client()->ReleaseUser(user_steam_pipe, CLIENT_HSTEAMUSER);
     get_steam_client()->BReleaseSteamPipe(user_steam_pipe);
     get_steam_client()->BShutdownIfAllPipesClosed();
 
@@ -1297,7 +1297,7 @@ STEAMAPI_API steam_bool S_CALLTYPE SteamAPI_ManualDispatch_GetNextCallback( HSte
 {
     PRINT_DEBUG("%i %p", hSteamPipe, pCallbackMsg);
     Steam_Client *steam_client = get_steam_client();
-    if (!steam_client->steamclient_server_inited) {
+    if (!steam_client->IsServerInit()) {
         while(!server_cb.empty()) server_cb.pop();
     }
 

--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -211,6 +211,15 @@ static void load_old_steam_interfaces()
     reset_LastError();
 }
 
+inline int get_old_interface_ver(const char *interface_name)
+{
+    size_t len = strlen(interface_name);
+    if (len < 3)
+        return 0;
+
+    return atoi(interface_name + (len - 3));
+}
+
 // declare "g_pSteamClientGameServer" as an export for API library, then actually define it
 #if !defined(STEAMCLIENT_DLL) // api
 STEAMAPI_API ISteamClient *g_pSteamClientGameServer;
@@ -227,11 +236,9 @@ Steam_Client *get_steam_client()
             load_old_steam_interfaces();
             steamclient_instance = new Steam_Client();
 
-            if (strstr(old_friends, "SteamFriends")) {
-                int friends_ver = atoi(old_friends + 12);
-                if (friends_ver != 0 && friends_ver <= 4) {
-                    steamclient_instance->using_old_callbacks = true;
-                }
+            int friends_ver = get_old_interface_ver(old_friends);
+            if (friends_ver != 0 && friends_ver <= 4) {
+                steamclient_instance->using_old_callbacks = true;
             }
         }
     }
@@ -966,31 +973,26 @@ STEAMAPI_API HSteamUser S_CALLTYPE SteamGameServer_GetHSteamUser()
     return SERVER_HSTEAMUSER;
 }
 
+static bool is_nosteam_server{};
+
 STEAMAPI_API ISteamClient *SteamGameServerClient();
 
-//SteamGameServer002 (very old, not in public SDKs):
+// 0.99u:
 //STEAMAPI_API steam_bool SteamGameServer_Init( uint32 unIP, uint16 usPort, uint16 usGamePort, EServerMode eServerMode, int nGameAppId, const char *pchGameDir, const char *pchVersionString );
-//SteamGameServer004 and before:
+// 0.99v-1.00:
 //STEAMAPI_API steam_bool SteamGameServer_Init( uint32 unIP, uint16 usPort, uint16 usGamePort, uint16 usSpectatorPort, uint16 usQueryPort, EServerMode eServerMode, int nGameAppId, const char *pchGameDir, const char *pchVersionString );
-//SteamGameServer010 and before:
+// 1.01-1.16:
 //STEAMAPI_API steam_bool SteamGameServer_Init( uint32 unIP, uint16 usPort, uint16 usGamePort, uint16 usSpectatorPort, uint16 usQueryPort, EServerMode eServerMode, const char *pchGameDir, const char *pchVersionString );
-//SteamGameServer014 and before:
+// 1.16x-1.50:
 //STEAMAPI_API steam_bool SteamGameServer_Init( uint32 unIP, uint16 usSteamPort, uint16 usGamePort, uint16 usQueryPort, EServerMode eServerMode, const char *pchVersionString );
-//SteamGameServer015 and later:
+// 1.51 and later:
 //STEAMAPI_API steam_bool SteamGameServer_Init( uint32 unIP, uint16 usGamePort, uint16 usQueryPort, EServerMode eServerMode, const char *pchVersionString );
 STEAMAPI_API steam_bool SteamGameServer_Init( void *a1, void *a2, void *a3, void *a4, void *a5, void *a6, void *a7, void *a8, void *a9 )
 {
     PRINT_DEBUG_ENTRY();
 
-    if (!strstr(old_gameserver, "SteamGameServer"))
-        return false;
-
-    int gameserver_version = atoi(old_gameserver + 15);
-    if (gameserver_version == 0)
-        return false;
-
     // call this first since it loads old interfaces
-    Steam_Client* client = get_steam_client();
+    Steam_Client *client = get_steam_client();
     if (!server_steam_pipe) {
         client->CreateLocalUser(&server_steam_pipe, k_EAccountTypeGameServer);
         sdk_lifetime_counters.update(true);
@@ -998,9 +1000,46 @@ STEAMAPI_API steam_bool SteamGameServer_Init( void *a1, void *a2, void *a3, void
         g_pSteamClientGameServer = SteamGameServerClient();
     }
 
+    is_nosteam_server = false;
+
+    int gameserver_version = get_old_interface_ver(old_gameserver);
+    int user_version = get_old_interface_ver(old_user);
+    bool has_ms_updater = (settings_old_interfaces().count(SettingsItf::MASTERSERVER_UPDATER) != 0);
+
+    if (gameserver_version < 2 || user_version < 4)
+        return false;
+
     bool ret = false;
 
-    if (gameserver_version <= 4) {
+    if (gameserver_version == 2 && !has_ms_updater) {
+        uint32 unIP;
+        uint16 usPort;
+        uint16 usGamePort;
+        EServerMode eServerMode;
+        int nGameAppId;
+        const char *pchGameDir;
+        const char *pchVersionString;
+
+        memcpy(&unIP, &a1, sizeof(unIP));
+        memcpy(&usPort, &a2, sizeof(usPort));
+        memcpy(&usGamePort, &a3, sizeof(usGamePort));
+        memcpy(&eServerMode, &a4, sizeof(eServerMode));
+        memcpy(&nGameAppId, &a5, sizeof(nGameAppId));
+        memcpy(&pchGameDir, &a6, sizeof(pchGameDir));
+        memcpy(&pchVersionString, &a7, sizeof(pchVersionString));
+
+        uint32 unFlags = 0;
+        if (eServerMode == eServerModeAuthenticationAndSecure) unFlags = k_unServerFlagSecure;
+        bool bLANMode = (eServerMode == eServerModeNoAuthentication);
+
+        if (!bLANMode) {
+            client->steam_gameserver->LogOnAnonymous();
+            ret = client->steam_gameserver->GSSetServerType(nGameAppId, unFlags, unIP, usGamePort, pchGameDir, pchVersionString);
+        } else {
+            is_nosteam_server = true;
+            ret = true;
+        }
+    } else if (gameserver_version <= 4) {
         uint32 unIP;
         uint16 usPort;
         uint16 usGamePort;
@@ -1026,7 +1065,12 @@ STEAMAPI_API steam_bool SteamGameServer_Init( void *a1, void *a2, void *a3, void
         else if (eServerMode == eServerModeNoAuthentication) unFlags = k_unServerFlagPrivate;
         bool bLANMode = (eServerMode == eServerModeNoAuthentication);
 
-        client->steam_gameserver->LogOnAnonymous();
+        if (user_version >= 6 || !bLANMode) {
+            client->steam_gameserver->LogOnAnonymous();
+        } else {
+            is_nosteam_server = true;
+        }
+
         ret = client->steam_gameserver->BSetServerType(nGameAppId, unFlags, unIP, usGamePort, usSpectatorPort, usQueryPort, pchGameDir, pchVersionString, bLANMode);
     } else if (gameserver_version <= 10) {
         uint32 unIP;
@@ -1088,23 +1132,29 @@ STEAMAPI_API steam_bool SteamGameServer_Init( void *a1, void *a2, void *a3, void
     return ret;
 }
 
-//See: SteamGameServer_Init
+// See SteamGameServer_Init
 //STEAMAPI_API steam_bool S_CALLTYPE SteamGameServer_InitSafe( uint32 unIP, uint16 usPort, uint16 usGamePort, uint16 usSpectatorPort, uint16 usQueryPort, EServerMode eServerMode, const char *pchGameDir, const char *pchVersionString )
 //STEAMAPI_API steam_bool S_CALLTYPE SteamGameServer_InitSafe( uint32 unIP, uint16 usSteamPort, uint16 usGamePort, uint16 usQueryPort, EServerMode eServerMode, const char *pchVersionString )
 STEAMAPI_API steam_bool S_CALLTYPE SteamGameServer_InitSafe( void *a1, void *a2, void *a3, void *a4, void *a5, void *a6, void *a7, void *a8 )
 {
     PRINT_DEBUG_ENTRY();
 
-    if (!strstr(old_gameserver, "SteamGameServer"))
-        return false;
+    // call this first since it loads old interfaces
+    Steam_Client *client = get_steam_client();
+    if (!server_steam_pipe) {
+        client->CreateLocalUser(&server_steam_pipe, k_EAccountTypeGameServer);
+        sdk_lifetime_counters.update(true);
+        //g_pSteamClientGameServer is only used in pre 1.37 (where the interface versions are not provided by the game)
+        g_pSteamClientGameServer = SteamGameServerClient();
+    }
 
-    int gameserver_version = atoi(old_gameserver + 15);
-    if (gameserver_version == 0)
+    int gameserver_version = get_old_interface_ver(old_gameserver);
+    if (gameserver_version < 5) // export didn't exist before 1.01
         return false;
 
     bool ret = false;
 
-    if (gameserver_version >= 5 && gameserver_version <= 10) { // export didn't exist before 1.01
+    if (gameserver_version <= 10) {
         ret = SteamGameServer_Init(a1, a2, a3, a4, a5, a6, a7, a8, 0);
     } else if (gameserver_version <= 12) { // export was removed in 1.37
         ret = SteamGameServer_Init(a1, a2, a3, a4, a5, a6, 0, 0, 0);
@@ -1193,7 +1243,7 @@ STEAMAPI_API void SteamGameServer_Shutdown()
 STEAMAPI_API void SteamGameServer_RunCallbacks()
 {
     // PRINT_DEBUG_ENTRY();
-    get_steam_client()->RunCallbacks(false, true);
+    get_steam_client()->RunCallbacks(false, !is_nosteam_server);
 }
 
 STEAMAPI_API steam_bool SteamGameServer_BSecure()

--- a/dll/dll/callsystem.h
+++ b/dll/dll/callsystem.h
@@ -87,6 +87,8 @@ public:
 
     void setCbAll(void (*cb_all)(std::vector<char> result, int callback));
 
+    void clear();
+
     void runCallResults();
 };
 

--- a/dll/dll/steam_client.h
+++ b/dll/dll/steam_client.h
@@ -183,8 +183,6 @@ public:
 
     PlaytimeCounter* playtime_counter{};
 
-    bool steamclient_server_inited{};
-
     bool gameserver_has_ipv6_functions{};
     int steamclient_version{};
     bool using_old_callbacks{};

--- a/dll/dll/steam_user.h
+++ b/dll/dll/steam_user.h
@@ -53,6 +53,7 @@ public ISteamUser
     class SteamCallBacks *callbacks{};
 	class SteamCallResults *callback_results{};
     Local_Storage *local_storage{};
+    bool is_server{};
 
 	std::string encrypted_app_ticket{};
 	Auth_Manager *auth_manager{};
@@ -69,7 +70,7 @@ public ISteamUser
     std::vector<std::pair<CSteamID, std::chrono::high_resolution_clock::time_point>> player_auths{};
 
 public:
-    Steam_User(Settings *settings, Local_Storage *local_storage, class Networking *network, class SteamCallResults *callback_results, class SteamCallBacks *callbacks);
+    Steam_User(Settings *settings, Local_Storage *local_storage, class Networking *network, class SteamCallResults *callback_results, class SteamCallBacks *callbacks, bool is_server);
     ~Steam_User();
 
     // returns the HSteamUser this interface represents

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -1743,6 +1743,7 @@ static bool try_parse_old_steam_interfaces_file(std::string interfaces_path)
         OLD_ITF_LINE("SteamUtils", SettingsItf::UTILS);
         OLD_ITF_LINE("STEAMUSERSTATS_INTERFACE_VERSION", SettingsItf::USER_STATS);
         OLD_ITF_LINE("STEAMAPPS_INTERFACE_VERSION", SettingsItf::APPS);
+        OLD_ITF_LINE("SteamApps", SettingsItf::APPS);
         OLD_ITF_LINE("SteamNetworking", SettingsItf::NETWORKING);
         OLD_ITF_LINE("STEAMREMOTESTORAGE_INTERFACE_VERSION", SettingsItf::REMOTE_STORAGE);
         OLD_ITF_LINE("STEAMSCREENSHOTS_INTERFACE_VERSION", SettingsItf::SCREENSHOTS);

--- a/dll/steam_client.cpp
+++ b/dll/steam_client.cpp
@@ -100,7 +100,7 @@ Steam_Client::Steam_Client()
     PRINT_DEBUG("init client");
     steam_overlay = new Steam_Overlay(settings_client, local_storage, callback_results_client, callbacks_client, run_every_runcb, network);
 
-    steam_user = new Steam_User(settings_client, local_storage, network, callback_results_client, callbacks_client);
+    steam_user = new Steam_User(settings_client, local_storage, network, callback_results_client, callbacks_client, false);
     steam_friends = new Steam_Friends(settings_client, local_storage, network, callback_results_client, callbacks_client, run_every_runcb, steam_overlay);
     steam_utils = new Steam_Utils(settings_client, callback_results_client, callbacks_client, steam_overlay);
     
@@ -143,7 +143,7 @@ Steam_Client::Steam_Client()
     PRINT_DEBUG("init gameserver");
 
     steam_gameserver = new Steam_GameServer(settings_server, network, callbacks_server);
-    steam_gameserver_user = new Steam_User(settings_server, local_storage, network, callback_results_server, callbacks_server);
+    steam_gameserver_user = new Steam_User(settings_server, local_storage, network, callback_results_server, callbacks_server, true);
     steam_gameserver_utils = new Steam_Utils(settings_server, callback_results_server, callbacks_server, steam_overlay);
     steam_gameserverstats = new Steam_GameServerStats(settings_server, network, callback_results_server, callbacks_server, run_every_runcb);
     steam_gameserver_networking = new Steam_Networking(settings_server, network, callbacks_server, run_every_runcb);

--- a/dll/steam_client.cpp
+++ b/dll/steam_client.cpp
@@ -257,12 +257,14 @@ Steam_Client::~Steam_Client()
 
 void Steam_Client::userLogIn()
 {
+    callback_results_client->clear();
     network->addListenId(settings_client->get_local_steam_id());
     user_logged_in = true;
 }
 
 void Steam_Client::serverInit()
 {
+    callback_results_server->clear();
     server_init = true;
 }
 
@@ -278,11 +280,13 @@ bool Steam_Client::IsUserLogIn()
 
 void Steam_Client::serverShutdown()
 {
+    callback_results_server->clear();
     server_init = false;
 }
 
 void Steam_Client::clientShutdown()
 {
+    callback_results_client->clear();
     user_logged_in = false;
 }
 
@@ -383,7 +387,6 @@ HSteamUser Steam_Client::CreateLocalUser( HSteamPipe *phSteamPipe, EAccountType 
     HSteamPipe pipe = CreateSteamPipe();
     if (phSteamPipe) *phSteamPipe = pipe;
     steam_pipes[pipe] = Steam_Pipe::SERVER;
-    steamclient_server_inited = true;
     return SERVER_HSTEAMUSER;
     //}
 }
@@ -1003,12 +1006,12 @@ void Steam_Client::RunCallbacks(bool runClientCB, bool runGameserverCB)
     // PRINT_DEBUG("steam_user *********");
     steam_gameserver_user->RunCallbacks();
 
-    if (runClientCB) {
+    if (runClientCB && IsUserLogIn()) {
         // PRINT_DEBUG("callback_results_client *********");
         callback_results_client->runCallResults();
     }
 
-    if (runGameserverCB) {
+    if (runGameserverCB && IsServerInit()) {
         // PRINT_DEBUG("callback_results_server *********");
         callback_results_server->runCallResults();
     }

--- a/dll/steam_client.cpp
+++ b/dll/steam_client.cpp
@@ -398,12 +398,18 @@ HSteamUser Steam_Client::CreateLocalUser( HSteamPipe *phSteamPipe )
 void Steam_Client::ReleaseUser( HSteamPipe hSteamPipe, HSteamUser hUser )
 {
     PRINT_DEBUG_ENTRY();
-    if (hUser == SERVER_HSTEAMUSER && steam_pipes.count(hSteamPipe)) {
+
+    if (!steam_pipes.count(hSteamPipe))
+        return;
+
+    if (hUser == SERVER_HSTEAMUSER) {
         if (steam_gameserver->BLoggedOn()) {
             steam_gameserver->LogOff();
         }
 
-        steamclient_server_inited = false;
+        serverShutdown();
+    } else if (hUser == CLIENT_HSTEAMUSER) {
+        clientShutdown();
     }
 }
 

--- a/dll/steam_gameserver.cpp
+++ b/dll/steam_gameserver.cpp
@@ -1071,7 +1071,17 @@ bool Steam_GameServer::GSSendSteam3UserConnect( CSteamID steamID, uint32 unIPPub
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
     CSteamID ticket_steam_id;
-    return SendUserConnectAndAuthenticate(unIPPublic, pvCookie, cubCookie, &ticket_steam_id);
+    Auth_Data ticket_data = auth_manager->validateTicket(pvCookie, cubCookie, steamID, &ticket_steam_id);
+    if (!ticket_data.id.IsValid())
+        return false;
+
+    // If this function gets called then SteamID was likely obtained from Steam.dll and won't match
+    // the client's Goldberg SteamID. So just ignore SteamID we got from auth ticket.
+    GSClientApprove_t data{};
+    data.m_SteamID = data.m_OwnerSteamID = steamID;
+    callbacks->addCBResult(data.k_iCallback, &data, sizeof(data), 0.1);
+    add_player(steamID);
+    return true;
 }
 
 bool Steam_GameServer::GSRemoveUserConnect( uint32 unUserID )

--- a/dll/steam_user.cpp
+++ b/dll/steam_user.cpp
@@ -94,10 +94,17 @@ ELogonState Steam_User::GetLogonState()
     PRINT_DEBUG_ENTRY();
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
-    if(settings->is_offline())
-        return (ELogonState)0;
-    else
-        return (ELogonState)4; // tested on real steam, undocumented return value
+    if (settings->is_offline()) {
+        if (call_logged_on) {
+            return k_ELogonStateLoggingOn;
+        } else if (call_logged_off) {
+            return k_ELogonStateLoggingOff;
+        } else {
+            return k_ELogonStateNotLoggedOn;
+        }
+    } else {
+        return k_ELogonStateLoggedOn;
+    }
 }
 
 bool Steam_User::BConnected()

--- a/dll/steam_user.cpp
+++ b/dll/steam_user.cpp
@@ -21,13 +21,14 @@
 #include "dll/base64.h"
 #include "dll/dll.h"
 
-Steam_User::Steam_User(Settings *settings, Local_Storage *local_storage, class Networking *network, class SteamCallResults *callback_results, class SteamCallBacks *callbacks)
+Steam_User::Steam_User(Settings *settings, Local_Storage *local_storage, class Networking *network, class SteamCallResults *callback_results, class SteamCallBacks *callbacks, bool is_server)
 {
     this->settings = settings;
     this->local_storage = local_storage;
     this->network = network;
     this->callbacks = callbacks;
     this->callback_results = callback_results;
+    this->is_server = is_server;
     
     auth_manager = new Auth_Manager(settings, network, callbacks);
     voicechat = new VoiceChat();
@@ -44,7 +45,7 @@ Steam_User::~Steam_User()
 HSteamUser Steam_User::GetHSteamUser()
 {
     PRINT_DEBUG_ENTRY();
-    return (settings == get_steam_client()->settings_server) ? SERVER_HSTEAMUSER : CLIENT_HSTEAMUSER;
+    return is_server ? SERVER_HSTEAMUSER : CLIENT_HSTEAMUSER;
 }
 
 void Steam_User::LogOn( CSteamID steamID )
@@ -56,7 +57,7 @@ void Steam_User::LogOn( CSteamID steamID )
     call_logged_off = false;
     logon_time = std::chrono::high_resolution_clock::now();
 
-    if (settings == get_steam_client()->settings_server) {
+    if (is_server) {
         get_steam_client()->steam_gameserver->LogOnAnonymous();
     }
 }
@@ -73,7 +74,7 @@ void Steam_User::LogOff()
     settings->set_offline(true);
     player_auths.clear();
 
-    if (settings == get_steam_client()->settings_server) {
+    if (is_server) {
         get_steam_client()->steam_gameserver->LogOff();
     }
 }
@@ -1010,7 +1011,7 @@ void Steam_User::Init( ICMCallback *cmcallback, ISteam2Auth *steam2auth )
 bool Steam_User::BGetCallback( int *piCallback, uint8 **ppubParam, int *unk )
 {
     PRINT_DEBUG_ENTRY();
-    HSteamUser user = (settings == get_steam_client()->settings_server) ? SERVER_HSTEAMUSER : CLIENT_HSTEAMUSER;
+    HSteamUser user = is_server ? SERVER_HSTEAMUSER : CLIENT_HSTEAMUSER;
     HSteamPipe pipe = get_steam_client()->get_pipe_for_user(user);
     if (!pipe)
         return false;
@@ -1027,7 +1028,7 @@ bool Steam_User::BGetCallback( int *piCallback, uint8 **ppubParam, int *unk )
 void Steam_User::FreeLastCallback()
 {
     PRINT_DEBUG_ENTRY();
-    HSteamUser user = (settings == get_steam_client()->settings_server) ? SERVER_HSTEAMUSER : CLIENT_HSTEAMUSER;
+    HSteamUser user = is_server ? SERVER_HSTEAMUSER : CLIENT_HSTEAMUSER;
     HSteamPipe pipe = get_steam_client()->get_pipe_for_user(user);
     if (!pipe)
         return;

--- a/tools/generate_interfaces/generate_interfaces.cpp
+++ b/tools/generate_interfaces/generate_interfaces.cpp
@@ -8,6 +8,7 @@
 // static char old_xxx[128] = ...
 const static std::vector<std::string> interface_patterns = {
     R"(STEAMAPPS_INTERFACE_VERSION\d+)",
+    R"(SteamApps\d+)",
     R"(STEAMAPPLIST_INTERFACE_VERSION\d+)",
     R"(STEAMAPPTICKET_INTERFACE_VERSION\d+)",
     R"(SteamClient\d+)",


### PR DESCRIPTION
Another round of fixes for game servers, key points:
- Implemented the oldest existing variant of `SteamGameServer_Init`, found in 2006 games.
- Oldest version of ISteamApps interface is called SteamApps001, so I've added support for that name to interface list generator.
- Fixed `Steam_User::GetLogonState` return values. 4 is not a valid enum value in any of Steam API versions that I've seen, so I assume this is a typo and it was actually meant to be 3.
- Callbacks are no longer processed if the associated user is not active, and callback queue is cleared when user is created/released. This should prevent pending callbacks from a previous listen server carrying over into the next one, which isn't supposed to happen since shutting down a server calls `ReleaseUser`.