### PR TITLE
Fix SteamNetworkingSockets lane propagation and SendMessages path

### DIFF
--- a/dll/net.proto
+++ b/dll/net.proto
@@ -126,6 +126,7 @@ message Networking_Sockets {
     uint64 connection_id_from = 4;
     bytes data = 5;
     uint64 message_number = 7;
+    uint32 lane = 8;
 }
 
 message Networking_Messages {

--- a/dll/steam_networking_sockets.cpp
+++ b/dll/steam_networking_sockets.cpp
@@ -54,6 +54,7 @@ SteamNetworkingMessage_t* Steam_Networking_Sockets::get_steam_message_connection
     pMsg->m_pfnFreeData = &free_steam_message_data;
     pMsg->m_pfnRelease = &delete_steam_message;
     pMsg->m_nChannel = 0;
+    pMsg->m_idxLane = static_cast<uint16>(connect_socket->second.data.top().lane());
     connect_socket->second.data.pop();
     PRINT_DEBUG("get_steam_message_connection %u %lu, %llu", hConn, size, pMsg->m_nMessageNumber);
     return pMsg;
@@ -758,6 +759,7 @@ EResult Steam_Networking_Sockets::SendMessageToConnection( HSteamNetConnection h
     msg.mutable_networking_sockets()->set_connection_id_from(connect_socket->first);
     msg.mutable_networking_sockets()->set_connection_id(connect_socket->second.remote_id);
     msg.mutable_networking_sockets()->set_data(pData, cbData);
+    msg.mutable_networking_sockets()->set_lane(0);
     uint64 message_number = connect_socket->second.packet_send_counter;
     msg.mutable_networking_sockets()->set_message_number(message_number);
     connect_socket->second.packet_send_counter += 1;
@@ -816,7 +818,44 @@ void Steam_Networking_Sockets::SendMessages( int nMessages, SteamNetworkingMessa
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
     for (int i = 0; i < nMessages; ++i) {
         int64 out_number = 0;
-        int result = SendMessageToConnection(pMessages[i]->m_conn, pMessages[i]->m_pData, pMessages[i]->m_cbSize, pMessages[i]->m_nFlags, &out_number);
+        int result = k_EResultInvalidParam;
+
+        if (pMessages[i]) {
+            auto connect_socket = sbcs->connect_sockets.find(pMessages[i]->m_conn);
+            if (connect_socket == sbcs->connect_sockets.end()) {
+                result = k_EResultInvalidParam;
+            } else if (connect_socket->second.status == CONNECT_SOCKET_CLOSED || connect_socket->second.status == CONNECT_SOCKET_TIMEDOUT) {
+                result = k_EResultNoConnection;
+            } else if (connect_socket->second.status != CONNECT_SOCKET_CONNECTED && connect_socket->second.status != CONNECT_SOCKET_CONNECTING) {
+                result = k_EResultInvalidState;
+            } else {
+                Common_Message msg;
+                msg.set_source_id(connect_socket->second.created_by.ConvertToUint64());
+                msg.set_dest_id(connect_socket->second.remote_identity.GetSteamID64());
+                msg.set_allocated_networking_sockets(new Networking_Sockets);
+                msg.mutable_networking_sockets()->set_type(Networking_Sockets::DATA);
+                msg.mutable_networking_sockets()->set_virtual_port(connect_socket->second.virtual_port);
+                msg.mutable_networking_sockets()->set_real_port(connect_socket->second.real_port);
+                msg.mutable_networking_sockets()->set_connection_id_from(connect_socket->first);
+                msg.mutable_networking_sockets()->set_connection_id(connect_socket->second.remote_id);
+                msg.mutable_networking_sockets()->set_data(pMessages[i]->m_pData, pMessages[i]->m_cbSize);
+                msg.mutable_networking_sockets()->set_lane(pMessages[i]->m_idxLane);
+
+                uint64 message_number = connect_socket->second.packet_send_counter;
+                msg.mutable_networking_sockets()->set_message_number(message_number);
+                connect_socket->second.packet_send_counter += 1;
+
+                bool reliable = false;
+                if (pMessages[i]->m_nFlags & k_nSteamNetworkingSend_Reliable) reliable = true;
+                if (network->sendTo(&msg, reliable)) {
+                    out_number = message_number;
+                    result = k_EResultOK;
+                } else {
+                    result = k_EResultFail;
+                }
+            }
+        }
+
         if (pOutMessageNumberOrResult) {
             if (result == k_EResultOK) {
                 pOutMessageNumberOrResult[i] = out_number;


### PR DESCRIPTION
## What this fixes

Closes #238, closes #401

---

Both of those issues trace back to Enshrouded's use of `SteamNetworkingSockets` after their May 2025 Steam API update. The game calls `ConfigureConnectionLanes` and then sends traffic tagged with a lane index, expecting the remote side to receive messages with the correct `m_idxLane` populated. Without that, the host's packet header validation fails immediately ("Packet from 0 is smaller than the header"), the session never establishes, and players time out.

There were also a couple of gaps in `SendMessages` — the fast-path used by the game for bulk sends — that meant messages could silently drop or return wrong error codes.

### Changes

**`dll/net.proto`**
- Added `lane` field (field 8) to `Networking_Sockets` message so lane information survives the wire hop between instances.

**`dll/steam_networking_sockets.cpp`**
- `get_steam_message_connection`: populate `m_idxLane` on received messages from the value carried in the proto, so the receiving game sees the correct lane.
- `SendMessageToConnection`: set lane to 0 on the outgoing proto (safe default, keeps the field populated for the reader).
- `SendMessages`: previously just delegated straight to `SendMessageToConnection` in a one-liner, which threw away the `m_idxLane` from the caller's `SteamNetworkingMessage_t`. Rewrote the inner loop to build the proto directly and copy `m_idxLane` from the message, matching what `SendMessageToConnection` does but preserving the per-message lane. Also added the same connection-state guards (`CONNECT_SOCKET_CLOSED`, `CONNECT_SOCKET_TIMEDOUT`, etc.) that the single-message path already had, so error codes are consistent.

### Testing notes

Tested against Enshrouded (build post May 13 2025) in a two-instance LAN setup. With these changes both instances reach an established `SteamNetworkingSockets` session and the "Packet from 0 is smaller than the header" error no longer appears.
