### PR TITLE
Update pipe index handling + fix interface generator

### DIFF
--- a/dll/dll/steam_client.h
+++ b/dll/dll/steam_client.h
@@ -192,7 +192,8 @@ public:
     int steamclient_version{};
     bool using_old_callbacks{};
     
-    unsigned steam_pipe_counter = 1;
+    uint32 steam_pipe_counter = 1;
+    std::priority_queue<uint32, std::vector<uint32>, std::greater<>> freed_steam_pipes{};
     std::map<HSteamPipe, Steam_Pipe> steam_pipes{};
 
 

--- a/dll/dll/steam_client.h
+++ b/dll/dll/steam_client.h
@@ -200,141 +200,141 @@ public:
     ~Steam_Client();
 
     // Creates a communication pipe to the Steam client.
-	// NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
-	HSteamPipe CreateSteamPipe();
+    // NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
+    HSteamPipe CreateSteamPipe();
 
-	// Releases a previously created communications pipe
-	// NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
-	bool BReleaseSteamPipe( HSteamPipe hSteamPipe );
+    // Releases a previously created communications pipe
+    // NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
+    bool BReleaseSteamPipe( HSteamPipe hSteamPipe );
 
-	// connects to an existing global user, failing if none exists
-	// used by the game to coordinate with the steamUI
-	// NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
-	HSteamUser ConnectToGlobalUser( HSteamPipe hSteamPipe );
+    // connects to an existing global user, failing if none exists
+    // used by the game to coordinate with the steamUI
+    // NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
+    HSteamUser ConnectToGlobalUser( HSteamPipe hSteamPipe );
 
-	// used by game servers, create a steam user that won't be shared with anyone else
-	// NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
-	HSteamUser CreateLocalUser( HSteamPipe *phSteamPipe, EAccountType eAccountType );
+    // used by game servers, create a steam user that won't be shared with anyone else
+    // NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
+    HSteamUser CreateLocalUser( HSteamPipe *phSteamPipe, EAccountType eAccountType );
     HSteamUser CreateLocalUser( HSteamPipe *phSteamPipe );
 
-	// removes an allocated user
-	// NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
-	void ReleaseUser( HSteamPipe hSteamPipe, HSteamUser hUser );
+    // removes an allocated user
+    // NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
+    void ReleaseUser( HSteamPipe hSteamPipe, HSteamUser hUser );
 
