### PR TITLE
Fixes for Source query handler

### DIFF
--- a/dll/dll/steam_gameserver.h
+++ b/dll/dll/steam_gameserver.h
@@ -79,6 +79,7 @@ public:
     Steam_GameServer(class Settings *settings, class Networking *network, class SteamCallBacks *callbacks);
     ~Steam_GameServer();
 
+    void set_protocol_version(unsigned short nProtocolVersion);
     std::vector<std::pair<CSteamID, Gameserver_Player_Info_t>>* get_players();
     void add_player(CSteamID steamID);
     void remove_player(CSteamID steamID);

--- a/dll/net.proto
+++ b/dll/net.proto
@@ -174,6 +174,8 @@ message Gameserver {
     uint32 port = 33;
     uint32 query_port = 34;
     uint32 appid = 35;
+    bytes version_name = 36;
+    uint32 protocol_version = 37;
 
     bool offline = 48;
     uint32 type = 49;

--- a/dll/source_query.cpp
+++ b/dll/source_query.cpp
@@ -152,11 +152,11 @@ std::vector<uint8_t> Source_Query::handle_source_query(const void* buffer, size_
 
             serialize_response(output_buffer, source_query_magic::simple);
             serialize_response(output_buffer, source_response_header::A2S_INFO);
-            serialize_response(output_buffer, static_cast<uint8_t>(2));
+            serialize_response(output_buffer, static_cast<uint8_t>(gs.protocol_version()));
             serialize_response(output_buffer, gs.server_name());
             serialize_response(output_buffer, gs.map_name());
             serialize_response(output_buffer, gs.mod_dir());
-            serialize_response(output_buffer, gs.product());
+            serialize_response(output_buffer, gs.game_description());
             serialize_response(output_buffer, static_cast<uint16_t>(gs.appid()));
             serialize_response(output_buffer, static_cast<uint8_t>(players.size()));
             serialize_response(output_buffer, static_cast<uint8_t>(gs.max_player_count()));
@@ -165,7 +165,7 @@ std::vector<uint8_t> Source_Query::handle_source_query(const void* buffer, size_
             serialize_response(output_buffer, my_server_env);
             serialize_response(output_buffer, (gs.password_protected() ? source_server_visibility::_private : source_server_visibility::_public));
             serialize_response(output_buffer, (gs.secure() ? source_server_vac::secured : source_server_vac::unsecured));
-            serialize_response(output_buffer, std::to_string(gs.version()));
+            serialize_response(output_buffer, gs.version_name());
 
             uint8_t flags = source_server_extra_flag::none;
 

--- a/dll/source_query.cpp
+++ b/dll/source_query.cpp
@@ -155,7 +155,7 @@ std::vector<uint8_t> Source_Query::handle_source_query(const void* buffer, size_
             serialize_response(output_buffer, static_cast<uint8_t>(2));
             serialize_response(output_buffer, gs.server_name());
             serialize_response(output_buffer, gs.map_name());
-            serialize_response(output_buffer, !gs.mod_dir().empty() ? gs.mod_dir() : gs.game_dir());
+            serialize_response(output_buffer, gs.mod_dir());
             serialize_response(output_buffer, gs.product());
             serialize_response(output_buffer, static_cast<uint16_t>(gs.appid()));
             serialize_response(output_buffer, static_cast<uint8_t>(players.size()));

--- a/dll/steam_gameserver.cpp
+++ b/dll/steam_gameserver.cpp
@@ -93,12 +93,13 @@ void Steam_GameServer::set_version(const char *pchVersionString)
     try {
         auto ver = std::stoul(version);
         server_data.set_version(ver);
+        server_data.set_version_name(pchVersionString);
         PRINT_DEBUG("set version to %lu", ver);
     } catch (...) {
         server_data.set_version(0);
+        server_data.set_version_name("");
         PRINT_DEBUG("not a number '%s'", pchVersionString);
     }
-
 }
 
 void Steam_GameServer::add_player(CSteamID steamID)
@@ -143,6 +144,10 @@ Steam_GameServer::~Steam_GameServer()
     auth_manager = nullptr;
 }
 
+void Steam_GameServer::set_protocol_version(unsigned short nProtocolVersion)
+{
+    server_data.set_protocol_version(nProtocolVersion);
+}
 
 std::vector<std::pair<CSteamID, Gameserver_Player_Info_t>>* Steam_GameServer::get_players()
 {
@@ -172,6 +177,12 @@ bool Steam_GameServer::InitGameServer( uint32 unIP, uint16 usGamePort, uint16 us
     set_appid(nGameAppId, "", false);
     set_version(pchVersionString);
     server_data.set_offline(false);
+    // Fixed versions sent by SteamGameServer011+. Actual steamclient.dll behavior.
+    if (nGameAppId < 200) {
+        server_data.set_protocol_version(48);
+    } else {
+        server_data.set_protocol_version(17);
+    }
 
     //TODO: flags should be k_unServerFlag
     flags = unFlags;

--- a/dll/steam_gameserver.cpp
+++ b/dll/steam_gameserver.cpp
@@ -586,7 +586,7 @@ bool Steam_GameServer::BSetServerType( uint32 unServerFlags, uint32 unGameIP, ui
     server_data.set_port(unGamePort);
     server_data.set_spectator_port(unSpectatorPort);
     server_data.set_query_port(usQueryPort);
-    server_data.set_game_dir(pchGameDir ? pchGameDir : "");
+    server_data.set_mod_dir(pchGameDir ? pchGameDir : "");
     set_version(pchVersion);
     server_data.set_offline(false);
 
@@ -1018,7 +1018,7 @@ bool Steam_GameServer::Obsolete_GSSetStatus( int32 nAppIdServed, uint32 unServer
     server_data.set_spectator_port(0);
     server_data.set_server_name(pchServerName);
     server_data.set_spectator_server_name(pchServerName);
-    server_data.set_game_dir(pchGameDir);
+    server_data.set_mod_dir(pchGameDir);
     server_data.set_map_name(pchMapName);
     set_version(pchVersion);
     server_data.set_offline(false);

--- a/dll/steam_masterserver_updater.cpp
+++ b/dll/steam_masterserver_updater.cpp
@@ -136,7 +136,8 @@ void Steam_Masterserver_Updater::SetBasicServerData(
 {
     PRINT_DEBUG_TODO();
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
-    
+
+    gameserver->set_protocol_version(nProtocolVersion);
     gameserver->SetDedicatedServer(bDedicatedServer);
     gameserver->SetRegion(pRegionName);
     gameserver->SetProduct(pProductName);

--- a/dll/steam_matchmaking_servers.cpp
+++ b/dll/steam_matchmaking_servers.cpp
@@ -637,7 +637,7 @@ void Steam_Matchmaking_Servers::server_details(Gameserver *g, gameserveritem_t *
                 PRINT_DEBUG("  ssq server info ok");
                 if (ssq_info_has_steamid(ssq_a2s_info)) g->set_id(ssq_a2s_info->steamid);
                 g->set_game_description(ssq_a2s_info->game);
-                g->set_game_dir(ssq_a2s_info->folder);
+                g->set_mod_dir(ssq_a2s_info->folder);
                 if (ssq_a2s_info->server_type == A2S_SERVER_TYPE_DEDICATED) g->set_dedicated_server(true);
                 else if (ssq_a2s_info->server_type == A2S_SERVER_TYPE_STV_RELAY) g->set_dedicated_server(true);
                 else g->set_dedicated_server(false);
@@ -694,11 +694,7 @@ void Steam_Matchmaking_Servers::server_details(Gameserver *g, gameserveritem_t *
     server->m_steamID = CSteamID((uint64)g->id());
     
     memset(server->m_szGameDir, 0, sizeof(server->m_szGameDir));
-    if (!g->mod_dir().empty()) {
-        g->mod_dir().copy(server->m_szGameDir, sizeof(server->m_szGameDir) - 1);
-    } else {
-        g->game_dir().copy(server->m_szGameDir, sizeof(server->m_szGameDir) - 1);
-    }
+    g->mod_dir().copy(server->m_szGameDir, sizeof(server->m_szGameDir) - 1);
 
     memset(server->m_szMap, 0, sizeof(server->m_szMap));
     g->map_name().copy(server->m_szMap, sizeof(server->m_szMap) - 1);
@@ -956,56 +952,57 @@ void Steam_Matchmaking_Servers::Callback(Common_Message *msg)
 {
     if (msg->has_gameserver() && msg->gameserver().type() != eFriendsServer) {
         PRINT_DEBUG("got SERVER " "%" PRIu64 ", offline:%u", msg->gameserver().id(), msg->gameserver().offline());
+
+        auto it = std::find_if(gameservers.begin(), gameservers.end(),
+            [msg](const Steam_Matchmaking_Servers_Gameserver &item) {
+                return (msg->gameserver().id() == item.server.id());
+            }
+        );
+
         if (msg->gameserver().offline()) {
-            for (auto &g : gameservers) {
-                if (g.server.id() == msg->gameserver().id()) {
-                    g.last_recv = std::chrono::high_resolution_clock::time_point();
-                    g.type = eLANServer;
-                }
+            if (it != gameservers.end()) {
+                it->last_recv = std::chrono::high_resolution_clock::time_point();
+                it->type = eLANServer;
             }
         } else {
-            bool already = false;
-            for (auto &g : gameservers) {
-                if (g.server.id() == msg->gameserver().id()) {
-                    g.last_recv = std::chrono::high_resolution_clock::now();
-                    g.server = msg->gameserver();
-                    g.server.set_ip(msg->source_ip());
-                    g.type = eLANServer;
-                    already = true;
-                }
-            }
-
-            if (!already) {
-                struct Steam_Matchmaking_Servers_Gameserver g{};
-                g.last_recv = std::chrono::high_resolution_clock::now();
-                g.server = msg->gameserver();
-                g.server.set_ip(msg->source_ip());
-                g.type = eLANServer;
-                gameservers.push_back(g);
+            if (it == gameservers.end()) {
+                it = gameservers.emplace(it);
                 PRINT_DEBUG("  eLANServer SERVER ADDED");
             }
+
+            it->last_recv = std::chrono::high_resolution_clock::now();
+            it->server = msg->gameserver();
+            it->server.set_ip(msg->source_ip());
+
+            // TODO: This is obsolete, remove game_dir field eventually.
+            if (it->server.mod_dir().empty()) {
+                it->server.set_mod_dir(it->server.game_dir());
+            }
+
+            it->type = eLANServer;
         }
+
+        return;
     }
 
     if (msg->has_gameserver() && msg->gameserver().type() == eFriendsServer) {
         PRINT_DEBUG("got eFriendsServer SERVER " "%" PRIu64 "", msg->gameserver().id());
-        bool addserver = true;
-        for (auto &g : gameservers_friends) {
-            if (g.source_id == msg->source_id()) {
-                g.ip = msg->gameserver().ip();
-                g.port = msg->gameserver().port();
-                g.last_recv = std::chrono::high_resolution_clock::now();
-                addserver = false;
+
+        auto it = std::find_if(gameservers_friends.begin(), gameservers_friends.end(),
+            [msg](const Steam_Matchmaking_Servers_Gameserver_Friends &item) {
+                return (msg->source_id() == item.source_id);
             }
+        );
+
+        if (it == gameservers_friends.end()) {
+            it = gameservers_friends.emplace(it);
+            it->source_id = msg->source_id();
         }
 
-        if (addserver) {
-            struct Steam_Matchmaking_Servers_Gameserver_Friends gameserver_friend;
-            gameserver_friend.source_id = msg->source_id();
-            gameserver_friend.ip = msg->gameserver().ip();
-            gameserver_friend.port = msg->gameserver().port();
-            gameserver_friend.last_recv = std::chrono::high_resolution_clock::now();
-            gameservers_friends.push_back(gameserver_friend);
-        }
+        it->ip = msg->gameserver().ip();
+        it->port = msg->gameserver().port();
+        it->last_recv = std::chrono::high_resolution_clock::now();
+
+        return;
     }
 }


### PR DESCRIPTION
- "Game dir" and "Mod dir" in game server info are in fact one and the same. So I've merged them into one. Old proto field number is still supported by Steam_Matchmaking_Servers, but it's deprecated and should be removed eventually.
- Adjusted some fields in Source query handler so its output is more accurate.