### PR TITLE
fix(gamepad): stop polling HID devices every callback

### DIFF
--- a/.github/workflows/emu-build-all-linux.yml
+++ b/.github/workflows/emu-build-all-linux.yml
@@ -46,6 +46,8 @@ jobs:
             # tools
             "tool_lobby_connect",
             "tool_generate_interfaces",
+            # tests
+            "test_gamepad_linux",
           ]
         arch: ["x64", "x32"]
         cfg: ["debug", "release"]

--- a/libs/gamepad/gamepad.c
+++ b/libs/gamepad/gamepad.c
@@ -27,7 +27,7 @@
 #	include <unistd.h>
 #	include <dirent.h>
 #	include <sys/stat.h>
-#	include <time.h>
+#	include <sys/inotify.h>
 #else
 #	error "Unknown platform in gamepad.c"
 #endif
@@ -73,6 +73,13 @@ static GAMEPAD_STATE STATE[4];
 /* Note whether a gamepad is currently connected */
 #define FLAG_CONNECTED	(1<<0)
 #define FLAG_RUMBLE		(1<<1)
+#if defined(__linux__)
+static int GAMEPAD_WATCH_FD = -1;
+static GAMEPAD_BOOL GAMEPAD_DEVICE_SCAN_PENDING = GAMEPAD_FALSE;
+#ifdef GAMEPAD_TESTING
+static unsigned int GAMEPAD_TEST_DETECT_COUNT = 0;
+#endif
+#endif
 
 /* Prototypes for utility functions */
 static void GamepadResetState		(GAMEPAD_DEVICE gamepad);
@@ -80,6 +87,11 @@ static void GamepadUpdateCommon		(void);
 static void GamepadUpdateDevice		(GAMEPAD_DEVICE gamepad);
 static void GamepadUpdateStick		(GAMEPAD_AXIS* axis, float deadzone);
 static void GamepadUpdateTrigger	(GAMEPAD_TRIGINFO* trig);
+#if defined(__linux__)
+static void GamepadPollDeviceChanges(void);
+static void GamepadRequestDeviceScan(void);
+static void GamepadInitDeviceWatch(void);
+#endif
 
 /* Various values of PI */
 #define PI_1_4	0.78539816339744f
@@ -209,6 +221,9 @@ static void GamepadRemoveDevice(const char* devPath);
 
 static void GamepadDetect()
 {
+#ifdef GAMEPAD_TESTING
+	++GAMEPAD_TEST_DETECT_COUNT;
+#endif
 	DIR *folder;
 	struct dirent *dent;
 
@@ -237,6 +252,41 @@ static void GamepadDetect()
 	}
 }
 
+#if defined(__linux__)
+static void GamepadRequestDeviceScan(void)
+{
+	GAMEPAD_DEVICE_SCAN_PENDING = GAMEPAD_TRUE;
+}
+
+static void GamepadInitDeviceWatch(void)
+{
+	GAMEPAD_WATCH_FD = inotify_init();
+	if (GAMEPAD_WATCH_FD < 0) {
+		return;
+	}
+
+	fcntl(GAMEPAD_WATCH_FD, F_SETFL, O_NONBLOCK);
+	fcntl(GAMEPAD_WATCH_FD, F_SETFD, FD_CLOEXEC);
+
+	if (inotify_add_watch(GAMEPAD_WATCH_FD, "/dev/input",
+		IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO | IN_ATTRIB | IN_DELETE_SELF | IN_MOVE_SELF) < 0) {
+		close(GAMEPAD_WATCH_FD);
+		GAMEPAD_WATCH_FD = -1;
+	}
+}
+
+static void GamepadPollDeviceChanges(void)
+{
+	if (GAMEPAD_WATCH_FD < 0) {
+		return;
+	}
+
+	char buffer[sizeof(struct inotify_event) * 16];
+	while (read(GAMEPAD_WATCH_FD, buffer, sizeof(buffer)) > 0) {
+		GamepadRequestDeviceScan();
+	}
+}
+#endif
 
 
 /* Helper to add a new device */
@@ -377,9 +427,6 @@ static void GamepadRemoveDevice(const char* devPath) {
 }
 
 void GamepadInit(void) {
-	struct udev_list_entry* devices;
-	struct udev_list_entry* item;
-	struct udev_enumerate* enu;
 	int i;
 
 	/* initialize connection state */
@@ -388,17 +435,22 @@ void GamepadInit(void) {
 		STATE[i].fd = STATE[i].effect = -1;
 	}
 
+#if defined(__linux__)
+	GAMEPAD_DEVICE_SCAN_PENDING = GAMEPAD_FALSE;
+	GamepadInitDeviceWatch();
+#endif
+
 	GamepadDetect();
 }
 
 void GamepadUpdate(void) {
-	static unsigned long last = 0;
-	unsigned long cur = time(NULL);
-
-	if (last + 2 < cur) {
+#if defined(__linux__)
+	GamepadPollDeviceChanges();
+	if (GAMEPAD_DEVICE_SCAN_PENDING) {
+		GAMEPAD_DEVICE_SCAN_PENDING = GAMEPAD_FALSE;
 		GamepadDetect();
-		last = cur;
 	}
+#endif
 
 	GamepadUpdateCommon();
 }
@@ -544,7 +596,24 @@ void GamepadShutdown(void) {
 			close(STATE[i].fd);
 		}
 	}
