### PR TITLE
Add playtime tracking to player info with pause-on-blur

### DIFF
--- a/dll/dll/playtime.h
+++ b/dll/dll/playtime.h
@@ -25,7 +25,7 @@
 
 class PlaytimeCounter {
 public:
-    explicit PlaytimeCounter(Local_Storage* local_storage);
+    explicit PlaytimeCounter(Local_Storage* local_storage, bool record_playtime = false);
     ~PlaytimeCounter();
 
     // Tick the playtime counter, call regularly
@@ -43,8 +43,11 @@ public:
     void set_pause_total(bool pause);
     void set_pause_session(bool pause);
 
+    bool get_record_playtime() const { return record_playtime; }
+
 private:
     Local_Storage* local_storage{};
+    bool record_playtime = false;
     const std::string playtime_filename = "playtime.txt";
     std::chrono::steady_clock::time_point last_tick{};
     uint64_t playtime_seconds = 0;

--- a/dll/dll/playtime.h
+++ b/dll/dll/playtime.h
@@ -37,12 +37,21 @@ public:
 
     // Get current playtime in seconds
     uint64_t seconds() const;
+    uint64_t session_seconds() const;
+
+    // Pause/resume total or session accumulation (e.g. when game is unfocused)
+    void set_pause_total(bool pause);
+    void set_pause_session(bool pause);
 
 private:
     Local_Storage* local_storage{};
     const std::string playtime_filename = "playtime.txt";
     std::chrono::steady_clock::time_point last_tick{};
     uint64_t playtime_seconds = 0;
+    uint64_t playtime_accumulator_ms = 0; // sub-second accumulation
+    uint64_t session_seconds_accumulated = 0; // session time accumulated per tick
+    bool pause_total = false;
+    bool pause_session = false;
     mutable std::mutex mutex;
     bool initialized = false;
     uint64_t since_save = 0; // seconds since last save

--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -157,6 +157,7 @@ struct Overlay_Appearance {
     uint32 notification_duration_chat = 4000; // sliding animation duration duration (millisec)
 
     std::string ach_unlock_datetime_format = "%Y/%m/%d - %H:%M:%S";
+    bool show_playtime_in_user_info = false;
     
     float background_r = 0.12f;
     float background_g = 0.11f;
@@ -302,6 +303,10 @@ public:
 
     // whether to record playtime
     bool record_playtime = false;
+
+    // pause total / session playtime when the game window loses focus (ALT+TAB)
+    bool pause_total_when_unfocused = false;
+    bool pause_session_when_unfocused = false;
 
     // bypass to make SetAchievement() always return true, prevent some games from breaking
     bool achievement_bypass = false;

--- a/dll/playtime.cpp
+++ b/dll/playtime.cpp
@@ -19,11 +19,15 @@
 
 #include <limits>
 
-PlaytimeCounter::PlaytimeCounter(Local_Storage* local_storage)
+PlaytimeCounter::PlaytimeCounter(Local_Storage* local_storage, bool record_playtime)
    : local_storage(local_storage),
+     record_playtime(record_playtime),
      last_tick(std::chrono::steady_clock::now())
 {
     load();
+    if (record_playtime) {
+        save();
+    }
 }
 
 PlaytimeCounter::~PlaytimeCounter()
@@ -68,7 +72,7 @@ void PlaytimeCounter::tick()
                 }
 
                 since_save += accrued_sec;
-                if (since_save >= 60) {
+                if (since_save >= 15) {
                     since_save = 0;
                     need_save = true;
                 }
@@ -106,6 +110,7 @@ void PlaytimeCounter::load()
 
 void PlaytimeCounter::save()
 {
+    if (!record_playtime) return;
     std::lock_guard<std::mutex> lock(mutex);
 
     std::string data = std::to_string(playtime_seconds);

--- a/dll/playtime.cpp
+++ b/dll/playtime.cpp
@@ -20,7 +20,8 @@
 #include <limits>
 
 PlaytimeCounter::PlaytimeCounter(Local_Storage* local_storage)
-   : local_storage(local_storage), last_tick(std::chrono::steady_clock::now())
+   : local_storage(local_storage),
+     last_tick(std::chrono::steady_clock::now())
 {
     load();
 }
@@ -46,23 +47,37 @@ void PlaytimeCounter::tick()
     {
         std::lock_guard<std::mutex> lock(mutex);
 
-        auto delta = std::chrono::duration_cast<std::chrono::seconds>(now - last_tick).count();
-        if (delta <= 0) return;
+        auto delta_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_tick).count();
+        if (delta_ms <= 0) return;
 
-        uint64_t inc = static_cast<uint64_t>(delta);
-        const uint64_t maxv = std::numeric_limits<uint64_t>::max();
-        if (playtime_seconds > maxv - inc) {
-            playtime_seconds = maxv;
-        } else {
-            playtime_seconds += inc;
-        }
-        
         last_tick = now;
 
-        since_save += delta;
-        if (since_save >= 60) {
-            since_save = 0;
-            need_save = true;
+        // Accumulate milliseconds, convert whole seconds
+        playtime_accumulator_ms += static_cast<uint64_t>(delta_ms);
+        uint64_t accrued_sec = playtime_accumulator_ms / 1000;
+        playtime_accumulator_ms %= 1000;
+
+        if (accrued_sec > 0) {
+            // Accumulate total playtime (unless paused)
+            if (!pause_total) {
+                const uint64_t maxv = std::numeric_limits<uint64_t>::max();
+                if (playtime_seconds > maxv - accrued_sec) {
+                    playtime_seconds = maxv;
+                } else {
+                    playtime_seconds += accrued_sec;
+                }
+
+                since_save += accrued_sec;
+                if (since_save >= 60) {
+                    since_save = 0;
+                    need_save = true;
+                }
+            }
+
+            // Accumulate session playtime (unless paused)
+            if (!pause_session) {
+                session_seconds_accumulated += accrued_sec;
+            }
         }
     }
 
@@ -76,6 +91,8 @@ void PlaytimeCounter::load()
     std::lock_guard<std::mutex> lock(mutex);
 
     playtime_seconds = 0;
+    playtime_accumulator_ms = 0;
+    session_seconds_accumulated = 0;
 
     std::string data(32, '\0');
     if (local_storage->get_data("", playtime_filename, data.data(), static_cast<unsigned int>(data.size()), 0) > 0) {
@@ -99,4 +116,22 @@ uint64_t PlaytimeCounter::seconds() const
 {
     std::lock_guard<std::mutex> lock(mutex);
     return playtime_seconds;
+}
+
+uint64_t PlaytimeCounter::session_seconds() const
+{
+    std::lock_guard<std::mutex> lock(mutex);
+    return session_seconds_accumulated;
+}
+
+void PlaytimeCounter::set_pause_total(bool pause)
+{
+    std::lock_guard<std::mutex> lock(mutex);
+    pause_total = pause;
+}
+
+void PlaytimeCounter::set_pause_session(bool pause)
+{
+    std::lock_guard<std::mutex> lock(mutex);
+    pause_session = pause;
 }

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -377,6 +377,10 @@ static void load_overlay_appearance(class Settings *settings_client, class Setti
             } else if (name.compare("Achievement_Unlock_Datetime_Format") == 0) {
                 settings_client->overlay_appearance.ach_unlock_datetime_format = value;
                 settings_server->overlay_appearance.ach_unlock_datetime_format = value;
+            } else if (name.compare("Show_Playtime_In_User_Info") == 0) {
+                bool show = (std::stol(value, NULL) != 0);
+                settings_client->overlay_appearance.show_playtime_in_user_info = show;
+                settings_server->overlay_appearance.show_playtime_in_user_info = show;
             } else if (name.compare("Achievement_Notification_Delay") == 0) {
                 float delay_sec = std::stof(value, NULL);
                 settings_client->achievement_notification_delay_ms = static_cast<int>(delay_sec * 1000.0f);
@@ -1762,6 +1766,11 @@ static void parse_stats_features(class Settings *settings_client, class Settings
 
     settings_client->record_playtime = ini.GetBoolValue("main::stats", "record_playtime", settings_client->record_playtime);
     settings_server->record_playtime = ini.GetBoolValue("main::stats", "record_playtime", settings_server->record_playtime);
+
+    settings_client->pause_total_when_unfocused = ini.GetBoolValue("main::stats", "pause_total_when_unfocused", settings_client->pause_total_when_unfocused);
+    settings_server->pause_total_when_unfocused = ini.GetBoolValue("main::stats", "pause_total_when_unfocused", settings_server->pause_total_when_unfocused);
+    settings_client->pause_session_when_unfocused = ini.GetBoolValue("main::stats", "pause_session_when_unfocused", settings_client->pause_session_when_unfocused);
+    settings_server->pause_session_when_unfocused = ini.GetBoolValue("main::stats", "pause_session_when_unfocused", settings_server->pause_session_when_unfocused);
 }
 
 

--- a/dll/steam_client.cpp
+++ b/dll/steam_client.cpp
@@ -127,7 +127,7 @@ Steam_Client::Steam_Client()
 
     // client
     PRINT_DEBUG("init client");
-    playtime_counter = new PlaytimeCounter(local_storage);
+    playtime_counter = new PlaytimeCounter(local_storage, settings_client->record_playtime);
     steam_overlay = new Steam_Overlay(settings_client, local_storage, callback_results_client, callbacks_client, run_every_runcb, network, playtime_counter);
 
     steam_user = new Steam_User(settings_client, local_storage, network, callback_results_client, callbacks_client, false);

--- a/dll/steam_client.cpp
+++ b/dll/steam_client.cpp
@@ -18,18 +18,13 @@
 #include "dll/steam_client.h"
 #include "dll/settings_parser.h"
 #include "dll/dll.h"
-#include <optional>
-
-#if defined(_WIN32)
-#include <windows.h>
-#endif
 
 
 // Returns true if the game window is the currently focused foreground window.
 // On non-Windows platforms, always returns true (no focus-based pausing).
 static bool is_game_focused()
 {
-#if defined(_WIN32)
+#if defined(__WINDOWS__)
     HWND fg = GetForegroundWindow();
     if (!fg) return false;
     DWORD pid = 0;

--- a/dll/steam_client.cpp
+++ b/dll/steam_client.cpp
@@ -18,7 +18,27 @@
 #include "dll/steam_client.h"
 #include "dll/settings_parser.h"
 #include "dll/dll.h"
+#include <optional>
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
+
+// Returns true if the game window is the currently focused foreground window.
+// On non-Windows platforms, always returns true (no focus-based pausing).
+static bool is_game_focused()
+{
+#if defined(_WIN32)
+    HWND fg = GetForegroundWindow();
+    if (!fg) return false;
+    DWORD pid = 0;
+    GetWindowThreadProcessId(fg, &pid);
+    return pid == GetCurrentProcessId();
+#else
+    return true;
+#endif
+}
 
 void Steam_Client::background_thread_proc()
 {
@@ -38,6 +58,15 @@ void Steam_Client::background_thread_proc()
     }
 
     if (settings_client->record_playtime) {
+        // Only update pause flags when focus state actually changes,
+        // to avoid pointless mutex acquisitions on every tick.
+        static std::optional<bool> last_focused;
+        bool focused = is_game_focused();
+        if (!last_focused.has_value() || *last_focused != focused) {
+            last_focused = focused;
+            playtime_counter->set_pause_total(settings_client->pause_total_when_unfocused && !focused);
+            playtime_counter->set_pause_session(settings_client->pause_session_when_unfocused && !focused);
+        }
         playtime_counter->tick(); // update playtime counter
     }
 }
@@ -98,7 +127,8 @@ Steam_Client::Steam_Client()
 
     // client
     PRINT_DEBUG("init client");
-    steam_overlay = new Steam_Overlay(settings_client, local_storage, callback_results_client, callbacks_client, run_every_runcb, network);
+    playtime_counter = new PlaytimeCounter(local_storage);
+    steam_overlay = new Steam_Overlay(settings_client, local_storage, callback_results_client, callbacks_client, run_every_runcb, network, playtime_counter);
 
     steam_user = new Steam_User(settings_client, local_storage, network, callback_results_client, callbacks_client, false);
     steam_friends = new Steam_Friends(settings_client, local_storage, network, callback_results_client, callbacks_client, run_every_runcb, steam_overlay);
@@ -161,8 +191,6 @@ Steam_Client::Steam_Client()
 
     PRINT_DEBUG("init AppTicket");
     steam_app_ticket = new Steam_AppTicket(settings_client);
-
-    playtime_counter = new PlaytimeCounter(local_storage);
 
     gameserver_has_ipv6_functions = false;
     steamclient_version = 6; // default for C exports

--- a/overlay_experimental/overlay/steam_overlay.h
+++ b/overlay_experimental/overlay/steam_overlay.h
@@ -11,6 +11,7 @@
 #include <future>
 #include <atomic>
 #include <memory>
+#include "dll/playtime.h"
 #include "InGameOverlay/RendererHook.h"
 #include "InGameOverlay/ImGui/imgui.h"
 #include "overlay/steam_overlay_stats.h"
@@ -119,6 +120,7 @@ class Steam_Overlay
     class SteamCallBacks* callbacks;
     class RunEveryRunCB* run_every_runcb;
     class Networking* network;
+    class PlaytimeCounter* playtime_counter;
     class Steam_Overlay_Stats stats;
 
     // friend id, show client window (to chat and accept invite maybe)
@@ -287,7 +289,7 @@ class Steam_Overlay
     static void overlay_networking_callback(void* object, Common_Message* msg);
     
 public:
-    Steam_Overlay(Settings* settings, Local_Storage *local_storage, SteamCallResults* callback_results, SteamCallBacks* callbacks, RunEveryRunCB* run_every_runcb, Networking *network);
+    Steam_Overlay(Settings* settings, Local_Storage *local_storage, SteamCallResults* callback_results, SteamCallBacks* callbacks, RunEveryRunCB* run_every_runcb, Networking *network, PlaytimeCounter* playtime_counter);
 
     ~Steam_Overlay();
 
@@ -322,10 +324,12 @@ public:
 
 #else // EMU_OVERLAY
 
+class PlaytimeCounter;
+
 class Steam_Overlay
 {
 public:
-    Steam_Overlay(Settings* settings, Local_Storage *local_storage, SteamCallResults* callback_results, SteamCallBacks* callbacks, RunEveryRunCB* run_every_runcb, Networking* network) {}
+    Steam_Overlay(Settings* settings, Local_Storage *local_storage, SteamCallResults* callback_results, SteamCallBacks* callbacks, RunEveryRunCB* run_every_runcb, Networking* network, PlaytimeCounter* playtime_counter) {}
     ~Steam_Overlay() {}
 
     bool Ready() const { return false; }

--- a/overlay_experimental/overlay/steam_overlay_stats.h
+++ b/overlay_experimental/overlay/steam_overlay_stats.h
@@ -2,6 +2,7 @@
 #define _STEAM_OVERLAY_STATS_H_
 
 #include <chrono>
+#include <optional>
 #include <string_view>
 #include <unordered_map>
 #include <vector>
@@ -25,6 +26,8 @@ private:
         std::chrono::high_resolution_clock::now();
     std::chrono::high_resolution_clock::time_point last_playtime =
         std::chrono::high_resolution_clock::now();
+    std::chrono::high_resolution_clock::duration total_playtime_paused{0};
+    std::optional<std::chrono::high_resolution_clock::time_point> playtime_pause_start;
     unsigned active_playtime_hr = 0;
     unsigned active_playtime_min = 0;
     unsigned active_playtime_sec = 0;

--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -1594,7 +1594,7 @@ void Steam_Overlay::render_main_window()
                 unsigned total_m = static_cast<unsigned>((total_sec % 3600) / 60);
 
                 char total_buf[32]{};
-                char session_buf[32];
+                char session_buf[32]{};
                 snprintf(total_buf, sizeof(total_buf), "%uh %um", total_h, total_m);
                 snprintf(session_buf, sizeof(session_buf), "%02u:%02u:%02u", hh, mm, ss);
 

--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -141,13 +141,14 @@ void Steam_Overlay::parse_key_combo()
     }
 }
 
-Steam_Overlay::Steam_Overlay(Settings* settings, Local_Storage *local_storage, SteamCallResults* callback_results, SteamCallBacks* callbacks, RunEveryRunCB* run_every_runcb, Networking* network) :
+Steam_Overlay::Steam_Overlay(Settings* settings, Local_Storage *local_storage, SteamCallResults* callback_results, SteamCallBacks* callbacks, RunEveryRunCB* run_every_runcb, Networking* network, PlaytimeCounter* playtime_counter) :
     settings(settings),
     local_storage(local_storage),
     callback_results(callback_results),
     callbacks(callbacks),
     run_every_runcb(run_every_runcb),
     network(network),
+    playtime_counter(playtime_counter),
     stats(Steam_Overlay_Stats(settings))
 {
     // don't even bother initializing the overlay
@@ -1581,6 +1582,24 @@ void Steam_Overlay::render_main_window()
                 settings->get_local_name(),
                 settings->get_local_steam_id().ConvertToUint64(),
                 settings->get_local_game_id().AppID());
+
+            if (settings->record_playtime && playtime_counter && settings->overlay_appearance.show_playtime_in_user_info) {
+                uint64_t session_sec = playtime_counter->session_seconds();
+                unsigned ss = static_cast<unsigned>(session_sec % 60);
+                unsigned mm = static_cast<unsigned>((session_sec / 60) % 60);
+                unsigned hh = static_cast<unsigned>(session_sec / 3600);
+
+                uint64_t total_sec = playtime_counter->seconds();
+                unsigned total_h = static_cast<unsigned>(total_sec / 3600);
+                unsigned total_m = static_cast<unsigned>((total_sec % 3600) / 60);
+
+                char total_buf[32]{};
+                char session_buf[32];
+                snprintf(total_buf, sizeof(total_buf), "%uh %um", total_h, total_m);
+                snprintf(session_buf, sizeof(session_buf), "%02u:%02u:%02u", hh, mm, ss);
+
+                ImGui::LabelText("##playtime", "Total: %s  Session: %s", total_buf, session_buf);
+            }
         }
 
         ImGui::Spacing();

--- a/overlay_experimental/steam_overlay_stats.cpp
+++ b/overlay_experimental/steam_overlay_stats.cpp
@@ -3,6 +3,26 @@
 #include "overlay/steam_overlay_translations.h"
 #include <utility>
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
+
+// Returns true if the game window is the currently focused foreground window.
+// On non-Windows platforms, always returns true (no focus-based pausing).
+static bool is_game_focused()
+{
+#if defined(_WIN32)
+    HWND fg = GetForegroundWindow();
+    if (!fg) return false;
+    DWORD pid = 0;
+    GetWindowThreadProcessId(fg, &pid);
+    return pid == GetCurrentProcessId();
+#else
+    return true;
+#endif
+}
+
 
 Steam_Overlay_Stats::Steam_Overlay_Stats(class Settings* settings):
     settings(settings)
@@ -44,10 +64,25 @@ void Steam_Overlay_Stats::update_playtime(const std::chrono::high_resolution_clo
     ).count();
     if (update_duration_sec < 1) return;
 
+    // Pause accumulation when the game window loses focus (ALT+TAB)
+    if (!is_game_focused() && settings->pause_session_when_unfocused) {
+        if (!playtime_pause_start.has_value()) {
+            playtime_pause_start = now;
+        }
+        return; // freeze the display values
+    }
+
+    // Accumulate paused duration when focus returns
+    if (playtime_pause_start.has_value()) {
+        total_playtime_paused += now - *playtime_pause_start;
+        playtime_pause_start.reset();
+    }
+
     last_playtime = now;
 
+    const auto effective_elapsed = (now - initial_time) - total_playtime_paused;
     const auto time_duration_sec = (unsigned long long)std::chrono::duration_cast<std::chrono::seconds>(
-        now - initial_time
+        effective_elapsed
     ).count();
     active_playtime_sec = static_cast<unsigned>(time_duration_sec % 60);
 

--- a/post_build/steam_settings.EXAMPLE/configs.main.EXAMPLE.ini
+++ b/post_build/steam_settings.EXAMPLE/configs.main.EXAMPLE.ini
@@ -87,6 +87,12 @@ paginated_achievements_icons=10
 # the emu will also resume recording playtime when the game is relaunched
 # default=0
 record_playtime=0
+# when enabled, total playtime pauses when the game window loses focus (ALT+TAB)
+# default=0
+pause_total_when_unfocused=0
+# when enabled, session playtime pauses when the game window loses focus (ALT+TAB)
+# default=0
+pause_session_when_unfocused=0
 
 [main::connectivity]
 # 1=prevent hooking OS networking APIs and allow any external requests

--- a/post_build/steam_settings.EXAMPLE/configs.overlay.EXAMPLE.ini
+++ b/post_build/steam_settings.EXAMPLE/configs.overlay.EXAMPLE.ini
@@ -148,6 +148,10 @@ Achievement_Notification_Delay=0
 # default=%Y/%m/%d - %H:%M:%S
 Achievement_Unlock_Datetime_Format=%Y/%m/%d - %H:%M:%S
 
+# 1=show the playtime display in the user info section of the overlay
+# requires record_playtime=1 in [main::stats]
+# default=0
+Show_Playtime_In_User_Info=0
 # main background when you press shift+tab
 Background_R=0.12
 Background_G=0.11


### PR DESCRIPTION
Adds per-game playtime tracking displayed in the overlay's user info section, with automatic pause when the game loses focus.

Features:
**1. Playtime tracking** — records total and session playtime per game
**2. Pause-on-blur** — total and session playtime independently configurable to pause when game not focused
**3. Overlay display** — shows playtime in the user info panel
**4. Settings:** record_playtime (default=0), pause_total_when_unfocused (default=0), pause_session_when_unfocused (default=0) under [main::stats], and Show_Playtime_In_User_Info (default=0) under [overlay::general]