### PR TITLE
Fix lobby join callback flow and improve lobby discovery synchronization

### DIFF
--- a/dll/dll/network.h
+++ b/dll/dll/network.h
@@ -144,6 +144,8 @@ public:
     void addListenId(CSteamID id);
     void setAppID(uint32 appid);
     void Run();
+    void sendAnnounceBroadcastsNow();
+    bool hasConnectedIndividualAccounts();
 
     // send to a specific user, set_dest_id() must be called
     bool sendTo(Common_Message *msg, bool reliable, Connection *conn = NULL);

--- a/dll/dll/steam_matchmaking.h
+++ b/dll/dll/steam_matchmaking.h
@@ -86,6 +86,7 @@ public ISteamMatchmaking
     std::chrono::high_resolution_clock::time_point lobby_last_search{};
     SteamAPICall_t search_call_api_id{};
     bool searching{};
+    bool search_waiting_for_initial_sync{};
 
     std::vector<struct Chat_Entry> chat_entries{};
     std::vector<struct Data_Requested> data_requested{};
@@ -99,7 +100,8 @@ public ISteamMatchmaking
     static bool leave_lobby(Lobby *lobby, CSteamID id);
 
     Lobby *get_lobby(CSteamID id);
-    void send_lobby_data();
+    void send_lobby(Lobby const& lobby, CSteamID dest_id);
+    void send_lobby_data(CSteamID dest_id = k_steamIDNil);
 
     void trigger_lobby_dataupdate(CSteamID lobby, CSteamID member, bool success, double cb_timeout=0.005, bool send_changed_lobby=true);
     void trigger_lobby_member_join_leave(CSteamID lobby, CSteamID member, bool leaving, bool success, double cb_timeout=0.0);

--- a/dll/dll/steam_networking_utils.h
+++ b/dll/dll/steam_networking_utils.h
@@ -36,6 +36,9 @@ public ISteamNetworkingUtils
     FSteamNetworkingSocketsDebugOutput debug_function{};
     bool relay_initialized = false;
     bool init_relay = true; //  Initializing relay immediately when we ask for it. Fixing Elden Ring SeamlessCoop