+
+#if defined(__linux__)
+	if (GAMEPAD_WATCH_FD != -1) {
+		close(GAMEPAD_WATCH_FD);
+		GAMEPAD_WATCH_FD = -1;
+	}
+#endif
 }
+
+#if defined(__linux__) && defined(GAMEPAD_TESTING)
+unsigned int GamepadTestDetectCount(void) {
+	return GAMEPAD_TEST_DETECT_COUNT;
+}
+
+void GamepadTestSignalDeviceChange(void) {
+	GamepadRequestDeviceScan();
+}
+#endif
 
 void GamepadSetRumble(GAMEPAD_DEVICE gamepad, float left, float right, unsigned int rumble_length_ms) {
 	if (STATE[gamepad].fd != -1) {

--- a/libs/gamepad/gamepad.h
+++ b/libs/gamepad/gamepad.h
@@ -318,6 +318,11 @@ GAMEPAD_API GAMEPAD_STICKDIR GamepadStickDir(GAMEPAD_DEVICE device, GAMEPAD_STIC
  */
 GAMEPAD_API GAMEPAD_BOOL GamepadStickDirTriggered(GAMEPAD_DEVICE device, GAMEPAD_STICK stick, GAMEPAD_STICKDIR dir);
 
+#if defined(GAMEPAD_TESTING) && defined(__linux__)
+GAMEPAD_API unsigned int GamepadTestDetectCount(void);
+GAMEPAD_API void GamepadTestSignalDeviceChange(void);
+#endif
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif

--- a/premake5.lua
+++ b/premake5.lua
@@ -1674,6 +1674,46 @@ project "test_crash_printer_sa_sigaction"
     }
 -- End test_crash_printer_sa_sigaction
 
+
+-- Project test_gamepad_linux
+---------
+project "test_gamepad_linux"
+    kind "ConsoleApp"
+    location "%{wks.location}/%{prj.name}"
+    targetdir(path.join(build_dir, os_iden, _ACTION, "%{cfg.buildcfg}/tests/gamepad"))
+    targetname "test_gamepad_linux_%{cfg.platform}"
+
+
+    -- defines
+    ---------
+    filter {} -- reset the filter and remove all active keywords
+    defines {
+        "GAMEPAD_TESTING",
+    }
+
+
+    -- common source & header files
+    ---------
+    filter {} -- reset the filter and remove all active keywords
+    files {
+        'libs/gamepad/gamepad.c',
+        'libs/gamepad/gamepad.h',
+        'tests/gamepad/test_gamepad_linux.cpp',
+    }
+    removefiles {
+        'post_build/**',
+        'build/deps/**',
+    }
+
+
+    -- post build
+    ---------
+    filter {} -- reset the filter and remove all active keywords
+    postbuildcommands {
+        '%[%{!cfg.buildtarget.abspath}]',
+    }
+-- End test_gamepad_linux
+
 end
 -- End LINUX ONLY TARGETS
 

--- a/tests/gamepad/test_gamepad_linux.cpp
+++ b/tests/gamepad/test_gamepad_linux.cpp
@@ -1,0 +1,43 @@
+#include "gamepad/gamepad.h"
+
+#include <iostream>
+
+#ifdef GAMEPAD_TESTING
+extern "C" unsigned int GamepadTestDetectCount(void);
+extern "C" void GamepadTestSignalDeviceChange(void);
+#endif
+
+int main()
+{
+#ifndef GAMEPAD_TESTING
+    std::cerr << "GAMEPAD_TESTING must be enabled for this test" << std::endl;
+    return 1;
+#else
+    GamepadInit();
+
+    if (GamepadTestDetectCount() != 1) {
+        std::cerr << "expected exactly one initial device scan" << std::endl;
+        return 1;
+    }
+
+    for (int i = 0; i < 10; ++i) {
+        GamepadUpdate();
+    }
+
+    if (GamepadTestDetectCount() != 1) {
+        std::cerr << "unexpected rescans without hotplug" << std::endl;
+        return 1;
+    }
+
+    GamepadTestSignalDeviceChange();
+    GamepadUpdate();
+
+    if (GamepadTestDetectCount() != 2) {
+        std::cerr << "expected a rescan after a hotplug signal" << std::endl;
+        return 1;
+    }
+
+    GamepadShutdown();
+    return 0;
+#endif
+}


### PR DESCRIPTION
GamepadUpdate now only rescans /dev/input when an inotify hotplug event arrives, instead of polling the directory every couple of seconds. That removes the repeated open/close churn that was stalling the main thread on hosts with lots of HID endpoints. I added a Linux regression test that verifies we do not rescan without a device-change signal and do rescan after one. Thanks to BillionClaw for the report.
