### PR TITLE
Fail if `SteamAPI_ManualDispatch_FreeLastCallback()` is not called before `SteamAPI_ManualDispatch_GetNextCallback()`

### DIFF
--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -1309,8 +1309,6 @@ static void cb_add_queue_client(std::vector<char> result, int callback)
     client_cb.push(cb);
 }
 
-static std::unordered_map<HSteamPipe, bool> got_last_callback;
-
 /// Inform the API that you wish to use manual event dispatch.  This must be called after SteamAPI_Init, but before
 /// you use any of the other manual dispatch functions below.
 STEAMAPI_API void S_CALLTYPE SteamAPI_ManualDispatch_Init()
@@ -1335,9 +1333,9 @@ STEAMAPI_API void S_CALLTYPE SteamAPI_ManualDispatch_RunFrame( HSteamPipe hSteam
         return;
     }
 
-    if (it->second == Steam_Pipe::SERVER) {
+    if (it->second.type == Steam_Pipe_Type::SERVER) {
         steam_client->RunCallbacks(false, true);
-    } else if (it->second == Steam_Pipe::CLIENT) {
+    } else if (it->second.type == Steam_Pipe_Type::CLIENT) {
         steam_client->RunCallbacks(true, false);
     }
 }
@@ -1348,15 +1346,6 @@ STEAMAPI_API void S_CALLTYPE SteamAPI_ManualDispatch_RunFrame( HSteamPipe hSteam
 STEAMAPI_API steam_bool S_CALLTYPE SteamAPI_ManualDispatch_GetNextCallback( HSteamPipe hSteamPipe, CallbackMsg_t *pCallbackMsg )
 {
     PRINT_DEBUG("%i %p", hSteamPipe, pCallbackMsg);
-
-    auto it_glcb = got_last_callback.find(hSteamPipe);
-    if (it_glcb != got_last_callback.end()) {
-        if (it_glcb->second) {
-            PRINT_DEBUG("last cb not freed on pipe %d!", hSteamPipe);
-            return false;
-        }
-    }
-
     Steam_Client *steam_client = get_steam_client();
     if (!steam_client->IsServerInit()) {
         while(!server_cb.empty()) server_cb.pop();
@@ -1370,10 +1359,16 @@ STEAMAPI_API steam_bool S_CALLTYPE SteamAPI_ManualDispatch_GetNextCallback( HSte
 
     std::queue<struct cb_data> *q = NULL;
     HSteamUser m_hSteamUser = 0;
-    if (it->second == Steam_Pipe::SERVER) {
+
+    if (it->second.got_last_cb) {
+        PRINT_DEBUG("last cb not freed on pipe %d!", hSteamPipe);
+        return false;
+    }
+
+    if (it->second.type == Steam_Pipe_Type::SERVER) {
         q = &server_cb;
         m_hSteamUser = SERVER_HSTEAMUSER;
-    } else if (it->second == Steam_Pipe::CLIENT) {
+    } else if (it->second.type == Steam_Pipe_Type::CLIENT) {
         q = &client_cb;
         m_hSteamUser = CLIENT_HSTEAMUSER;
     } else {
@@ -1392,7 +1387,7 @@ STEAMAPI_API steam_bool S_CALLTYPE SteamAPI_ManualDispatch_GetNextCallback( HSte
         pCallbackMsg->m_pubParam = (uint8 *)&(q->front().result[0]);
         pCallbackMsg->m_cubParam = static_cast<unsigned long>(q->front().result.size());
         PRINT_DEBUG("cb number %i", q->front().cb_id);
-        got_last_callback.insert_or_assign(hSteamPipe, true);
+        it->second.got_last_cb = true;
         return true;
     }
 
@@ -1411,9 +1406,9 @@ STEAMAPI_API void S_CALLTYPE SteamAPI_ManualDispatch_FreeLastCallback( HSteamPip
         return;
     }
 
-    if (it->second == Steam_Pipe::SERVER) {
+    if (it->second.type == Steam_Pipe_Type::SERVER) {
         q = &server_cb;
-    } else if (it->second == Steam_Pipe::CLIENT) {
+    } else if (it->second.type == Steam_Pipe_Type::CLIENT) {
         q = &client_cb;
     } else {
         return;
@@ -1421,10 +1416,7 @@ STEAMAPI_API void S_CALLTYPE SteamAPI_ManualDispatch_FreeLastCallback( HSteamPip
 
     if (!q->empty()) q->pop();
 
-    auto it_glcb = got_last_callback.find(hSteamPipe);
-    if (it_glcb != got_last_callback.end()) {
-        it_glcb->second = false;
-    }
+    it->second.got_last_cb = false;
 }
 
 /// Return the call result for the specified call on the specified pipe.  You really should
@@ -1437,9 +1429,9 @@ STEAMAPI_API steam_bool S_CALLTYPE SteamAPI_ManualDispatch_GetAPICallResult( HSt
         return false;
     }
 
-    if (steam_client->steam_pipes[hSteamPipe] == Steam_Pipe::SERVER) {
+    if (steam_client->steam_pipes[hSteamPipe].type == Steam_Pipe_Type::SERVER) {
         return steam_client->steam_gameserver_utils->GetAPICallResult(hSteamAPICall, pCallback, cubCallback, iCallbackExpected, pbFailed);
-    } else if (steam_client->steam_pipes[hSteamPipe] == Steam_Pipe::CLIENT) {
+    } else if (steam_client->steam_pipes[hSteamPipe].type == Steam_Pipe_Type::CLIENT) {
         return steam_client->steam_utils->GetAPICallResult(hSteamAPICall, pCallback, cubCallback, iCallbackExpected, pbFailed);
     } else {
         return false;

--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -1309,6 +1309,8 @@ static void cb_add_queue_client(std::vector<char> result, int callback)
     client_cb.push(cb);
 }
 
+static std::unordered_map<HSteamPipe, bool> got_last_callback;
+
 /// Inform the API that you wish to use manual event dispatch.  This must be called after SteamAPI_Init, but before
 /// you use any of the other manual dispatch functions below.
 STEAMAPI_API void S_CALLTYPE SteamAPI_ManualDispatch_Init()
@@ -1346,6 +1348,15 @@ STEAMAPI_API void S_CALLTYPE SteamAPI_ManualDispatch_RunFrame( HSteamPipe hSteam
 STEAMAPI_API steam_bool S_CALLTYPE SteamAPI_ManualDispatch_GetNextCallback( HSteamPipe hSteamPipe, CallbackMsg_t *pCallbackMsg )
 {
     PRINT_DEBUG("%i %p", hSteamPipe, pCallbackMsg);
+
+    auto it_glcb = got_last_callback.find(hSteamPipe);
+    if (it_glcb != got_last_callback.end()) {
+        if (it_glcb->second) {
+            PRINT_DEBUG("last cb not freed on pipe %d!", hSteamPipe);
+            return false;
+        }
+    }
+
     Steam_Client *steam_client = get_steam_client();
     if (!steam_client->IsServerInit()) {
         while(!server_cb.empty()) server_cb.pop();
@@ -1381,6 +1392,7 @@ STEAMAPI_API steam_bool S_CALLTYPE SteamAPI_ManualDispatch_GetNextCallback( HSte
         pCallbackMsg->m_pubParam = (uint8 *)&(q->front().result[0]);
         pCallbackMsg->m_cubParam = static_cast<unsigned long>(q->front().result.size());
         PRINT_DEBUG("cb number %i", q->front().cb_id);
+        got_last_callback.insert_or_assign(hSteamPipe, true);
         return true;
     }
 
@@ -1408,6 +1420,11 @@ STEAMAPI_API void S_CALLTYPE SteamAPI_ManualDispatch_FreeLastCallback( HSteamPip
     }
 
     if (!q->empty()) q->pop();
+
+    auto it_glcb = got_last_callback.find(hSteamPipe);
+    if (it_glcb != got_last_callback.end()) {
+        it_glcb->second = false;
+    }
 }
 
 /// Return the call result for the specified call on the specified pipe.  You really should

--- a/dll/dll/common_includes.h
+++ b/dll/dll/common_includes.h
@@ -48,6 +48,7 @@
 #include <set>
 #include <queue>
 #include <list>
+#include <unordered_map>
 
 #include <thread>
 #include <mutex>

--- a/dll/dll/steam_client.h
+++ b/dll/dll/steam_client.h
@@ -66,10 +66,15 @@
 #include "playtime.h"
 #include "callback_wrapper.h"
 
-enum Steam_Pipe {
+enum Steam_Pipe_Type {
     NO_USER,
     CLIENT,
     SERVER
+};
+
+struct Steam_Pipe {
+    Steam_Pipe_Type type{};
+    bool got_last_cb{};
 };
 
 class Steam_Client :
@@ -188,7 +193,7 @@ public:
     bool using_old_callbacks{};
     
     unsigned steam_pipe_counter = 1;
-    std::map<HSteamPipe, enum Steam_Pipe> steam_pipes{};
+    std::map<HSteamPipe, Steam_Pipe> steam_pipes{};
 
 
     Steam_Client();

--- a/dll/settings_parser_ufs.cpp
+++ b/dll/settings_parser_ufs.cpp
@@ -16,7 +16,6 @@
    <http://www.gnu.org/licenses/>.  */
 
 #include "dll/settings_parser_ufs.h"
-#include <unordered_map>
 #include <functional>
 
 

--- a/dll/steam_client.cpp
+++ b/dll/steam_client.cpp
@@ -321,7 +321,7 @@ HSteamPipe Steam_Client::CreateSteamPipe()
     ++steam_pipe_counter;
     PRINT_DEBUG("  returned pipe handle %i", pipe);
 
-    steam_pipes[pipe] = Steam_Pipe::NO_USER;
+    steam_pipes[pipe] = {Steam_Pipe_Type::NO_USER, false};
     
     return pipe;
 }
@@ -364,7 +364,7 @@ HSteamUser Steam_Client::ConnectToGlobalUser( HSteamPipe hSteamPipe )
 
     steam_overlay->SetupOverlay();
     
-    steam_pipes[hSteamPipe] = Steam_Pipe::CLIENT;
+    steam_pipes[hSteamPipe] = {Steam_Pipe_Type::CLIENT, false};
     return CLIENT_HSTEAMUSER;
 }
 
@@ -386,7 +386,7 @@ HSteamUser Steam_Client::CreateLocalUser( HSteamPipe *phSteamPipe, EAccountType 
 
     HSteamPipe pipe = CreateSteamPipe();
     if (phSteamPipe) *phSteamPipe = pipe;
-    steam_pipes[pipe] = Steam_Pipe::SERVER;
+    steam_pipes[pipe] = {Steam_Pipe_Type::SERVER, false};
     return SERVER_HSTEAMUSER;
     //}
 }
@@ -1120,8 +1120,8 @@ HSteamUser Steam_Client::CreateGlobalUser( HSteamPipe *phSteamPipe )
 {
     // TODO not sure if this implementation is correct
     PRINT_DEBUG_TODO();
-    for (const auto &[pipe_handle, pipe_type] : steam_pipes) {
-        if (pipe_type == Steam_Pipe::CLIENT) {
+    for (const auto &[pipe_handle, pipe_struct] : steam_pipes) {
+        if (pipe_struct.type == Steam_Pipe_Type::CLIENT) {
             if (phSteamPipe) *phSteamPipe = pipe_handle;
             return 0;
         }
@@ -1130,7 +1130,7 @@ HSteamUser Steam_Client::CreateGlobalUser( HSteamPipe *phSteamPipe )
     HSteamPipe pipe = CreateSteamPipe();
     if (phSteamPipe) *phSteamPipe = pipe;
 
-    steam_pipes[pipe] = Steam_Pipe::CLIENT;
+    steam_pipes[pipe] = {Steam_Pipe_Type::CLIENT, false};
     return CLIENT_HSTEAMUSER;
 }
 
@@ -1177,14 +1177,14 @@ void Steam_Client::SetEUniverse( EUniverse universe )
 HSteamPipe Steam_Client::get_pipe_for_user(HSteamUser hUser)
 {
     if (hUser == CLIENT_HSTEAMUSER) {
-        for (const auto &[pipe_handle, pipe_type] : steam_pipes) {
-            if (pipe_type == Steam_Pipe::CLIENT) {
+        for (const auto &[pipe_handle, pipe_struct] : steam_pipes) {
+            if (pipe_struct.type == Steam_Pipe_Type::CLIENT) {
                 return pipe_handle;
             }
         }
     } else if (hUser == SERVER_HSTEAMUSER) {
-        for (const auto &[pipe_handle, pipe_type] : steam_pipes) {
-            if (pipe_type == Steam_Pipe::SERVER) {
+        for (const auto &[pipe_handle, pipe_struct] : steam_pipes) {
+            if (pipe_struct.type == Steam_Pipe_Type::SERVER) {
                 return pipe_handle;
             }
         }

--- a/dll/steam_client_interface_getter.cpp
+++ b/dll/steam_client_interface_getter.cpp
@@ -79,7 +79,7 @@ ISteamGameStats *Steam_Client::GetISteamGameStats( HSteamUser hSteamUser, HSteam
 
     Steam_GameStats *steam_gamestats_tmp{};
 
-    if (steam_pipes[hSteamPipe] == Steam_Pipe::SERVER) {
+    if (steam_pipes[hSteamPipe].type == Steam_Pipe_Type::SERVER) {
         steam_gamestats_tmp = steam_gameserver_gamestats;
     } else {
         steam_gamestats_tmp = steam_gamestats;
@@ -111,7 +111,7 @@ ISteamUser *Steam_Client::GetISteamUser( HSteamUser hSteamUser, HSteamPipe hStea
 
     Steam_User *steam_user_tmp{};
 
-    if (steam_pipes[hSteamPipe] == Steam_Pipe::SERVER) {
+    if (steam_pipes[hSteamPipe].type == Steam_Pipe_Type::SERVER) {
         steam_user_tmp = steam_gameserver_user;
     } else {
         steam_user_tmp = steam_user;
@@ -276,7 +276,7 @@ ISteamUtils *Steam_Client::GetISteamUtils( HSteamPipe hSteamPipe, const char *pc
 
     Steam_Utils *steam_utils_temp{};
 
-    if (steam_pipes[hSteamPipe] == Steam_Pipe::SERVER) {
+    if (steam_pipes[hSteamPipe].type == Steam_Pipe_Type::SERVER) {
         steam_utils_temp = steam_gameserver_utils;
     } else {
         steam_utils_temp = steam_utils;
@@ -359,7 +359,7 @@ void *Steam_Client::GetISteamGenericInterface( HSteamUser hSteamUser, HSteamPipe
     if (!steam_pipes.count(hSteamPipe)) return NULL;
 
     bool server = false;
-    if (steam_pipes[hSteamPipe] == Steam_Pipe::SERVER) {
+    if (steam_pipes[hSteamPipe].type == Steam_Pipe_Type::SERVER) {
         // PRINT_DEBUG("requesting interface with server pipe");
         server = true;
     } else {
@@ -611,7 +611,7 @@ ISteamApps *Steam_Client::GetISteamApps( HSteamUser hSteamUser, HSteamPipe hStea
 
     Steam_Apps *steam_apps_temp{};
 
-    if (steam_pipes[hSteamPipe] == Steam_Pipe::SERVER) {
+    if (steam_pipes[hSteamPipe].type == Steam_Pipe_Type::SERVER) {
         steam_apps_temp = steam_gameserver_apps;
     } else {
         steam_apps_temp = steam_apps;
@@ -647,7 +647,7 @@ ISteamNetworking *Steam_Client::GetISteamNetworking( HSteamUser hSteamUser, HSte
 
     Steam_Networking *steam_networking_temp{};
 
-    if (steam_pipes[hSteamPipe] == Steam_Pipe::SERVER) {
+    if (steam_pipes[hSteamPipe].type == Steam_Pipe_Type::SERVER) {
         steam_networking_temp = steam_gameserver_networking;
     } else {
         steam_networking_temp = steam_networking;
@@ -738,7 +738,7 @@ ISteamHTTP *Steam_Client::GetISteamHTTP( HSteamUser hSteamuser, HSteamPipe hStea
     if (!steam_pipes.count(hSteamPipe) || !hSteamuser) return NULL;
     Steam_HTTP *steam_http_temp{};
 
-    if (steam_pipes[hSteamPipe] == Steam_Pipe::SERVER) {
+    if (steam_pipes[hSteamPipe].type == Steam_Pipe_Type::SERVER) {
         steam_http_temp = steam_gameserver_http;
     } else {
         steam_http_temp = steam_http;
@@ -816,7 +816,7 @@ ISteamUGC *Steam_Client::GetISteamUGC( HSteamUser hSteamUser, HSteamPipe hSteamP
     if (!steam_pipes.count(hSteamPipe) || !hSteamUser) return NULL;
     Steam_UGC *steam_ugc_temp{};
 
-    if (steam_pipes[hSteamPipe] == Steam_Pipe::SERVER) {
+    if (steam_pipes[hSteamPipe].type == Steam_Pipe_Type::SERVER) {
         steam_ugc_temp = steam_gameserver_ugc;
     } else {
         steam_ugc_temp = steam_ugc;
@@ -939,7 +939,7 @@ ISteamInventory *Steam_Client::GetISteamInventory( HSteamUser hSteamuser, HSteam
     if (!steam_pipes.count(hSteamPipe) || !hSteamuser) return NULL;
     Steam_Inventory *steam_inventory_temp{};
 
-    if (steam_pipes[hSteamPipe] == Steam_Pipe::SERVER) {
+    if (steam_pipes[hSteamPipe].type == Steam_Pipe_Type::SERVER) {
         steam_inventory_temp = steam_gameserver_inventory;
     } else {
         steam_inventory_temp = steam_inventory;

--- a/dll/steam_gamestats.cpp
+++ b/dll/steam_gamestats.cpp
@@ -22,7 +22,6 @@
 */
 
 #include "dll/steam_gamestats.h"
-#include <unordered_map>
 
 
 Steam_GameStats::Attribute_t::Attribute_t(AttributeType_t type)


### PR DESCRIPTION
Some games may do manual callback dispatch but forget to free the last callback before fetching next one, resulting the emu returning the same callback over and over again and eventually crashing the game. Real steam returns false when this case happens.
Hopefully this fixes #489.