+    static FnSteamNetConnectionStatusChanged connection_status_changed_callback;
+    static FnSteamNetAuthenticationStatusChanged auth_status_changed_callback;
+    static FnSteamRelayNetworkStatusChanged relay_network_status_changed_callback;
     // NOTE from Detanup01: They should call InitializeRelayAccess BTW. Whoever write that mod cannot read valve docs.
     /*
     Valve docs:
@@ -56,6 +59,10 @@ public ISteamNetworkingUtils
 public:
     Steam_Networking_Utils(class Settings *settings, class Networking *network, class SteamCallResults *callback_results, class SteamCallBacks *callbacks, class RunEveryRunCB *run_every_runcb);
     ~Steam_Networking_Utils();
+
+    static void InvokeConnectionStatusChanged(SteamNetConnectionStatusChangedCallback_t *data);
+    static void InvokeAuthStatusChanged(SteamNetAuthenticationStatus_t *data);
+    static void InvokeRelayNetworkStatusChanged(SteamRelayNetworkStatus_t *data);
 
     /// Allocate and initialize a message object.  Usually the reason
     /// you call this is to pass it to ISteamNetworkingSockets::SendMessages.

--- a/dll/net.proto
+++ b/dll/net.proto
@@ -62,6 +62,7 @@ message Lobby_Messages {
         CHANGE_OWNER = 2;
         MEMBER_DATA = 3;
         CHAT_MESSAGE = 4;
+        DATA_REQUEST = 5;
     }
 
     Types type = 2;

--- a/dll/network.cpp
+++ b/dll/network.cpp
@@ -1157,6 +1157,28 @@ void Networking::setAppID(uint32 appid)
     this->appid = appid;
 }
 
+void Networking::sendAnnounceBroadcastsNow()
+{
+    send_announce_broadcasts();
+}
+
+bool Networking::hasConnectedIndividualAccounts()
+{
+    std::lock_guard<std::recursive_mutex> lock(mutex);
+
+    for (auto const &conn : connections) {
+        if (!conn.connected) continue;
+
+        for (auto const &steam_id : conn.ids) {
+            if (steam_id.BIndividualAccount()) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 bool Networking::sendToIPPort(Common_Message *msg, uint32 ip, uint16 port, bool reliable)
 {
     bool is_local_ip = ((ip >> 24) == 0x7F);

--- a/dll/steam_matchmaking.cpp
+++ b/dll/steam_matchmaking.cpp
@@ -28,6 +28,7 @@
 #define FILTER_MAX_DEFAULT 4096
 
 #define LOBBY_SEARCH_TIMEOUT 0.2 //Tested on real steam
+#define LOBBY_SEARCH_CONNECT_TIMEOUT 0.75
 
 
 google::protobuf::Map<std::string,std::string>::const_iterator Steam_Matchmaking::caseinsensitive_find(const ::google::protobuf::Map< ::std::string, ::std::string >& map, std::string key)
@@ -55,7 +56,20 @@ Lobby* Steam_Matchmaking::get_lobby(CSteamID id)
     return &(*lobby);
 }
 
-void Steam_Matchmaking::send_lobby_data()
+void Steam_Matchmaking::send_lobby(Lobby const& lobby, CSteamID dest_id)
+{
+    Common_Message msg = Common_Message();
+    msg.set_source_id(settings->get_local_steam_id().ConvertToUint64());
+    msg.set_allocated_lobby(new Lobby(lobby));
+    if (dest_id.IsValid()) {
+        msg.set_dest_id(dest_id.ConvertToUint64());
+        network->sendTo(&msg, true);
+    } else {
+        network->sendToAllIndividuals(&msg, true);
+    }
+}
+
+void Steam_Matchmaking::send_lobby_data(CSteamID dest_id)
 {
     if (lobbies.size()) {
         PRINT_DEBUG("lobbies %zu", lobbies.size());
@@ -64,10 +78,7 @@ void Steam_Matchmaking::send_lobby_data()
     for(auto & l: lobbies) {
         if (get_lobby_member(&l, settings->get_local_steam_id()) && l.owner() == settings->get_local_steam_id().ConvertToUint64() && !l.deleted()) {
             PRINT_DEBUG("lobby " "%" PRIu64 "", l.room_id());
-            Common_Message msg = Common_Message();
-            msg.set_source_id(settings->get_local_steam_id().ConvertToUint64());
-            msg.set_allocated_lobby(new Lobby(l));
-            network->sendToAllIndividuals(&msg, true);
+            send_lobby(l, dest_id);
         }
     }
 }
@@ -479,6 +490,11 @@ SteamAPICall_t Steam_Matchmaking::RequestLobbyList()
     filter_max_results_copy = filter_max_results;
     filter_values.clear();
     filter_max_results = FILTER_MAX_DEFAULT;
+    // Give discovery a chance to receive the first announce burst.
+    search_waiting_for_initial_sync = !network->hasConnectedIndividualAccounts();
+    if (search_waiting_for_initial_sync) {
+        network->sendAnnounceBroadcastsNow();
+    }
     searching = true;
     if (search_call_api_id) callback_results->rmCallBack(search_call_api_id, NULL);
     search_call_api_id = callback_results->reserveCallResult();
@@ -1043,10 +1059,34 @@ bool Steam_Matchmaking::RequestLobbyData( CSteamID steamIDLobby )
     PRINT_DEBUG("%llu", steamIDLobby.ConvertToUint64());
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
-    struct Data_Requested requested{};
-    requested.lobby_id = steamIDLobby;
-    requested.requested = std::chrono::high_resolution_clock::now();
-    data_requested.push_back(requested);
+    if (get_lobby(steamIDLobby)) {
+        trigger_lobby_dataupdate(steamIDLobby, steamIDLobby, true);
+        return true;
+    }
+
+    auto existing_request = std::find_if(data_requested.begin(), data_requested.end(), [&steamIDLobby](Data_Requested const& item) {
+        return item.lobby_id == steamIDLobby;
+    });
+    if (existing_request != data_requested.end()) {
+        existing_request->requested = std::chrono::high_resolution_clock::now();
+    } else {
+        struct Data_Requested requested{};
+        requested.lobby_id = steamIDLobby;
+        requested.requested = std::chrono::high_resolution_clock::now();
+        data_requested.push_back(requested);
+    }
+
+    if (!network->hasConnectedIndividualAccounts()) {
+        network->sendAnnounceBroadcastsNow();
+    }
+
+    Lobby_Messages *message = new Lobby_Messages();
+    message->set_type(Lobby_Messages::DATA_REQUEST);
+    Common_Message msg{};
+    msg.set_allocated_lobby_messages(message);
+    msg.set_source_id(settings->get_local_steam_id().ConvertToUint64());
+    msg.mutable_lobby_messages()->set_id(steamIDLobby.ConvertToUint64());
+    network->sendToAllIndividuals(&msg, true);
     return true;
 }
 
@@ -1474,17 +1514,25 @@ void Steam_Matchmaking::RunCallbacks()
                 callback_results->addCallResult(search_call_api_id, data.k_iCallback, &data, sizeof(data));
                 callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
                 search_call_api_id = 0;
+                search_waiting_for_initial_sync = false;
             }
         }
     }
 
-    if (searching && check_timedout(lobby_last_search, LOBBY_SEARCH_TIMEOUT)) {
+    double lobby_search_timeout = LOBBY_SEARCH_TIMEOUT;
+    if (search_waiting_for_initial_sync && filtered_lobbies.empty()) {
+        // Allow one longer search window while the first peer connection comes up.
+        lobby_search_timeout = LOBBY_SEARCH_CONNECT_TIMEOUT;
+    }
+
+    if (searching && check_timedout(lobby_last_search, lobby_search_timeout)) {
         PRINT_DEBUG("LOBBY_SEARCH_TIMEOUT %zu", filtered_lobbies.size());
         LobbyMatchList_t data{};
         data.m_nLobbiesMatching = static_cast<uint32>(filtered_lobbies.size());
         callback_results->addCallResult(search_call_api_id, data.k_iCallback, &data, sizeof(data));
         callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
         searching = false;
+        search_waiting_for_initial_sync = false;
         search_call_api_id = 0;
     }
 
@@ -1560,6 +1608,7 @@ void Steam_Matchmaking::Callback(Common_Message *msg)
     if (msg->has_lobby()) {
         PRINT_DEBUG("GOT A LOBBY appid: %u " "%" PRIu64 "", msg->lobby().appid(), msg->lobby().owner());
         if (msg->lobby().owner() != settings->get_local_steam_id().ConvertToUint64() && msg->lobby().appid() == settings->get_local_game_id().AppID()) {
+            search_waiting_for_initial_sync = false;
             Lobby *lobby = get_lobby((uint64)msg->lobby().room_id());
             if (!lobby) {
                 size_t old_size = lobbies.size();
@@ -1712,12 +1761,22 @@ void Steam_Matchmaking::Callback(Common_Message *msg)
                     }
                 }
             }
+
+            if (msg->lobby_messages().type() == Lobby_Messages::DATA_REQUEST) {
+                PRINT_DEBUG("LOBBY MESSAGE: DATA REQUEST");
+                if (lobby->owner() == settings->get_local_steam_id().ConvertToUint64()) {
+                    // Only the owner answers targeted lobby data requests.
+                    send_lobby(*lobby, (uint64)msg->source_id());
+                }
+            }
         }
     }
 
     if (msg->has_low_level()) {
         if (msg->low_level().type() == Low_Level::CONNECT) {
-            
+            if (msg->source_id() != settings->get_local_steam_id().ConvertToUint64()) {
+                send_lobby_data((uint64)msg->source_id());
+            }
         }
 
         if (msg->low_level().type() == Low_Level::DISCONNECT) {

--- a/dll/steam_networking_sockets.cpp
+++ b/dll/steam_networking_sockets.cpp
@@ -16,6 +16,7 @@
    <http://www.gnu.org/licenses/>.  */
 
 #include "dll/steam_networking_sockets.h"
