### PR TITLE
ManualDispatch Callback Fix

### DIFF
--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -1347,6 +1347,7 @@ STEAMAPI_API steam_bool S_CALLTYPE SteamAPI_ManualDispatch_GetNextCallback( HSte
 {
     PRINT_DEBUG("%i %p", hSteamPipe, pCallbackMsg);
     Steam_Client *steam_client = get_steam_client();
+    steam_client->RunCallbacks(true, true);
     if (!steam_client->IsServerInit()) {
         while(!server_cb.empty()) server_cb.pop();
     }
@@ -1560,8 +1561,6 @@ SteamMasterServerUpdater
 bool steamclient_get_callback(HSteamPipe hSteamPipe, CallbackMsg_t *pCallbackMsg)
 {
     SteamAPI_ManualDispatch_Init();
-    Steam_Client *steam_client = get_steam_client();
-    steam_client->RunCallbacks(true, true);
     return SteamAPI_ManualDispatch_GetNextCallback(hSteamPipe, pCallbackMsg);
 }
 


### PR DESCRIPTION
Fixes callback delivery issues in games using the ManualDispatch function, like Battle Realms: Zen Edition
(entering mp gets stuck at "Getting list of game servers")