### PR TITLE
Split achievement list into unlocked/locked sections

### DIFF
--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -1593,8 +1593,9 @@ void Steam_Overlay::render_main_window()
                     const bool achieved = x.achieved;
                     const bool hidden = x.hidden && !achieved;
 
-                    try_load_ach_icon(x, true, settings->paginated_achievements_icons == 0);
-                    try_load_ach_icon(x, false, settings->paginated_achievements_icons == 0);
+                    // Load only the icon matching the current state.
+                    // The other variant is loaded by the background pagination or on state change.
+                    try_load_ach_icon(x, achieved, settings->paginated_achievements_icons == 0);
 
                     ImGui::Separator();
 
@@ -1632,9 +1633,11 @@ void Steam_Overlay::render_main_window()
                     if (achieved) {
                         char buffer[80]{};
                         time_t unlock_time = (time_t)x.unlock_time;
-                        size_t written = std::strftime(buffer, sizeof(buffer), settings->overlay_appearance.ach_unlock_datetime_format.c_str(), std::localtime(&unlock_time));
+                        struct tm unlock_tm{};
+                        localtime_s(&unlock_tm, &unlock_time);
+                        size_t written = std::strftime(buffer, sizeof(buffer), settings->overlay_appearance.ach_unlock_datetime_format.c_str(), &unlock_tm);
                         if (!written) {
-                            std::strftime(buffer, sizeof(buffer), "%Y/%m/%d - %H:%M:%S", std::localtime(&unlock_time));
+                            std::strftime(buffer, sizeof(buffer), "%Y/%m/%d - %H:%M:%S", &unlock_tm);
                         }
 
                         ImGui::TextColored(ImVec4(0, 255, 0, 255), translationAchievedOn[current_language], buffer);

--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -1626,6 +1626,16 @@ void Steam_Overlay::render_main_window()
 
                     if (hidden) {
                         ImGui::Text("%s", translationHiddenAchievement[current_language]);
+                        ImGui::SameLine();
+
+                        ImGui::PushID(&x);
+                        ImGui::SmallButton("Show");
+                        bool show = ImGui::IsItemActive();
+                        ImGui::PopID();
+
+                        if (show) {
+                            ImGui::TextWrapped("%s", x.description.c_str());
+                        }
                     } else {
                         ImGui::TextWrapped("%s", x.description.c_str());
                     }

--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -1572,11 +1572,27 @@ void Steam_Overlay::render_main_window()
             if (ImGui::Begin(translationAchievementWindow[current_language], &show_achievements)) {
                 ImGui::Text("%s", translationListOfAchievements[current_language]);
                 ImGui::BeginChild(translationAchievements[current_language]);
-                for (auto & x : achievements) {
-                    bool achieved = x.achieved;
-                    bool hidden = x.hidden && !achieved;
 
-                    // force upload to GPU if the pagination is request-based
+                // Build sorted index lists: unlocked by time desc, locked in API order
+                std::vector<size_t> unlocked_idx, locked_idx;
+                unlocked_idx.reserve(achievements.size());
+                locked_idx.reserve(achievements.size());
+                for (size_t i = 0; i < achievements.size(); ++i) {
+                    if (achievements[i].achieved)
+                        unlocked_idx.push_back(i);
+                    else
+                        locked_idx.push_back(i);
+                }
+                std::sort(unlocked_idx.begin(), unlocked_idx.end(),
+                    [this](size_t a, size_t b) {
+                        return achievements[a].unlock_time > achievements[b].unlock_time;
+                    });
+
+                // Lambda to render a single achievement card
+                auto render_ach = [this](Overlay_Achievement &x) {
+                    const bool achieved = x.achieved;
+                    const bool hidden = x.hidden && !achieved;
+
                     try_load_ach_icon(x, true, settings->paginated_achievements_icons == 0);
                     try_load_ach_icon(x, false, settings->paginated_achievements_icons == 0);
 
@@ -1605,7 +1621,6 @@ void Steam_Overlay::render_main_window()
                         }
                     }
 
-                    // we want to display the ach text regardless the icons were displayed or not
                     ImGui::Text("%s", x.title.c_str());
 
                     if (hidden) {
@@ -1618,7 +1633,7 @@ void Steam_Overlay::render_main_window()
                         char buffer[80]{};
                         time_t unlock_time = (time_t)x.unlock_time;
                         size_t written = std::strftime(buffer, sizeof(buffer), settings->overlay_appearance.ach_unlock_datetime_format.c_str(), std::localtime(&unlock_time));
-                        if (!written) { // count was reached before the entire string could be stored, keep it safe
+                        if (!written) {
                             std::strftime(buffer, sizeof(buffer), "%Y/%m/%d - %H:%M:%S", std::localtime(&unlock_time));
                         }
 
@@ -1631,7 +1646,30 @@ void Steam_Overlay::render_main_window()
                     if (could_create_ach_table_entry) ImGui::EndTable();
 
                     ImGui::Separator();
+                };
+
+                // --- Unlocked section ---
+                if (ImGui::CollapsingHeader("Unlocked", ImGuiTreeNodeFlags_DefaultOpen)) {
+                    if (unlocked_idx.empty()) {
+                        ImGui::TextDisabled("No achievements unlocked yet");
+                    } else {
+                        for (auto idx : unlocked_idx) {
+                            render_ach(achievements[idx]);
+                        }
+                    }
                 }
+
+                // --- Locked section ---
+                if (ImGui::CollapsingHeader("Locked", ImGuiTreeNodeFlags_DefaultOpen)) {
+                    if (locked_idx.empty()) {
+                        ImGui::TextDisabled("All achievements unlocked!");
+                    } else {
+                        for (auto idx : locked_idx) {
+                            render_ach(achievements[idx]);
+                        }
+                    }
+                }
+
                 ImGui::EndChild();
             }
 

--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -1634,7 +1634,11 @@ void Steam_Overlay::render_main_window()
                         char buffer[80]{};
                         time_t unlock_time = (time_t)x.unlock_time;
                         struct tm unlock_tm{};
+#ifdef _MSC_VER
                         localtime_s(&unlock_tm, &unlock_time);
+#else
+                        localtime_r(&unlock_time, &unlock_tm);
+#endif
                         size_t written = std::strftime(buffer, sizeof(buffer), settings->overlay_appearance.ach_unlock_datetime_format.c_str(), &unlock_tm);
                         if (!written) {
                             std::strftime(buffer, sizeof(buffer), "%Y/%m/%d - %H:%M:%S", &unlock_tm);


### PR DESCRIPTION
Previously the achievement list showed all achievements in a single flat list with no visual separation between completed and uncompleted ones. This restructures the window into two clearly separated sections.

Changes:
- Splits the achievement list into Locked and Unlocked sections
- Each section is independently sorted and collapsible
- Unlocked section shows completion timestamps
- Add [Show] button to reveal hidden achievement descriptions on hold