+#include "dll/steam_networking_utils.h"
 
 
 void Steam_Networking_Sockets::steam_callback(void *object, Common_Message *msg)
@@ -231,6 +232,8 @@ void Steam_Networking_Sockets::launch_callback(HSteamNetConnection m_hConn, enum
     data.m_eOldState = convert_status(old_status);
     set_steamnetconnectioninfo(connect_socket, &data.m_info);
     callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
+    // Also deliver the callback through the global config hook.
+    Steam_Networking_Utils::InvokeConnectionStatusChanged(&data);
 }
 
 
@@ -364,7 +367,11 @@ HSteamNetConnection Steam_Networking_Sockets::ConnectByIPAddress( const SteamNet
     SteamNetworkingIdentity ip_id;
     ip_id.SetIPAddr(address);
     HSteamNetConnection socket = new_connect_socket(ip_id, SNS_DISABLED_PORT, address.m_port);
-    send_packet_new_connection(socket);
+    if (socket != k_HSteamNetConnection_Invalid) {
+        send_packet_new_connection(socket);
+        // Mirror the initial connection state transition immediately.
+        launch_callback(socket, CONNECT_SOCKET_NO_CONNECTION);
+    }
     return socket;
 }
 
@@ -375,7 +382,11 @@ HSteamNetConnection Steam_Networking_Sockets::ConnectByIPAddress( const SteamNet
     SteamNetworkingIdentity ip_id;
     ip_id.SetIPAddr(*address);
     HSteamNetConnection socket = new_connect_socket(ip_id, SNS_DISABLED_PORT, address->m_port);
-    send_packet_new_connection(socket);
+    if (socket != k_HSteamNetConnection_Invalid) {
+        send_packet_new_connection(socket);
+        // Mirror the initial connection state transition immediately.
+        launch_callback(socket, CONNECT_SOCKET_NO_CONNECTION);
+    }
     return socket;
 }
 