-	// retrieves the ISteamUser interface associated with the handle
-	ISteamUser *GetISteamUser( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // retrieves the ISteamUser interface associated with the handle
+    ISteamUser *GetISteamUser( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// retrieves the ISteamGameServer interface associated with the handle
-	ISteamGameServer *GetISteamGameServer( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // retrieves the ISteamGameServer interface associated with the handle
+    ISteamGameServer *GetISteamGameServer( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// set the local IP and Port to bind to
-	// this must be set before CreateLocalUser()
-	void SetLocalIPBinding( uint32 unIP, uint16 usPort ); 
+    // set the local IP and Port to bind to
+    // this must be set before CreateLocalUser()
+    void SetLocalIPBinding( uint32 unIP, uint16 usPort ); 
     void SetLocalIPBinding( const SteamIPAddress_t &unIP, uint16 usPort );
 
-	// returns the ISteamFriends interface
-	ISteamFriends *GetISteamFriends( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // returns the ISteamFriends interface
+    ISteamFriends *GetISteamFriends( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// returns the ISteamUtils interface
-	ISteamUtils *GetISteamUtils( HSteamPipe hSteamPipe, const char *pchVersion );
+    // returns the ISteamUtils interface
+    ISteamUtils *GetISteamUtils( HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// returns the ISteamMatchmaking interface
-	ISteamMatchmaking *GetISteamMatchmaking( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // returns the ISteamMatchmaking interface
+    ISteamMatchmaking *GetISteamMatchmaking( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// returns the ISteamMatchmakingServers interface
-	ISteamMatchmakingServers *GetISteamMatchmakingServers( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // returns the ISteamMatchmakingServers interface
+    ISteamMatchmakingServers *GetISteamMatchmakingServers( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// returns the a generic interface
-	void *GetISteamGenericInterface( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // returns the a generic interface
+    void *GetISteamGenericInterface( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// returns the ISteamUserStats interface
-	ISteamUserStats *GetISteamUserStats( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // returns the ISteamUserStats interface
+    ISteamUserStats *GetISteamUserStats( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// returns the ISteamGameServerStats interface
-	ISteamGameServerStats *GetISteamGameServerStats( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // returns the ISteamGameServerStats interface
+    ISteamGameServerStats *GetISteamGameServerStats( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// returns apps interface
-	ISteamApps *GetISteamApps( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // returns apps interface
+    ISteamApps *GetISteamApps( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// networking
-	ISteamNetworking *GetISteamNetworking( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // networking
+    ISteamNetworking *GetISteamNetworking( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// remote storage
-	ISteamRemoteStorage *GetISteamRemoteStorage( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // remote storage
+    ISteamRemoteStorage *GetISteamRemoteStorage( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// user screenshots
-	ISteamScreenshots *GetISteamScreenshots( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // user screenshots
+    ISteamScreenshots *GetISteamScreenshots( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// game stats
-	ISteamGameStats *GetISteamGameStats( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // game stats
+    ISteamGameStats *GetISteamGameStats( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// steam timeline
-	ISteamTimeline *GetISteamTimeline( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // steam timeline
+    ISteamTimeline *GetISteamTimeline( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// steam app disable update
-	ISteamAppDisableUpdate *GetISteamAppDisableUpdate( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // steam app disable update
+    ISteamAppDisableUpdate *GetISteamAppDisableUpdate( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
 
     // steam billing
     ISteamBilling *GetISteamBilling( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// Deprecated. Applications should use SteamAPI_RunCallbacks() or SteamGameServer_RunCallbacks() instead.
-	STEAM_PRIVATE_API( void RunFrame() );
+    // Deprecated. Applications should use SteamAPI_RunCallbacks() or SteamGameServer_RunCallbacks() instead.
+    STEAM_PRIVATE_API( void RunFrame() );
 
-	// returns the number of IPC calls made since the last time this function was called
-	// Used for perf debugging so you can understand how many IPC calls your game makes per frame
-	// Every IPC call is at minimum a thread context switch if not a process one so you want to rate
-	// control how often you do them.
-	uint32 GetIPCCallCount();
+    // returns the number of IPC calls made since the last time this function was called
+    // Used for perf debugging so you can understand how many IPC calls your game makes per frame
+    // Every IPC call is at minimum a thread context switch if not a process one so you want to rate
+    // control how often you do them.
+    uint32 GetIPCCallCount();
 
-	// API warning handling
-	// 'int' is the severity; 0 for msg, 1 for warning
-	// 'const char *' is the text of the message
-	// callbacks will occur directly after the API function is called that generated the warning or message.
-	void SetWarningMessageHook( SteamAPIWarningMessageHook_t pFunction );
+    // API warning handling
+    // 'int' is the severity; 0 for msg, 1 for warning
+    // 'const char *' is the text of the message
+    // callbacks will occur directly after the API function is called that generated the warning or message.
+    void SetWarningMessageHook( SteamAPIWarningMessageHook_t pFunction );
 
-	// Trigger global shutdown for the DLL
-	bool BShutdownIfAllPipesClosed();
+    // Trigger global shutdown for the DLL
+    bool BShutdownIfAllPipesClosed();
 
-	// Expose HTTP interface
-	ISteamHTTP *GetISteamHTTP( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // Expose HTTP interface
+    ISteamHTTP *GetISteamHTTP( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// Deprecated - the ISteamUnifiedMessages interface is no longer intended for public consumption.
-	STEAM_PRIVATE_API( void *DEPRECATED_GetISteamUnifiedMessages( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) ; )
+    // Deprecated - the ISteamUnifiedMessages interface is no longer intended for public consumption.
+    STEAM_PRIVATE_API( void *DEPRECATED_GetISteamUnifiedMessages( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) ; )
     ISteamUnifiedMessages *GetISteamUnifiedMessages( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// Exposes the ISteamController interface
-	ISteamController *GetISteamController( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // Exposes the ISteamController interface
+    ISteamController *GetISteamController( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// Exposes the ISteamUGC interface
-	ISteamUGC *GetISteamUGC( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // Exposes the ISteamUGC interface
+    ISteamUGC *GetISteamUGC( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// returns app list interface, only available on specially registered apps
-	ISteamAppList *GetISteamAppList( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
-	
-	// Music Player
-	ISteamMusic *GetISteamMusic( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // returns app list interface, only available on specially registered apps
+    ISteamAppList *GetISteamAppList( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );
+    
+    // Music Player
+    ISteamMusic *GetISteamMusic( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// Music Player Remote
-	ISteamMusicRemote *GetISteamMusicRemote(HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion);
+    // Music Player Remote
+    ISteamMusicRemote *GetISteamMusicRemote(HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion);
 
-	// html page display
-	ISteamHTMLSurface *GetISteamHTMLSurface(HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion);
+    // html page display
+    ISteamHTMLSurface *GetISteamHTMLSurface(HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion);
 
-	// Helper functions for internal Steam usage
-	STEAM_PRIVATE_API( void DEPRECATED_Set_SteamAPI_CPostAPIResultInProcess( void (*)() ); )
-	STEAM_PRIVATE_API( void DEPRECATED_Remove_SteamAPI_CPostAPIResultInProcess( void (*)() ); )
-	STEAM_PRIVATE_API( void Set_SteamAPI_CCheckCallbackRegisteredInProcess( SteamAPI_CheckCallbackRegistered_t func ); )
+    // Helper functions for internal Steam usage
+    STEAM_PRIVATE_API( void DEPRECATED_Set_SteamAPI_CPostAPIResultInProcess( void (*)() ); )
+    STEAM_PRIVATE_API( void DEPRECATED_Remove_SteamAPI_CPostAPIResultInProcess( void (*)() ); )
+    STEAM_PRIVATE_API( void Set_SteamAPI_CCheckCallbackRegisteredInProcess( SteamAPI_CheckCallbackRegistered_t func ); )
     void Set_SteamAPI_CPostAPIResultInProcess( SteamAPI_PostAPIResultInProcess_t func );
     void Remove_SteamAPI_CPostAPIResultInProcess( SteamAPI_PostAPIResultInProcess_t func );
 
-	// inventory
-	ISteamInventory *GetISteamInventory( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // inventory
+    ISteamInventory *GetISteamInventory( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// Video
-	ISteamVideo *GetISteamVideo( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // Video
+    ISteamVideo *GetISteamVideo( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion );
 
-	// Parental controls
-	ISteamParentalSettings *GetISteamParentalSettings( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion );
+    // Parental controls
+    ISteamParentalSettings *GetISteamParentalSettings( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion );
 
     //
     ISteamMasterServerUpdater *GetISteamMasterServerUpdater( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion );

--- a/dll/steam_client.cpp
+++ b/dll/steam_client.cpp
@@ -311,18 +311,25 @@ void Steam_Client::setAppID(uint32 appid)
     
 }
 
-    // Creates a communication pipe to the Steam client.
+// Creates a communication pipe to the Steam client.
 // NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
 HSteamPipe Steam_Client::CreateSteamPipe()
 {
     PRINT_DEBUG_ENTRY();
-    if (!steam_pipe_counter) ++steam_pipe_counter;
-    HSteamPipe pipe = steam_pipe_counter;
-    ++steam_pipe_counter;
-    PRINT_DEBUG("  returned pipe handle %i", pipe);
 
-    steam_pipes[pipe] = {Steam_Pipe_Type::NO_USER, false};
-    
+    HSteamPipe pipe{};
+    if (!freed_steam_pipes.empty()) {
+        pipe = freed_steam_pipes.top();
+        freed_steam_pipes.pop();
+    } else {
+        if (!steam_pipe_counter) ++steam_pipe_counter;
+        pipe = steam_pipe_counter;
+        ++steam_pipe_counter;
+    }
+
+    PRINT_DEBUG("  returned pipe handle %i", pipe);
+    steam_pipes[pipe] = { Steam_Pipe_Type::NO_USER, false };
+
     return pipe;
 }
 
@@ -334,6 +341,7 @@ bool Steam_Client::BReleaseSteamPipe( HSteamPipe hSteamPipe )
 {
     PRINT_DEBUG("%i", hSteamPipe);
     if (steam_pipes.count(hSteamPipe)) {
+        freed_steam_pipes.push(hSteamPipe);
         return steam_pipes.erase(hSteamPipe) > 0;
     }
 

--- a/dll/steam_client_interface_getter.cpp
+++ b/dll/steam_client_interface_getter.cpp
@@ -96,18 +96,7 @@ ISteamGameStats *Steam_Client::GetISteamGameStats( HSteamUser hSteamUser, HSteam
 ISteamUser *Steam_Client::GetISteamUser( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion )
 {
     PRINT_DEBUG("%s", pchVersion);
-    
-    if (!hSteamUser) {
-        return NULL;
-    }
-    if (!steam_pipes.count(hSteamPipe)) {
-        // Fallback for steamclient_experimental build: if pipe 1 is requested but not found,
-        // and we have other valid pipes, continue execution instead of returning NULL
-        if (hSteamPipe !=1 || steam_pipes.empty()) {
-            return NULL;
-        }
-    }
-
+    if (!steam_pipes.count(hSteamPipe) || !hSteamUser) return nullptr;
 
     Steam_User *steam_user_tmp{};
 

--- a/tools/generate_interfaces/generate_interfaces.cpp
+++ b/tools/generate_interfaces/generate_interfaces.cpp
@@ -62,7 +62,7 @@ const static std::vector<std::string> interface_patterns = {
     R"(SteamMasterServerUpdater\d+)", 
 };
 
-unsigned int findinterface(
+size_t findinterface(
     std::ofstream &out_file,
     const std::string &file_contents,
     const std::string &interface_patt)
@@ -72,15 +72,32 @@ unsigned int findinterface(
     auto begin = std::sregex_iterator(file_contents.cbegin(), file_contents.cend(), interface_regex);
     auto end = std::sregex_iterator();
 
-    unsigned int matches = 0;
-
+    std::vector<std::string> matches;
     for (std::sregex_iterator i = begin; i != end; ++i)
     {
-        out_file << i->str() << std::endl;
-        ++matches;
+        matches.push_back(i->str());
     }
 
-    return matches;
+    if (interface_patt == R"(SteamClient\d+)" &&
+        matches.size() > 1 &&
+        std::find(matches.begin(), matches.end(), "SteamClient017") != matches.end())
+    {
+        // In newer SDKs, legacy steam_api.dll interface exports were removed except for SteamClient(),
+        // which still returns SteamClient017.
+        auto rm = std::remove_if(matches.begin(), matches.end(), [](const std::string &item)
+            {
+                return (item != "SteamClient017");
+            }
+        );
+        matches.erase(rm, matches.end());
+    }
+
+    for (const std::string &match : matches)
+    {
+        out_file << match << std::endl;
+    }
+
+    return matches.size();
 }
 
 int main(int argc, char *argv[])
@@ -115,7 +132,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    unsigned int total_matches = 0;
+    size_t total_matches = 0;
 
     for (const auto &patt : interface_patterns)
     {


### PR DESCRIPTION
Real steamclient.dll stores pipes in CUtlLinkedList so it essentially returns the first free number starting from 1 as pipe handle (0 is taken up by the internal pipe Steam itself uses). Goldberg, on the other hand, returns an always incrementing number. E.g. if one were to call `ISteamClient::CreateSteamPipe` and `ISteamClient::BReleaseSteamPipe` a bunch of times, real Steam would always return 1 whereas Goldberg would return incrementing numbers.

This would normally be fine but some steam_api.dll versions have a bug where they pass pipe handle as user handle when requesting one of the interfaces. This bug usually doesn't break anything - if the game just calls `SteamAPI_Init` at startup, both pipe handle and user handle will be 1 on Steam and Goldberg. Problems arise, however, if the game then calls `SteamAPI_Shutdown` and then `SteamAPI_Init` again. Real Steam will still return 1 and 1, but Goldberg will return 2 and 1 so the aforementioned bug will cause `SteamAPI_Init` to fail. This happens with Half-Life (when changing video settings) and possibly Doom: The Dark Ages.

In this PR, I have made it so Goldberg emulates real Steam behavior. I have also reverted the workaround from https://github.com/Detanup01/gbe_fork/pull/293 since it's most likely no longer needed but I need confirmation that Doom: The Dark Ages works with this PR. I'd test it myself but it has Denuvo and I don't own this game.

Another change I've made is update interface list generator to properly handle modern steam_api.dll. In 1.37 SDK, Valve removed all interface C exports except for `SteamClient` which is fixed to return SteamClient017. Because it still calls up the latest SteamClient version internally, this confuses the generator and makes it list SteamClient twice. I've added special handling for this case so that it only lists SteamClient017.