@@ -386,7 +397,11 @@ HSteamNetConnection Steam_Networking_Sockets::ConnectByIPAddress( const SteamNet
     SteamNetworkingIdentity ip_id;
     ip_id.SetIPAddr(address);
     HSteamNetConnection socket = new_connect_socket(ip_id, SNS_DISABLED_PORT, address.m_port);
-    send_packet_new_connection(socket);
+    if (socket != k_HSteamNetConnection_Invalid) {
+        send_packet_new_connection(socket);
+        // Mirror the initial connection state transition immediately.
+        launch_callback(socket, CONNECT_SOCKET_NO_CONNECTION);
+    }
     return socket;
 }
 
@@ -444,7 +459,11 @@ HSteamNetConnection Steam_Networking_Sockets::ConnectP2P( const SteamNetworkingI
     }
 
     HSteamNetConnection socket = new_connect_socket(identityRemote, nVirtualPort, SNS_DISABLED_PORT);
-    send_packet_new_connection(socket);
+    if (socket != k_HSteamNetConnection_Invalid) {
+        send_packet_new_connection(socket);
+        // Mirror the initial connection state transition immediately.
+        launch_callback(socket, CONNECT_SOCKET_NO_CONNECTION);
+    }
     return socket;
 }
 
@@ -1312,6 +1331,8 @@ ESteamNetworkingAvailability Steam_Networking_Sockets::InitAuthentication()
     data.m_eAvail = k_ESteamNetworkingAvailability_Current;
     memcpy(data.m_debugMsg, "OK", 3);
     callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
+    // Also deliver the callback through the global config hook.
+    Steam_Networking_Utils::InvokeAuthStatusChanged(&data);
     return k_ESteamNetworkingAvailability_Current;
 }
 
@@ -2083,7 +2104,6 @@ void Steam_Networking_Sockets::RunCallbacks()
 {
     // PRINT_DEBUG_ENTRY();
 
-    //TODO: timeout unaccepted connections after a few seconds or so
     auto current_time = std::chrono::steady_clock::now();
     auto socket_conn = std::begin(sbcs->connect_sockets);
     while (socket_conn != std::end(sbcs->connect_sockets)) {
@@ -2091,6 +2111,11 @@ void Steam_Networking_Sockets::RunCallbacks()
             send_packet_new_connection(socket_conn->first);
             socket_conn->second.connect_request_last_sent = current_time;
             socket_conn->second.connect_requests_sent += 1;
+        } else if (socket_conn->second.connect_requests_sent >= 10 && socket_conn->second.status == CONNECT_SOCKET_CONNECTING && (std::chrono::duration_cast<std::chrono::milliseconds>(current_time - socket_conn->second.connect_request_last_sent).count() > 3000)) {
+            // Stop retrying once the pending connect request has timed out locally.
+            enum connect_socket_status old_status = socket_conn->second.status;
+            socket_conn->second.status = CONNECT_SOCKET_TIMEDOUT;
+            launch_callback(socket_conn->first, old_status);
         }
 
         ++socket_conn;

--- a/dll/steam_networking_utils.cpp
+++ b/dll/steam_networking_utils.cpp
@@ -17,6 +17,10 @@
 
 #include "dll/steam_networking_utils.h"
 
+FnSteamNetConnectionStatusChanged Steam_Networking_Utils::connection_status_changed_callback = nullptr;
+FnSteamNetAuthenticationStatusChanged Steam_Networking_Utils::auth_status_changed_callback = nullptr;
+FnSteamRelayNetworkStatusChanged Steam_Networking_Utils::relay_network_status_changed_callback = nullptr;
+
 void Steam_Networking_Utils::steam_callback(void *object, Common_Message *msg)
 {
     // PRINT_DEBUG_ENTRY();
@@ -49,6 +53,30 @@ Steam_Networking_Utils::~Steam_Networking_Utils()
 {
     this->network->rmCallback(CALLBACK_ID_USER_STATUS, settings->get_local_steam_id(), &Steam_Networking_Utils::steam_callback, this);
     this->run_every_runcb->remove(&Steam_Networking_Utils::steam_run_every_runcb, this);
+}
+
+void Steam_Networking_Utils::InvokeConnectionStatusChanged(SteamNetConnectionStatusChangedCallback_t *data)
+{
+    auto callback = connection_status_changed_callback;
+    if (callback && data) {
+        callback(data);
+    }
+}
+
+void Steam_Networking_Utils::InvokeAuthStatusChanged(SteamNetAuthenticationStatus_t *data)
+{
+    auto callback = auth_status_changed_callback;
+    if (callback && data) {
+        callback(data);
+    }
+}
+
+void Steam_Networking_Utils::InvokeRelayNetworkStatusChanged(SteamRelayNetworkStatus_t *data)
+{
+    auto callback = relay_network_status_changed_callback;
+    if (callback && data) {
+        callback(data);
+    }
 }
 
 void Steam_Networking_Utils::free_steam_message_data(SteamNetworkingMessage_t *pMsg)
@@ -358,8 +386,29 @@ bool Steam_Networking_Utils::SetConnectionConfigValueString( HSteamNetConnection
 bool Steam_Networking_Utils::SetConfigValue( ESteamNetworkingConfigValue eValue, ESteamNetworkingConfigScope eScopeType, intptr_t scopeObj,
     ESteamNetworkingConfigDataType eDataType, const void *pArg )
 {
-    PRINT_DEBUG("TODO %i %i " "%" PRIdPTR " %i %p", eValue, eScopeType, scopeObj, eDataType, pArg);
+    PRINT_DEBUG("%i %i " "%" PRIdPTR " %i %p", eValue, eScopeType, scopeObj, eDataType, pArg);
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
+    // Global pointer config is used to register the networking callback hooks.
+    if (eScopeType == k_ESteamNetworkingConfig_Global && eDataType == k_ESteamNetworkingConfig_Ptr) {
+        if (eValue == k_ESteamNetworkingConfig_Callback_ConnectionStatusChanged) {
+            connection_status_changed_callback = pArg ? *reinterpret_cast<FnSteamNetConnectionStatusChanged const *>(pArg) : nullptr;
+            PRINT_DEBUG("stored global connection status callback %p", connection_status_changed_callback);
+            return true;
+        }
+
+        if (eValue == k_ESteamNetworkingConfig_Callback_AuthStatusChanged) {
+            auth_status_changed_callback = pArg ? *reinterpret_cast<FnSteamNetAuthenticationStatusChanged const *>(pArg) : nullptr;
+            PRINT_DEBUG("stored global auth status callback %p", auth_status_changed_callback);
+            return true;
+        }
+
+        if (eValue == k_ESteamNetworkingConfig_Callback_RelayNetworkStatusChanged) {
+            relay_network_status_changed_callback = pArg ? *reinterpret_cast<FnSteamRelayNetworkStatusChanged const *>(pArg) : nullptr;
+            PRINT_DEBUG("stored global relay network status callback %p", relay_network_status_changed_callback);
+            return true;
+        }
+    }
+
     return true;
 }
 
@@ -709,6 +758,8 @@ void Steam_Networking_Utils::RunCallbacks()
         relay_initialized = true;
         SteamRelayNetworkStatus_t data = get_network_status();
         callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
+        // Also deliver the callback through the global config hook.
+        InvokeRelayNetworkStatusChanged(&data);
     }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes the post-discovery join path for lobby-based multiplayer and improves early lobby discovery synchronization.

## What Changed

### Networking sockets callback flow
- store and invoke the global networking callbacks registered through `ISteamNetworkingUtils`
- emit the initial connection status transition when `ConnectP2P` / `ConnectByIPAddress` begins
- propagate authentication and relay status through the same global callback path
- time out stalled outbound connect attempts locally instead of retrying indefinitely

### Lobby discovery synchronization
- trigger an immediate announce burst when lobby search starts before any individual peer is connected
- allow a longer initial search window while the first sync arrives
- support explicit lobby data requests through `Lobby_Messages::DATA_REQUEST`
- allow the lobby owner to reply with a targeted lobby snapshot
- send lobby data proactively on low-level peer connect

## Why

The previous behavior allowed the client to discover the host lobby, but the join flow could still stall in a long retry or timeout cycle because the expected networking callback path was not being delivered to the game.

In parallel, lobby discovery relied too heavily on passive propagation. The added synchronization path makes initial lobby visibility and targeted lobby refresh more reliable during early peer setup.

## Verification

- rebased onto latest `dev`
- branch reduced to 2 focused commits
- built `api_regular` successfully on the rebased branch

## Related Issues

May address or improve `#162`, `#339`, and `#395` based on matching symptoms in the join path and lobby visibility flow.

May also improve `#265`, but that has not been verified.