### PR TITLE
Screenshot system

### DIFF
--- a/dll/dll/local_storage.h
+++ b/dll/dll/local_storage.h
@@ -89,6 +89,7 @@ public:
     uint64_t file_timestamp(std::string folder, std::string file);
     std::string get_global_settings_path();
     std::string get_path(std::string folder);
+    bool dir_exists(std::string folder);
 
     bool update_save_filenames(std::string folder);
 

--- a/dll/dll/screenshot_format.h
+++ b/dll/dll/screenshot_format.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <vector>
+#include <cstdint>
+
+#ifdef EMU_OVERLAY
+#include "InGameOverlay/RendererHook.h"
+
+namespace ScreenshotFormat {
+
+// Converts from any ScreenshotDataFormat_t to RGBA format.
+// Returns a std::vector<uint8_t> containing the RGBA image data.
+// OutChannels can be 3 (RGB) or 4 (RGBA).
+std::vector<uint8_t> ConvertToRGBA(const InGameOverlay::ScreenshotCallbackParameter_t* screenshot, int outChannels = 4);
+
+}
+#endif // EMU_OVERLAY

--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -385,6 +385,9 @@ public:
     bool overlay_always_show_playtime = false;
     // keys used to toggle the overlay, default = Shift + Tab
     std::vector<std::string> overlay_toggle_keys{};
+    // 0=disable the F12 screenshot feature
+    // default=1
+    bool enable_screenshot = true;
     std::vector<std::string> overlay_screenshot_keys{};
     // minimum time interval between achievement notifications (in milliseconds)
     int achievement_notification_delay_ms = 0;

--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -155,6 +155,7 @@ struct Overlay_Appearance {
     uint32 notification_duration_achievement = 7000; // achievement unlocked duration (millisec)
     uint32 notification_duration_invitation = 8000; // friend invitation duration (millisec)
     uint32 notification_duration_chat = 4000; // sliding animation duration duration (millisec)
+    uint32 notification_duration_screenshot = 1000; // screenshot saved duration (millisec)
 
     std::string ach_unlock_datetime_format = "%Y/%m/%d - %H:%M:%S";
     
@@ -379,6 +380,7 @@ public:
     bool overlay_always_show_playtime = false;
     // keys used to toggle the overlay, default = Shift + Tab
     std::vector<std::string> overlay_toggle_keys{};
+    std::vector<std::string> overlay_screenshot_keys{};
     // minimum time interval between achievement notifications (in milliseconds)
     int achievement_notification_delay_ms = 0;
 

--- a/dll/dll/steam_screenshots.h
+++ b/dll/dll/steam_screenshots.h
@@ -19,6 +19,7 @@
 #define __INCLUDED_STEAM_SCRNSHOTS_H__
 
 #include "base.h"
+#include <functional>
 
 struct screenshot_infos_t {
 	std::string screenshot_name{};
@@ -33,7 +34,12 @@ public ISteamScreenshots
 	class Local_Storage *local_storage{};
 	class SteamCallBacks *callbacks{};
 
+public:
     bool hooked = false;
+    // Callback set by Steam_Overlay to delegate overlay screenshots to the renderer hook
+    std::function<void()> overlay_take_screenshot{};
+
+private:
 	std::map<ScreenshotHandle, screenshot_infos_t> _screenshots{};
 
 	ScreenshotHandle create_screenshot_handle();

--- a/dll/local_storage.cpp
+++ b/dll/local_storage.cpp
@@ -606,6 +606,14 @@ std::string Local_Storage::get_path(std::string folder)
     return path;
 }
 
+bool Local_Storage::dir_exists(std::string folder)
+{
+    if (folder.size() && folder.back() != *PATH_SEPARATOR) {
+        folder.append(PATH_SEPARATOR);
+    }
+    return common_helpers::dir_exist(save_directory + appid + folder);
+}
+
 std::string Local_Storage::get_global_settings_path()
 {
     return save_directory + settings_storage_folder + PATH_SEPARATOR;

--- a/dll/screenshot_format.cpp
+++ b/dll/screenshot_format.cpp
@@ -186,7 +186,7 @@ std::vector<uint8_t> ConvertToRGBA(const InGameOverlay::ScreenshotCallbackParame
             dst[1] = g;
             dst[2] = b;
             if (outChannels == 4) {
-                dst[3] = a;
+                dst[3] = 255;
             }
             dst += outChannels;
             srcPixel += screenshot->PixelSize;

--- a/dll/screenshot_format.cpp
+++ b/dll/screenshot_format.cpp
@@ -1,0 +1,202 @@
+#include "dll/screenshot_format.h"
+#include <algorithm>
+#include <cmath>
+
+#ifdef EMU_OVERLAY
+
+namespace ScreenshotFormat {
+
+// Simple float helper to uint8
+inline uint8_t FloatToByte(float val) {
+    if (val < 0.0f) val = 0.0f;
+    if (val > 1.0f) val = 1.0f;
+    return static_cast<uint8_t>(val * 255.0f);
+}
+
+inline uint8_t Unorm16ToByte(uint16_t val) {
+    return static_cast<uint8_t>(val >> 8);
+}
+
+std::vector<uint8_t> ConvertToRGBA(const InGameOverlay::ScreenshotCallbackParameter_t* screenshot, int outChannels) {
+    std::vector<uint8_t> outData;
+    if (!screenshot || !screenshot->Data || screenshot->Width == 0 || screenshot->Height == 0) {
+        return outData;
+    }
+
+    uint32_t width = screenshot->Width;
+    uint32_t height = screenshot->Height;
+    outData.resize(width * height * outChannels);
+
+    uint8_t* srcRow = static_cast<uint8_t*>(screenshot->Data);
+    uint8_t* dst = outData.data();
+
+    for (uint32_t y = 0; y < height; ++y) {
+        uint8_t* srcPixel = srcRow;
+        for (uint32_t x = 0; x < width; ++x) {
+            uint8_t r = 0, g = 0, b = 0, a = 255;
+
+            switch (screenshot->Format) {
+                case InGameOverlay::ScreenshotDataFormat_t::R8G8B8:
+                    r = srcPixel[0];
+                    g = srcPixel[1];
+                    b = srcPixel[2];
+                    break;
+                case InGameOverlay::ScreenshotDataFormat_t::R8G8B8A8:
+                    r = srcPixel[0];
+                    g = srcPixel[1];
+                    b = srcPixel[2];
+                    a = srcPixel[3];
+                    break;
+                case InGameOverlay::ScreenshotDataFormat_t::B8G8R8A8:
+                    b = srcPixel[0];
+                    g = srcPixel[1];
+                    r = srcPixel[2];
+                    a = srcPixel[3];
+                    break;
+                case InGameOverlay::ScreenshotDataFormat_t::B8G8R8X8:
+                    b = srcPixel[0];
+                    g = srcPixel[1];
+                    r = srcPixel[2];
+                    a = 255;
+                    break;
+                case InGameOverlay::ScreenshotDataFormat_t::A8R8G8B8:
+                case InGameOverlay::ScreenshotDataFormat_t::X8R8G8B8:
+                    // D3D/little-endian format: ARGB DWORD -> memory order BGRA
+                    b = srcPixel[0];
+                    g = srcPixel[1];
+                    r = srcPixel[2];
+                    a = (screenshot->Format == InGameOverlay::ScreenshotDataFormat_t::A8R8G8B8) ? srcPixel[3] : 255;
+                    break;
+
+                case InGameOverlay::ScreenshotDataFormat_t::A2R10G10B10: {
+                    uint32_t pixel = *reinterpret_cast<uint32_t*>(srcPixel);
+                    // 10 bits per channel in ARGB layout
+                    b = static_cast<uint8_t>((pixel & 0x3FF) >> 2);
+                    g = static_cast<uint8_t>(((pixel >> 10) & 0x3FF) >> 2);
+                    r = static_cast<uint8_t>(((pixel >> 20) & 0x3FF) >> 2);
+                    a = static_cast<uint8_t>((pixel >> 30) * 85); // 2 bits to 8 bits (0-3 -> 0-255)
+                    break;
+                }
+                case InGameOverlay::ScreenshotDataFormat_t::A2B10G10R10: {
+                    uint32_t pixel = *reinterpret_cast<uint32_t*>(srcPixel);
+                    r = static_cast<uint8_t>((pixel & 0x3FF) >> 2);
+                    g = static_cast<uint8_t>(((pixel >> 10) & 0x3FF) >> 2);
+                    b = static_cast<uint8_t>(((pixel >> 20) & 0x3FF) >> 2);
+                    a = static_cast<uint8_t>((pixel >> 30) * 85);
+                    break;
+                }
+                case InGameOverlay::ScreenshotDataFormat_t::R10G10B10A2: {
+                    uint32_t pixel = *reinterpret_cast<uint32_t*>(srcPixel);
+                    r = static_cast<uint8_t>((pixel & 0x3FF) >> 2);
+                    g = static_cast<uint8_t>(((pixel >> 10) & 0x3FF) >> 2);
+                    b = static_cast<uint8_t>(((pixel >> 20) & 0x3FF) >> 2);
+                    a = static_cast<uint8_t>((pixel >> 30) * 85);
+                    break;
+                }
+
+                case InGameOverlay::ScreenshotDataFormat_t::R5G6B5: {
+                    uint16_t pixel = *reinterpret_cast<uint16_t*>(srcPixel);
+                    r = ((pixel >> 11) & 0x1F) << 3;
+                    g = ((pixel >> 5) & 0x3F) << 2;
+                    b = (pixel & 0x1F) << 3;
+                    break;
+                }
+                case InGameOverlay::ScreenshotDataFormat_t::B5G6R5: {
+                    uint16_t pixel = *reinterpret_cast<uint16_t*>(srcPixel);
+                    b = ((pixel >> 11) & 0x1F) << 3;
+                    g = ((pixel >> 5) & 0x3F) << 2;
+                    r = (pixel & 0x1F) << 3;
+                    break;
+                }
+                case InGameOverlay::ScreenshotDataFormat_t::A1R5G5B5:
+                case InGameOverlay::ScreenshotDataFormat_t::X1R5G5B5: {
+                    uint16_t pixel = *reinterpret_cast<uint16_t*>(srcPixel);
+                    b = (pixel & 0x1F) << 3;
+                    g = ((pixel >> 5) & 0x1F) << 3;
+                    r = ((pixel >> 10) & 0x1F) << 3;
+                    a = (screenshot->Format == InGameOverlay::ScreenshotDataFormat_t::A1R5G5B5 && (pixel >> 15)) ? 255 : 0;
+                    break;
+                }
+                case InGameOverlay::ScreenshotDataFormat_t::B5G5R5A1: {
+                    uint16_t pixel = *reinterpret_cast<uint16_t*>(srcPixel);
+                    a = (pixel & 0x01) ? 255 : 0;
+                    r = ((pixel >> 1) & 0x1F) << 3;
+                    g = ((pixel >> 6) & 0x1F) << 3;
+                    b = ((pixel >> 11) & 0x1F) << 3;
+                    break;
+                }
+
+                case InGameOverlay::ScreenshotDataFormat_t::R16G16B16A16_FLOAT: {
+                    // Half float (16-bit float) format. We can rough-cast half to float.
+                    // To keep it simple, we can convert half-precision float bits to single-precision float.
+                    auto halfToFloat = [](uint16_t h) -> float {
+                        uint32_t sign = (h & 0x8000) << 16;
+                        uint32_t exp = (h & 0x7C00) >> 10;
+                        uint32_t mant = h & 0x03FF;
+                        if (exp == 0) {
+                            if (mant == 0) return 0.0f;
+                            while ((mant & 0x0400) == 0) {
+                                mant <<= 1;
+                                exp--;
+                            }
+                            exp++;
+                            mant &= ~0x0400;
+                        } else if (exp == 31) {
+                            exp = 255;
+                        } else {
+                            exp = exp - 15 + 127;
+                        }
+                        uint32_t f = sign | (exp << 23) | (mant << 13);
+                        return *reinterpret_cast<float*>(&f);
+                    };
+                    uint16_t* hf = reinterpret_cast<uint16_t*>(srcPixel);
+                    r = FloatToByte(halfToFloat(hf[0]));
+                    g = FloatToByte(halfToFloat(hf[1]));
+                    b = FloatToByte(halfToFloat(hf[2]));
+                    a = FloatToByte(halfToFloat(hf[3]));
+                    break;
+                }
+                case InGameOverlay::ScreenshotDataFormat_t::R16G16B16A16_UNORM: {
+                    uint16_t* un = reinterpret_cast<uint16_t*>(srcPixel);
+                    r = Unorm16ToByte(un[0]);
+                    g = Unorm16ToByte(un[1]);
+                    b = Unorm16ToByte(un[2]);
+                    a = Unorm16ToByte(un[3]);
+                    break;
+                }
+                case InGameOverlay::ScreenshotDataFormat_t::R32G32B32A32_FLOAT: {
+                    float* fl = reinterpret_cast<float*>(srcPixel);
+                    r = FloatToByte(fl[0]);
+                    g = FloatToByte(fl[1]);
+                    b = FloatToByte(fl[2]);
+                    a = FloatToByte(fl[3]);
+                    break;
+                }
+
+                default:
+                    // Unknown or unsupported format: default to standard RGBA (4 bytes)
+                    r = srcPixel[0];
+                    g = srcPixel[1];
+                    b = srcPixel[2];
+                    a = srcPixel[3];
+                    break;
+            }
+
+            dst[0] = r;
+            dst[1] = g;
+            dst[2] = b;
+            if (outChannels == 4) {
+                dst[3] = a;
+            }
+            dst += outChannels;
+            srcPixel += screenshot->PixelSize;
+        }
+        srcRow += screenshot->Pitch;
+    }
+
+    return outData;
+}
+
+} // namespace ScreenshotFormat
+
+#endif // EMU_OVERLAY

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -1660,6 +1660,9 @@ static void parse_overlay_general_config(class Settings *settings_client, class 
     settings_client->overlay_always_show_playtime = ini.GetBoolValue("overlay::general", "overlay_always_show_playtime", settings_client->overlay_always_show_playtime);
     settings_server->overlay_always_show_playtime = ini.GetBoolValue("overlay::general", "overlay_always_show_playtime", settings_server->overlay_always_show_playtime);
 
+    settings_client->enable_screenshot = ini.GetBoolValue("overlay::general", "enable_screenshot", settings_client->enable_screenshot);
+    settings_server->enable_screenshot = ini.GetBoolValue("overlay::general", "enable_screenshot", settings_server->enable_screenshot);
+
     {
         auto val = ini.GetLongValue("overlay::general", "fps_averaging_window", settings_client->overlay_fps_avg_window);
         if (val > 0) {

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -217,6 +217,23 @@ static void parse_overlay_hotkeys(class Settings *settings_client, class Setting
         settings_client->overlay_toggle_keys = combo;
         settings_server->overlay_toggle_keys = combo;
     }
+
+    auto screenshot_str = ini.GetValue("overlay::hotkeys", "screenshot_combo", "f12");
+    if (screenshot_str && screenshot_str[0]) {
+        auto combo = common_helpers::str_split(screenshot_str, "+");
+        std::for_each(combo.begin(), combo.end(),
+            [](std::string &item){ item = common_helpers::str_strip(item); }
+        );
+        combo.erase(
+            std::remove_if(
+                combo.begin(), combo.end(),
+                [](const std::string& item) { return item.empty(); }
+            ),
+            combo.end()
+        );
+        settings_client->overlay_screenshot_keys = combo;
+        settings_server->overlay_screenshot_keys = combo;
+    }
 }
 
 // overlay::appearance
@@ -374,6 +391,10 @@ static void load_overlay_appearance(class Settings *settings_client, class Setti
                 uint32 time = (uint32)(std::stof(value, NULL) * 1000.0f); // convert sec to milli
                 settings_client->overlay_appearance.notification_duration_chat = time;
                 settings_server->overlay_appearance.notification_duration_chat = time;
+            } else if (name.compare("Notification_Duration_Screenshot") == 0) {
+                uint32 time = (uint32)(std::stof(value, NULL) * 1000.0f); // convert sec to milli
+                settings_client->overlay_appearance.notification_duration_screenshot = time;
+                settings_server->overlay_appearance.notification_duration_screenshot = time;
             } else if (name.compare("Achievement_Unlock_Datetime_Format") == 0) {
                 settings_client->overlay_appearance.ach_unlock_datetime_format = value;
                 settings_server->overlay_appearance.ach_unlock_datetime_format = value;

--- a/dll/steam_screenshots.cpp
+++ b/dll/steam_screenshots.cpp
@@ -104,8 +104,10 @@ void Steam_Screenshots::TriggerScreenshot()
     if (hooked) {
         ScreenshotRequested_t data;
         callbacks->addCBResult(data.k_iCallback, &data, sizeof(data));
+    } else if (overlay_take_screenshot) {
+        overlay_take_screenshot();
     } else {
-        PRINT_DEBUG("  TODO: Make the overlay take a screenshot");
+        PRINT_DEBUG("  No overlay available to take screenshot");
     }
 }
 

--- a/overlay_experimental/overlay/steam_overlay.h
+++ b/overlay_experimental/overlay/steam_overlay.h
@@ -226,11 +226,26 @@ class Steam_Overlay
     int preview_index = -1;
     bool preview_open_active = false;       // true between OpenPopup and explicit close
     bool preview_delete_pending = false;    // true while inline delete confirmation is shown in preview
+    bool preview_crop_mode = false;         // true while the crop editor is open inside the preview
+    ImVec4 preview_crop_rect = { 0, 0, 0, 0 };        // current selection in source pixels (0,0,0,0 = full image)
+    ImVec4 preview_crop_rect_prev = { 0, 0, 0, 0 };   // saved on entering crop mode (for Cancel)
     bool delete_confirm_open_active = false;
 
     bool show_delete_confirmation = false;
     bool delete_all_selected = false;
     std::string single_delete_path;
+
+    // Drag state for the crop-rectangle editor. Used by both the pin and the
+    // preview crop flows. `handle` follows the same convention as in the
+    // editor implementation: 0..3 = corners (TL, TR, BR, BL), 4..7 = edge
+    // midpoints (T, R, B, L), 8 = body move, -1 = none.
+    struct CropDragState {
+        bool dragging = false;
+        ImVec2 start = { 0, 0 };
+        int handle = -1;
+        ImVec2 anchor = { 0, 0 };        // opposite corner / body offset
+        int handle_hover = -1;            // -1 = none
+    };
 
     struct PinnedScreenshot {
         uint64_t id;                              // unique per-pin ID for ImGui window identity
@@ -243,8 +258,13 @@ class Steam_Overlay
         ImVec2 pos = { 100, 100 };
         ImVec2 size = { 320, 180 };
         ImVec2 image_disp = { 0, 0 };             // actual image display size (capped by aspect ratio)
+        ImVec2 last_outer = { 0, 0 };             // actual window outer size from last frame (drift guard)
         bool focus_requested = false;              // true to bring window to front on next frame
         bool open = true;                          // tracks window close-button (X) state
+        ImVec4 crop_rect = { 0, 0, 0, 0 };         // crop region (x0,y0,x1,y1) in source pixels; (0,0,0,0) = no crop (show full image)
+        ImVec4 crop_rect_prev = { 0, 0, 0, 0 };    // saved crop_rect when entering crop mode (for Cancel)
+        bool crop_mode = false;                    // true while the crop editor is open for this pin
+        CropDragState crop_drag{};                 // per-pin drag state for the crop editor
     };
 
     std::vector<PinnedScreenshot> pinned_screenshots{};
@@ -299,6 +319,24 @@ class Steam_Overlay
     void unpin_screenshot(uint64_t id);
     // Removes all pinned screenshots (cleans up GPU resources).
     void unpin_all_screenshots();
+
+    // Drag state for the crop-rectangle editor. The pin version lives inside
+    // PinnedScreenshot (per-pin); the preview version is shared since only
+    // one preview exists at a time.
+    CropDragState preview_crop_drag{};
+
+    // Renders the crop-rectangle editor over a displayed image. `rect` is
+    // (x0, y0, x1, y1) in source pixels and is mutated in place. `tex_id` is
+    // the texture resource; it's used to redraw the image inside the
+    // selection area so the dim overlay outside doesn't cover it. Returns
+    // Active while the user keeps editing, Confirm when the Confirm button
+    // is clicked (caller applies the crop), Cancel when Cancel is clicked
+    // (caller discards).
+    enum class CropAction { Active, Confirm, Cancel };
+    CropAction render_crop_editor(ImVec4& rect, CropDragState& st,
+                                  ImTextureID tex_id,
+                                  uint32_t src_w, uint32_t src_h,
+                                  ImVec2 img_min, ImVec2 img_size);
 
     static void on_screenshot_captured(const InGameOverlay::ScreenshotCallbackParameter_t* screenshot, void* userParameter);
 

--- a/overlay_experimental/overlay/steam_overlay.h
+++ b/overlay_experimental/overlay/steam_overlay.h
@@ -61,7 +61,6 @@ enum class notification_type
     achievement,
     achievement_progress,
     auto_accept_invite,
-    game_update,
     screenshot,
 };
 

--- a/overlay_experimental/overlay/steam_overlay.h
+++ b/overlay_experimental/overlay/steam_overlay.h
@@ -61,6 +61,8 @@ enum class notification_type
     achievement,
     achievement_progress,
     auto_accept_invite,
+    game_update,
+    screenshot,
 };
 
 struct Overlay_Achievement
@@ -193,6 +195,66 @@ class Steam_Overlay
     int renderer_hook_timeout_ctr{};
 
     std::vector<InGameOverlay::ToggleKey> toggle_keys{};
+    std::vector<InGameOverlay::ToggleKey> screenshot_keys{};
+
+    struct ScreenshotItem {
+        std::string filename;
+        std::string full_path;
+        InGameOverlay::RendererResource_t* texture = nullptr;
+        // Keep pixel data alive until the GPU has consumed it (AttachResource does NOT own the data)
+        std::vector<uint8_t> thumbnail_pixels{};
+        bool selected = false;
+        bool failed_to_load = false;
+        time_t mtime = 0;  // file modification time, 0 = unknown
+    };
+
+    struct CapturedScreenshot {
+        uint32_t width;
+        uint32_t height;
+        std::vector<uint8_t> pixels_rgb;
+    };
+
+    std::vector<ScreenshotItem> screenshot_items{};
+    bool screenshots_loaded = false;
+    bool show_screenshots_window = false;
+    std::string preview_screenshot_path{};
+    InGameOverlay::RendererResource_t* preview_texture = nullptr;
+    // Persistent storage for preview/pin pixel data (AttachResource does NOT own the data)
+    std::vector<uint8_t> preview_pixels{};
+    uint32_t preview_pixels_w = 0;
+    uint32_t preview_pixels_h = 0;
+    int preview_index = -1;
+    bool preview_open_active = false;       // true between OpenPopup and explicit close
+    bool preview_delete_pending = false;    // true while inline delete confirmation is shown in preview
+    bool delete_confirm_open_active = false;
+
+    bool show_delete_confirmation = false;
+    bool delete_all_selected = false;
+    std::string single_delete_path;
+
+    struct PinnedScreenshot {
+        uint64_t id;                              // unique per-pin ID for ImGui window identity
+        std::string path;
+        InGameOverlay::RendererResource_t* texture = nullptr;
+        std::vector<uint8_t> pixels;
+        uint32_t pixels_w = 0, pixels_h = 0;
+        float opacity = 1.0f;
+        bool pos_set = false;
+        ImVec2 pos = { 100, 100 };
+        ImVec2 size = { 320, 180 };
+        ImVec2 image_disp = { 0, 0 };             // actual image display size (capped by aspect ratio)
+        bool focus_requested = false;              // true to bring window to front on next frame
+        bool open = true;                          // tracks window close-button (X) state
+    };
+
+    std::vector<PinnedScreenshot> pinned_screenshots{};
+    uint64_t next_pin_id = 1;
+
+    // Maximum dimension (px) for a context-menu-initiated pin. Generous — modern monitors are large.
+    static constexpr float kContextPinMaxDim = 800.0f;
+
+    std::vector<CapturedScreenshot> captured_screenshots_queue{};
+    std::mutex captured_screenshots_mutex{};
 
     // font stuff - now supporting independent font sizes
     ImFontAtlas fonts_atlas{};
@@ -219,12 +281,26 @@ class Steam_Overlay
     Steam_Overlay& operator=(Steam_Overlay&&) = delete;
 
     void parse_key_combo();
+    void parse_screenshot_key_combo();
     bool submit_notification(
         notification_type type,
         const std::string &msg,
         std::pair<const Friend, friend_window_state> *frd = nullptr,
         Overlay_Achievement *ach = nullptr
     );
+
+    void refresh_screenshots_list();
+    void render_gallery_window();
+    void render_pinned_screenshot();
+    void process_captured_screenshots();
+    // Clears all preview-popup state (path, index, texture, pixels). Does NOT call CloseCurrentPopup.
+    void clear_preview_state();
+    // Removes a single pinned screenshot by ID (cleans up GPU resources).
+    void unpin_screenshot(uint64_t id);
+    // Removes all pinned screenshots (cleans up GPU resources).
+    void unpin_all_screenshots();
+
+    static void on_screenshot_captured(const InGameOverlay::ScreenshotCallbackParameter_t* screenshot, void* userParameter);
 
     void notify_sound_user_invite(friend_window_state& friend_state);
     void notify_sound_user_achievement();

--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -1551,7 +1551,7 @@ void Steam_Overlay::overlay_render_proc()
     process_achievement_queue();
 
     // -- Screenshot hotkey detection --
-    if (_renderer && !screenshot_keys.empty()) {
+    if (_renderer && settings->enable_screenshot && !screenshot_keys.empty()) {
 #ifdef __WINDOWS__
         // Only respond when the game window is focused
         {

--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -14,11 +14,25 @@
 #include <utility>
 #include <unordered_set>
 #include <unordered_map>
+#include <algorithm>
+#include <shellapi.h>
+#include <sys/stat.h>
 
 #include "InGameOverlay/RendererDetector.h"
 
 #include "dll/dll.h"
 #include "dll/settings_parser.h"
+#include "dll/screenshot_format.h"
+
+// image loading for gallery thumbnails
+// local_storage.cpp already defines the IMPLEMENTATION with _STATIC,
+// so we must do the same here to avoid linker errors (each .obj gets its own private copy).
+#define STB_IMAGE_STATIC
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb/stb_image.h"
+#define STB_IMAGE_RESIZE_STATIC
+#define STB_IMAGE_RESIZE_IMPLEMENTATION
+#include "stb/stb_image_resize2.h"
 
 // translation
 #include "overlay/steam_overlay_translations.h"
@@ -141,6 +155,55 @@ void Steam_Overlay::parse_key_combo()
     }
 }
 
+void Steam_Overlay::parse_screenshot_key_combo()
+{
+    static const std::unordered_map<InGameOverlay::ToggleKey, std::string_view> KEYS_MAP {
+        { InGameOverlay::ToggleKey::SHIFT, "shift" },
+        { InGameOverlay::ToggleKey::CTRL,  "ctrl"  },
+        { InGameOverlay::ToggleKey::ALT,   "alt"   },
+        { InGameOverlay::ToggleKey::TAB,   "tab"   },
+        { InGameOverlay::ToggleKey::F1,    "fn1"   },
+        { InGameOverlay::ToggleKey::F2,    "fn2"   },
+        { InGameOverlay::ToggleKey::F3,    "fn3"   },
+        { InGameOverlay::ToggleKey::F4,    "fn4"   },
+        { InGameOverlay::ToggleKey::F5,    "fn5"   },
+        { InGameOverlay::ToggleKey::F6,    "fn6"   },
+        { InGameOverlay::ToggleKey::F7,    "fn7"   },
+        { InGameOverlay::ToggleKey::F8,    "fn8"   },
+        { InGameOverlay::ToggleKey::F9,    "fn9"   },
+        { InGameOverlay::ToggleKey::F10,   "fn10"  },
+        { InGameOverlay::ToggleKey::F11,   "fn11"  },
+        { InGameOverlay::ToggleKey::F12,   "fn12"  },
+    };
+
+    std::unordered_set<InGameOverlay::ToggleKey> keys_combo{};
+    bool use_default = false;
+    if (settings->overlay_screenshot_keys.empty()) {
+        use_default = true;
+    } else {
+        for (const auto &key_name : settings->overlay_screenshot_keys) {
+            auto key_it = std::find_if(KEYS_MAP.cbegin(), KEYS_MAP.cend(), [&key_name](decltype(*KEYS_MAP.cbegin()) const &item) {
+                return common_helpers::str_cmp_insensitive(item.second, key_name);
+            });
+            if (KEYS_MAP.cend() != key_it) {
+                keys_combo.insert(key_it->first);
+            } else {
+                use_default = true;
+                PRINT_DEBUG("[X] Unknown screenshot key '%s', using default F12", key_name.c_str());
+                break;
+            }
+        }
+    }
+
+    if (use_default) {
+        screenshot_keys = {
+            InGameOverlay::ToggleKey::F12
+        };
+    } else {
+        screenshot_keys = std::vector<InGameOverlay::ToggleKey>(keys_combo.begin(), keys_combo.end());
+    }
+}
+
 Steam_Overlay::Steam_Overlay(Settings* settings, Local_Storage *local_storage, SteamCallResults* callback_results, SteamCallBacks* callbacks, RunEveryRunCB* run_every_runcb, Networking* network) :
     settings(settings),
     local_storage(local_storage),
@@ -173,6 +236,7 @@ Steam_Overlay::Steam_Overlay(Settings* settings, Local_Storage *local_storage, S
     );
 
     parse_key_combo();
+    parse_screenshot_key_combo();
     strncpy(username_text, settings->get_local_name(), sizeof(username_text));
 
     // we need these copies to show the warning only once, then disable the flag
@@ -271,6 +335,14 @@ bool Steam_Overlay::renderer_hook_proc()
 
     bool started = _renderer->StartHook(overlay_toggle_callback, toggle_keys.data(), (int)toggle_keys.size(), &fonts_atlas);
     PRINT_DEBUG("started renderer hook (result=%i)", (int)started);
+
+    // Register screenshot callback
+    _renderer->SetScreenshotCallback(&Steam_Overlay::on_screenshot_captured, this);
+
+    // Wire up TriggerScreenshot API to use the overlay renderer
+    get_steam_client()->steam_screenshots->overlay_take_screenshot = [this]() {
+        if (_renderer) _renderer->TakeScreenshot(InGameOverlay::ScreenshotType_t::BeforeOverlay);
+    };
 
     return true;
 }
@@ -692,6 +764,8 @@ bool Steam_Overlay::submit_notification(
         case notification_type::achievement:
         case notification_type::auto_accept_invite:
         case notification_type::message:
+        case notification_type::game_update:
+        case notification_type::screenshot:
             // nothing
         break;
 
@@ -914,6 +988,12 @@ std::chrono::milliseconds Steam_Overlay::get_notification_duration(notification_
 
     case notification_type::auto_accept_invite:
         return Notification::default_show_time;
+
+    case notification_type::game_update:
+        return std::chrono::hours(24); // stay until user clicks a button
+
+    case notification_type::screenshot:
+        return std::chrono::milliseconds(settings->overlay_appearance.notification_duration_screenshot);
     }
 
     PRINT_DEBUG("ERROR unhandled type %i", (int)type);
@@ -1160,7 +1240,9 @@ void Steam_Overlay::build_notifications(float width, float height)
             break;
 
             case notification_type::invite:
-                // nothing
+            case notification_type::game_update:
+            case notification_type::screenshot:
+                // nothing (needs input for buttons)
             break;
 
             default:
@@ -1233,6 +1315,7 @@ void Steam_Overlay::build_notifications(float width, float height)
                 break;
 
                 case notification_type::auto_accept_invite:
+                case notification_type::screenshot:
                     ImGui::TextWrapped("%s", it->message.c_str());
                 break;
 
@@ -1268,6 +1351,8 @@ void Steam_Overlay::build_notifications(float width, float height)
                 case notification_type::achievement:
                 case notification_type::auto_accept_invite:
                 case notification_type::message:
+                case notification_type::game_update:
+                case notification_type::screenshot:
                     // nothing
                 break;
 
@@ -1466,9 +1551,124 @@ void Steam_Overlay::overlay_render_proc()
     // Process achievement queue to show scheduled notifications
     process_achievement_queue();
 
+    // -- Screenshot hotkey detection --
+    if (_renderer && !screenshot_keys.empty()) {
+#ifdef __WINDOWS__
+        // Map ToggleKey to Windows VK codes and check state
+        auto toggleKeyToVK = [](InGameOverlay::ToggleKey key) -> int {
+            switch (key) {
+                case InGameOverlay::ToggleKey::SHIFT: return VK_SHIFT;
+                case InGameOverlay::ToggleKey::CTRL:  return VK_CONTROL;
+                case InGameOverlay::ToggleKey::ALT:   return VK_MENU;
+                case InGameOverlay::ToggleKey::TAB:   return VK_TAB;
+                case InGameOverlay::ToggleKey::F1:    return VK_F1;
+                case InGameOverlay::ToggleKey::F2:    return VK_F2;
+                case InGameOverlay::ToggleKey::F3:    return VK_F3;
+                case InGameOverlay::ToggleKey::F4:    return VK_F4;
+                case InGameOverlay::ToggleKey::F5:    return VK_F5;
+                case InGameOverlay::ToggleKey::F6:    return VK_F6;
+                case InGameOverlay::ToggleKey::F7:    return VK_F7;
+                case InGameOverlay::ToggleKey::F8:    return VK_F8;
+                case InGameOverlay::ToggleKey::F9:    return VK_F9;
+                case InGameOverlay::ToggleKey::F10:   return VK_F10;
+                case InGameOverlay::ToggleKey::F11:   return VK_F11;
+                case InGameOverlay::ToggleKey::F12:   return VK_F12;
+                default: return 0;
+            }
+        };
+
+        bool all_pressed = true;
+        for (auto k : screenshot_keys) {
+            int vk = toggleKeyToVK(k);
+            if (!vk || !(GetAsyncKeyState(vk) & 0x8000)) {
+                all_pressed = false;
+                break;
+            }
+        }
+
+        // Rising edge detection + cooldown (1 second).
+        // `prev_initialized` ensures we don't fire a false trigger on the first call when the
+        // user happens to be holding the hotkey when the overlay is first loaded.
+        static bool prev_screenshot_keys = false;
+        static bool prev_initialized = false;
+        static std::chrono::steady_clock::time_point last_screenshot_time_local{};
+        auto now_local = std::chrono::steady_clock::now();
+        bool rising_edge = false;
+        if (prev_initialized) {
+            rising_edge = all_pressed && !prev_screenshot_keys;
+        }
+        prev_screenshot_keys = all_pressed;
+        prev_initialized = true;
+
+        if (rising_edge && (now_local - last_screenshot_time_local) > std::chrono::seconds(1)) {
+            last_screenshot_time_local = now_local;
+            PRINT_DEBUG("Screenshot hotkey triggered");
+            _renderer->TakeScreenshot(InGameOverlay::ScreenshotType_t::BeforeOverlay);
+        }
+#else
+        // Non-Windows: use ToggleKey to ImGui mapping
+        auto toggleKeyToImGui = [](InGameOverlay::ToggleKey key) -> ImGuiKey {
+            switch (key) {
+                case InGameOverlay::ToggleKey::SHIFT: return ImGuiKey_LeftShift;
+                case InGameOverlay::ToggleKey::CTRL:  return ImGuiKey_LeftCtrl;
+                case InGameOverlay::ToggleKey::ALT:   return ImGuiKey_LeftAlt;
+                case InGameOverlay::ToggleKey::TAB:   return ImGuiKey_Tab;
+                case InGameOverlay::ToggleKey::F1:    return ImGuiKey_F1;
+                case InGameOverlay::ToggleKey::F2:    return ImGuiKey_F2;
+                case InGameOverlay::ToggleKey::F3:    return ImGuiKey_F3;
+                case InGameOverlay::ToggleKey::F4:    return ImGuiKey_F4;
+                case InGameOverlay::ToggleKey::F5:    return ImGuiKey_F5;
+                case InGameOverlay::ToggleKey::F6:    return ImGuiKey_F6;
+                case InGameOverlay::ToggleKey::F7:    return ImGuiKey_F7;
+                case InGameOverlay::ToggleKey::F8:    return ImGuiKey_F8;
+                case InGameOverlay::ToggleKey::F9:    return ImGuiKey_F9;
+                case InGameOverlay::ToggleKey::F10:   return ImGuiKey_F10;
+                case InGameOverlay::ToggleKey::F11:   return ImGuiKey_F11;
+                case InGameOverlay::ToggleKey::F12:   return ImGuiKey_F12;
+                default: return ImGuiKey_None;
+            }
+        };
+
+        bool all_pressed = true;
+        for (auto k : screenshot_keys) {
+            ImGuiKey ik = toggleKeyToImGui(k);
+            if (ik == ImGuiKey_None || !ImGui::IsKeyDown(ik)) {
+                all_pressed = false;
+                break;
+            }
+        }
+
+        // Rising edge detection + cooldown (1 second). Skip the first frame so we don't
+        // trigger a false-positive if the user is already holding the hotkey.
+        static bool prev_screenshot_keys = false;
+        static bool prev_initialized = false;
+        static std::chrono::steady_clock::time_point last_screenshot_time_local{};
+        auto now_local = std::chrono::steady_clock::now();
+        bool rising_edge = false;
+        if (prev_initialized) {
+            rising_edge = all_pressed && !prev_screenshot_keys;
+        }
+        prev_screenshot_keys = all_pressed;
+        prev_initialized = true;
+
+        if (rising_edge && (now_local - last_screenshot_time_local) > std::chrono::seconds(1)) {
+            last_screenshot_time_local = now_local;
+            PRINT_DEBUG("Screenshot hotkey triggered");
+            _renderer->TakeScreenshot(InGameOverlay::ScreenshotType_t::BeforeOverlay);
+        }
+#endif
+    }
+
+    // Process any captured screenshots and save them to disk
+    process_captured_screenshots();
+
     if (show_overlay) {
         render_main_window();
+        render_gallery_window();
     }
+
+    // Pinned screenshot (always rendered when active, click-through when overlay closed)
+    render_pinned_screenshot();
 
     if (notifications.size()) {
         ImGuiIO &io = ImGui::GetIO();
@@ -1622,6 +1822,12 @@ void Steam_Overlay::render_main_window()
             show_notification_history = !show_notification_history;
         }
 
+        ImGui::SameLine();
+        // user clicked on "Screenshots"
+        if (ImGui::Button("Screenshots")) {
+            show_screenshots_window = !show_screenshots_window;
+        }
+
         ImGui::Spacing();
         ImGui::Spacing();
         // user clicked on "FPS"
@@ -1682,6 +1888,8 @@ void Steam_Overlay::render_main_window()
                             case notification_type::achievement: type_label = "Achievement"; break;
                             case notification_type::achievement_progress: type_label = "Progress"; break;
                             case notification_type::auto_accept_invite: type_label = "Auto-Invite"; break;
+                            case notification_type::game_update: type_label = "Update"; break;
+                            case notification_type::screenshot: type_label = "Screenshot"; break;
                         }
 
                         // For achievements the message contains "title\ndescription"
@@ -2061,6 +2269,26 @@ void Steam_Overlay::UnSetupOverlay()
                     ach.icon_gray->Unload();
                 }
             }
+
+            // Unload screenshot textures
+            for (auto &item : screenshot_items) {
+                if (item.texture) {
+                    if (item.texture->GetResourceId() != 0)
+                        item.texture->Unload();
+                    item.texture->Delete();
+                }
+            }
+            screenshot_items.clear();
+            preview_pixels.clear();
+            preview_pixels_w = 0;
+            preview_pixels_h = 0;
+            if (preview_texture) {
+                if (preview_texture->GetResourceId() != 0)
+                    preview_texture->Unload();
+                preview_texture->Delete();
+                preview_texture = nullptr;
+            }
+            unpin_all_screenshots();
 
             // manually calling this dtor looks bad, but it actually prevents a lot of crashes on exit, don't remove it!
             // many DX12 games will crash on exit if the hook wasn't manually removed (ex appid 2933080, 1583230)
@@ -2502,6 +2730,825 @@ void Steam_Overlay::networking_msg_received(Common_Message *msg)
             notify_sound_user_invite(friend_info->second);
         }
     }
+}
+
+// -- Screenshot capture callback --
+void Steam_Overlay::on_screenshot_captured(const InGameOverlay::ScreenshotCallbackParameter_t* screenshot, void* userParameter)
+{
+    auto* self = static_cast<Steam_Overlay*>(userParameter);
+    if (!screenshot || !screenshot->Data || screenshot->Width == 0 || screenshot->Height == 0)
+        return;
+
+    auto pixels = ScreenshotFormat::ConvertToRGBA(screenshot, 4);
+    if (pixels.empty())
+        return;
+
+    CapturedScreenshot item;
+    item.width = screenshot->Width;
+    item.height = screenshot->Height;
+    item.pixels_rgb = std::move(pixels);
+
+    std::lock_guard<std::mutex> lock(self->captured_screenshots_mutex);
+    self->captured_screenshots_queue.push_back(std::move(item));
+}
+
+void Steam_Overlay::process_captured_screenshots()
+{
+    std::vector<CapturedScreenshot> batch;
+    {
+        std::lock_guard<std::mutex> lock(captured_screenshots_mutex);
+        if (captured_screenshots_queue.empty()) return;
+        batch.swap(captured_screenshots_queue);
+    }
+
+    for (auto& item : batch) {
+        char buff[128];
+        auto now = std::chrono::system_clock::now();
+        auto now_time = std::chrono::system_clock::to_time_t(now);
+        struct tm local_tm{};
+#ifdef _MSC_VER
+        localtime_s(&local_tm, &now_time);
+#else
+        localtime_r(&now_time, &local_tm);
+#endif
+        std::strftime(buff, sizeof(buff), "%a_%b_%d_%H_%M_%S_%Y", &local_tm);
+        std::string filename = buff;
+        filename += ".png";
+
+        if (local_storage->save_screenshot(filename, item.pixels_rgb.data(), item.width, item.height, 4)) {
+            PRINT_DEBUG("Screenshot saved: %s", filename.c_str());
+            submit_notification(notification_type::screenshot, "Screenshot saved: " + filename);
+        } else {
+            PRINT_DEBUG("Failed to save screenshot!");
+        }
+    }
+
+    refresh_screenshots_list();
+}
+
+// -- Screenshots directory scanning --
+void Steam_Overlay::refresh_screenshots_list()
+{
+    // Unload existing textures
+    for (auto& item : screenshot_items) {
+        if (item.texture) {
+            if (item.texture->GetResourceId() != 0)
+                item.texture->Unload();
+            item.texture->Delete();
+        }
+    }
+    screenshot_items.clear();
+
+    std::string path = local_storage->get_path(Local_Storage::screenshots_folder);
+    auto filenames = Local_Storage::get_filenames_path(path);
+
+    for (auto& f : filenames) {
+        if (f.size() < 4) continue;
+        std::string ext = f.substr(f.size() - 4);
+        if (ext != ".png" && ext != ".PNG") continue;
+
+        ScreenshotItem item;
+        item.filename = f;
+        item.full_path = path + PATH_SEPARATOR + f;
+        // Read file modification time
+#ifdef _MSC_VER
+        struct _stat st;
+        if (_stat(item.full_path.c_str(), &st) == 0)
+            item.mtime = st.st_mtime;
+#else
+        struct stat st;
+        if (stat(item.full_path.c_str(), &st) == 0)
+            item.mtime = st.st_mtime;
+#endif
+        if (_renderer)
+            item.texture = _renderer->CreateResource();
+        screenshot_items.push_back(std::move(item));
+    }
+
+    // Sort oldest first so the gallery shows screenshots in chronological order
+    std::sort(screenshot_items.begin(), screenshot_items.end(),
+              [](const ScreenshotItem& a, const ScreenshotItem& b) {
+                  return a.mtime < b.mtime;
+              });
+
+    screenshots_loaded = true;
+}
+
+// -- Preview popup state cleanup --
+// Releases the preview's GPU texture and resets all state flags. Callers are responsible
+// for calling ImGui::CloseCurrentPopup() (or doing so in the same scope) if the popup is
+// currently open — this helper only tears down the C++ state.
+void Steam_Overlay::clear_preview_state()
+{
+    preview_screenshot_path.clear();
+    preview_open_active = false;
+    preview_delete_pending = false;
+    preview_index = -1;
+    if (preview_texture) {
+        if (preview_texture->GetResourceId() != 0)
+            preview_texture->Unload();
+        preview_texture->Delete();
+        preview_texture = nullptr;
+    }
+    preview_pixels.clear();
+    preview_pixels_w = 0;
+    preview_pixels_h = 0;
+}
+
+// -- Gallery window --
+void Steam_Overlay::render_gallery_window()
+{
+    if (!show_screenshots_window) return;
+
+    ImGui::PushFont(font_default);
+    uint32 style_color_stack = apply_global_style_color();
+
+    ImGui::SetNextWindowSizeConstraints(ImVec2(400, 300), ImVec2(8192, 8192));
+    ImGui::SetNextWindowSize(ImVec2(700, 500), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowBgAlpha(1.0f);
+    if (ImGui::Begin("Screenshots", &show_screenshots_window)) {
+        // Delete/Unpin toolbar
+        bool has_selection = false;
+        for (auto& item : screenshot_items) {
+            if (item.selected) { has_selection = true; break; }
+        }
+
+        if (!pinned_screenshots.empty()) {
+            if (ImGui::SmallButton("Unpin all")) {
+                unpin_all_screenshots();
+            }
+            ImGui::SameLine();
+        }
+
+        if (has_selection) {
+            if (ImGui::SmallButton("Delete selected")) {
+                delete_all_selected = true;
+                show_delete_confirmation = true;
+                delete_confirm_open_active = true;
+            }
+            ImGui::SameLine();
+        }
+
+        if (!screenshot_items.empty()) {
+            if (ImGui::SmallButton("Refresh")) {
+                refresh_screenshots_list();
+            }
+        }
+
+        ImGui::Separator();
+
+        if (screenshot_items.empty()) {
+            if (!screenshots_loaded)
+                refresh_screenshots_list();
+            if (screenshot_items.empty()) {
+                ImGui::TextDisabled("No screenshots yet");
+            }
+        }
+
+        // Thumbnail grid — use a fixed-column-count table so items don't
+        // slide around when the window is resized.  Each column is sized
+        // to exactly one thumbnail + checkbox + small gap.
+        if (!screenshot_items.empty()) {
+            const float thumb_width  = 160.0f;
+            const float thumb_height = 90.0f;
+            const float check_w = ImGui::GetFrameHeight()
+                                  + ImGui::GetStyle().FramePadding.x * 2.0f;
+            const float cell_w = thumb_width + check_w
+                                 + ImGui::GetStyle().ItemSpacing.x;
+
+            float avail_x = ImGui::GetContentRegionAvail().x;
+            int columns = std::max(1, (int)(avail_x / cell_w));
+
+            if (ImGui::BeginTable("##screenshot_grid", columns,
+                    ImGuiTableFlags_SizingFixedFit)) {
+                // Each column gets the same fixed width so the grid doesn't
+                // reflow on tiny width changes.
+                for (int c = 0; c < columns; ++c) {
+                    ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed, cell_w);
+                }
+                for (int idx = 0; idx < (int)screenshot_items.size(); ++idx) {
+                    ImGui::TableNextColumn();
+
+                    auto& item = screenshot_items[idx];
+                    ImGui::PushID(item.filename.c_str());
+
+                // Load thumbnail texture lazily
+                if (item.texture && item.texture->GetResourceId() == 0 && !item.failed_to_load) {
+                    int img_w = 0, img_h = 0;
+                    unsigned char* img = stbi_load(item.full_path.c_str(), &img_w, &img_h, nullptr, 4);
+                    if (img) {
+                        item.thumbnail_pixels.assign((size_t)thumb_width * (size_t)thumb_height * 4, 0);
+                        stbir_resize_uint8_linear(img, img_w, img_h, 0,
+                            item.thumbnail_pixels.data(), (int)thumb_width, (int)thumb_height, 0, STBIR_RGBA);
+                        item.texture->AttachResource(item.thumbnail_pixels.data(), (uint32_t)thumb_width, (uint32_t)thumb_height);
+                        stbi_image_free(img);
+                    } else {
+                        item.failed_to_load = true;
+                    }
+                }
+
+                // Thumbnail image button
+                if (item.texture && item.texture->GetResourceId() != 0) {
+                    if (ImGui::ImageButton("##thumb", item.texture->GetResourceId(), ImVec2(thumb_width, thumb_height))) {
+                        preview_index = idx;
+                        preview_screenshot_path = item.full_path;
+                    }
+                } else {
+                    ImGui::InvisibleButton("##thumb_placeholder", ImVec2(thumb_width, thumb_height));
+                }
+
+                // Right-click context menu
+                if (ImGui::BeginPopupContextItem("##screenshot_ctx")) {
+                    if (ImGui::Selectable("Pin")) {
+                        PinnedScreenshot pin;
+                        pin.id = next_pin_id++;
+                        pin.path = item.full_path;
+
+                        int img_w = 0, img_h = 0;
+                        unsigned char* img = stbi_load(item.full_path.c_str(), &img_w, &img_h, nullptr, 4);
+                        if (img) {
+                            pin.pixels.assign(img, img + ((size_t)img_w * (size_t)img_h * 4));
+                            pin.pixels_w = (uint32_t)img_w;
+                            pin.pixels_h = (uint32_t)img_h;
+                            pin.size = ImVec2((float)img_w, (float)img_h);
+                            if (pin.size.x > kContextPinMaxDim || pin.size.y > kContextPinMaxDim) {
+                                float scale = std::min(kContextPinMaxDim / pin.size.x,
+                                                       kContextPinMaxDim / pin.size.y);
+                                pin.size.x *= scale;
+                                pin.size.y *= scale;
+                            }
+                            if (_renderer) {
+                                pin.texture = _renderer->CreateResource();
+                                pin.texture->AttachResource(pin.pixels.data(), pin.pixels_w, pin.pixels_h);
+                            }
+                            stbi_image_free(img);
+                        }
+                        pin.focus_requested = true;
+                        pinned_screenshots.push_back(std::move(pin));
+                    }
+                    if (ImGui::Selectable("Delete")) {
+                        single_delete_path = item.full_path;
+                        delete_all_selected = false;
+                        show_delete_confirmation = true;
+                        delete_confirm_open_active = true;
+                    }
+                    ImGui::EndPopup();
+                }
+
+                // Checkbox with text beside it, width limited to thumbnail width
+                ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
+                ImGui::Checkbox("##sel", &item.selected);
+                ImGui::PopStyleVar();
+                ImGui::SameLine(0, 0);
+                ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + thumb_width);
+                if (item.mtime > 0) {
+                    char date_buf[32];
+                    struct tm local_tm{};
+#ifdef _MSC_VER
+                    localtime_s(&local_tm, &item.mtime);
+#else
+                    localtime_r(&item.mtime, &local_tm);
+#endif
+                    std::strftime(date_buf, sizeof(date_buf), "%Y-%m-%d-%H:%M", &local_tm);
+                    ImGui::TextUnformatted(date_buf);
+                } else {
+                    ImGui::TextUnformatted(item.filename.c_str());
+                }
+                ImGui::PopTextWrapPos();
+
+                ImGui::PopID();
+            }
+            ImGui::EndTable();
+            }
+        }
+
+        // -- Preview popup --
+        if (!preview_screenshot_path.empty() || preview_open_active) {
+            // Open the popup on the first frame only (not while navigating via Prev/Next)
+            if (!preview_screenshot_path.empty() && !preview_open_active) {
+                ImGui::OpenPopup("Screenshot Preview");
+                preview_open_active = true;
+
+                // Find the index for Prev/Next navigation
+                if (preview_index < 0 || preview_index >= (int)screenshot_items.size() ||
+                    screenshot_items[preview_index].full_path != preview_screenshot_path)
+                {
+                    preview_index = -1;
+                    for (int i = 0; i < (int)screenshot_items.size(); ++i) {
+                        if (screenshot_items[i].full_path == preview_screenshot_path) {
+                            preview_index = i;
+                            break;
+                        }
+                    }
+                }
+                // Set initial window size proportional to display
+                ImVec2 disp = ImGui::GetIO().DisplaySize;
+                ImGui::SetNextWindowSize(ImVec2(disp.x * 0.8f, disp.y * 0.8f), ImGuiCond_Appearing);
+            }
+            // Removed AlwaysAutoResize so the user can resize the preview window.
+            // Center the popup on screen so it never appears at a weird position.
+            ImVec2 disp_center = ImGui::GetIO().DisplaySize;
+            ImGui::SetNextWindowPos(ImVec2(disp_center.x * 0.5f, disp_center.y * 0.5f), ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+            ImGuiWindowFlags preview_flags = ImGuiWindowFlags_NoScrollbar;
+            bool preview_modal_open = true;
+            if (ImGui::BeginPopupModal("Screenshot Preview", &preview_modal_open, preview_flags)) {
+                // Navigate to a different screenshot
+                // (path changed via Prev/Next → unload current texture so it reloads next frame)
+                if (preview_texture && preview_index >= 0 && preview_index < (int)screenshot_items.size() &&
+                    screenshot_items[preview_index].full_path != preview_screenshot_path)
+                {
+                    preview_screenshot_path = screenshot_items[preview_index].full_path;
+                    if (preview_texture) {
+                        if (preview_texture->GetResourceId() != 0)
+                            preview_texture->Unload();
+                        preview_texture->Delete();
+                        preview_texture = nullptr;
+                    }
+                    preview_pixels.clear();
+                    preview_pixels_w = 0;
+                    preview_pixels_h = 0;
+                }
+
+                // Load full-resolution preview texture (not downscaled — scaling is done
+                // at render time so the image fills the user-resizable window)
+                if (preview_texture == nullptr) {
+                    preview_texture = _renderer ? _renderer->CreateResource() : nullptr;
+                }
+                if (preview_texture && preview_texture->GetResourceId() == 0 &&
+                    preview_index >= 0 && preview_index < (int)screenshot_items.size()) {
+                    int img_w = 0, img_h = 0;
+                    unsigned char* img = stbi_load(screenshot_items[preview_index].full_path.c_str(), &img_w, &img_h, nullptr, 4);
+                    if (img) {
+                        preview_pixels.assign(img, img + ((size_t)img_w * (size_t)img_h * 4));
+                        preview_pixels_w = (uint32_t)img_w;
+                        preview_pixels_h = (uint32_t)img_h;
+                        preview_texture->AttachResource(preview_pixels.data(), preview_pixels_w, preview_pixels_h);
+                        stbi_image_free(img);
+                    }
+                }
+
+                // Display image scaled to fit available content, maintaining aspect ratio.
+                bool preview_texture_ok = preview_texture && preview_texture->GetResourceId() != 0 && preview_pixels_w > 0 && preview_pixels_h > 0;
+                if (preview_texture_ok) {
+                    ImVec2 avail = ImGui::GetContentRegionAvail();
+                    // Reserve space for the date + button bar at the bottom
+                    float btn_h = ImGui::GetTextLineHeightWithSpacing() * 3.0f + ImGui::GetStyle().ItemSpacing.y * 4.0f;
+                    avail.y -= btn_h;
+                    float scale = std::min(avail.x / (float)preview_pixels_w, avail.y / (float)preview_pixels_h);
+                    ImVec2 preview_display_size = ImVec2((float)preview_pixels_w * scale, (float)preview_pixels_h * scale);
+                    // Center the image horizontally so portrait images don't leave a gap on the right
+                    float off_x = (avail.x - preview_display_size.x) * 0.5f;
+                    if (off_x > 0) ImGui::SetCursorPosX(ImGui::GetCursorPosX() + off_x);
+                    ImGui::Image(preview_texture->GetResourceId(), preview_display_size);
+
+                    ImGui::Separator();
+
+                    // Screenshot date — only shown when texture is loaded (avoids flash on navigation)
+                    if (!screenshot_items.empty() && preview_index >= 0 && preview_index < (int)screenshot_items.size()) {
+                        auto& src_item = screenshot_items[preview_index];
+                        if (src_item.mtime > 0) {
+                            char time_buf[64];
+                            struct tm local_tm{};
+#ifdef _MSC_VER
+                            localtime_s(&local_tm, &src_item.mtime);
+#else
+                            localtime_r(&src_item.mtime, &local_tm);
+#endif
+                            std::strftime(time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M:%S", &local_tm);
+                            ImGui::TextUnformatted(time_buf);
+                        } else {
+                            ImGui::TextUnformatted(src_item.filename.c_str());
+                        }
+                    }
+
+                    // Button bar: < Prev | Pin  Delete | Next >
+                    ImGui::BeginGroup();
+
+                    // Prev — always visible, wraps to last
+                    if (ImGui::Button("< Prev")) {
+                        if (preview_index <= 0)
+                            preview_index = (int)screenshot_items.size() - 1;
+                        else
+                            preview_index--;
+                    }
+                    ImGui::SameLine();
+
+                    ImGui::Text("|");
+                    ImGui::SameLine();
+
+                    if (ImGui::Button("Pin")) {
+                        PinnedScreenshot pin;
+                        pin.id = next_pin_id++;
+                        pin.path = screenshot_items[preview_index].full_path;
+
+                        // Repurpose the already-loaded preview pixels to avoid a second stbi_load
+                        if (preview_pixels_w > 0 && preview_pixels_h > 0) {
+                            pin.pixels = preview_pixels; // copies — small enough for a single frame
+                            pin.pixels_w = preview_pixels_w;
+                            pin.pixels_h = preview_pixels_h;
+                        } else {
+                            int img_w = 0, img_h = 0;
+                            unsigned char* img = stbi_load(pin.path.c_str(), &img_w, &img_h, nullptr, 4);
+                            if (img) {
+                                pin.pixels.assign(img, img + ((size_t)img_w * (size_t)img_h * 4));
+                                pin.pixels_w = (uint32_t)img_w;
+                                pin.pixels_h = (uint32_t)img_h;
+                                stbi_image_free(img);
+                            }
+                        }
+
+                        // Same initial sizing as context-menu pin (kContextPinMaxDim)
+                        pin.size = ImVec2((float)pin.pixels_w, (float)pin.pixels_h);
+                        if (pin.size.x > kContextPinMaxDim || pin.size.y > kContextPinMaxDim) {
+                            float scale = std::min(kContextPinMaxDim / pin.size.x,
+                                                   kContextPinMaxDim / pin.size.y);
+                            pin.size.x *= scale;
+                            pin.size.y *= scale;
+                        }
+
+                        if (_renderer) {
+                            pin.texture = _renderer->CreateResource();
+                            if (pin.texture && !pin.pixels.empty())
+                                pin.texture->AttachResource(pin.pixels.data(), pin.pixels_w, pin.pixels_h);
+                        }
+                        pin.focus_requested = true;
+                        pinned_screenshots.push_back(std::move(pin));
+
+                        // Leave preview open — pin is immediately visible in its own window
+                    }
+                    ImGui::SameLine();
+
+                    if (!preview_delete_pending && ImGui::Button("Delete")) {
+                        preview_delete_pending = true;
+                    }
+                    ImGui::SameLine();
+
+                    ImGui::Text("|");
+                    ImGui::SameLine();
+
+                    // Next — always visible, wraps to first
+                    if (ImGui::Button("Next >")) {
+                        if (preview_index >= (int)screenshot_items.size() - 1)
+                            preview_index = 0;
+                        else
+                            preview_index++;
+                    }
+
+                    ImGui::EndGroup();
+
+                    // Inline delete confirmation (avoids stacking modals which closes the preview)
+                    if (preview_delete_pending) {
+                        ImGui::Separator();
+                        ImGui::Text("Delete this screenshot?");
+                        ImGui::SameLine();
+                        if (ImGui::Button("Yes")) {
+                            preview_delete_pending = false;
+                            // Perform the delete inline
+                            auto& del_item = screenshot_items[preview_index];
+                            std::string base_path = local_storage->get_path(Local_Storage::screenshots_folder) + PATH_SEPARATOR;
+                            std::string filename;
+                            if (del_item.full_path.find(base_path) == 0) {
+                                filename = del_item.full_path.substr(base_path.size());
+                            } else {
+                                auto pos = del_item.full_path.find_last_of("/\\");
+                                filename = (pos != std::string::npos) ? del_item.full_path.substr(pos + 1) : del_item.full_path;
+                            }
+                            if (!filename.empty()) {
+                                local_storage->file_delete(Local_Storage::screenshots_folder, filename);
+                                std::string json_name = filename.substr(0, filename.size() - 4) + ".json";
+                                local_storage->file_delete(Local_Storage::screenshots_folder, json_name);
+                            }
+                            // Remove pin if the deleted file was pinned
+                            for (auto pit = pinned_screenshots.begin(); pit != pinned_screenshots.end(); ) {
+                                if (pit->path == del_item.full_path) {
+                                    if (pit->texture) {
+                                        if (pit->texture->GetResourceId() != 0)
+                                            pit->texture->Unload();
+                                        pit->texture->Delete();
+                                    }
+                                    pit = pinned_screenshots.erase(pit);
+                                } else {
+                                    ++pit;
+                                }
+                            }
+                            // Refresh and advance to next
+                            refresh_screenshots_list();
+                            if (screenshot_items.empty()) {
+                                ImGui::CloseCurrentPopup();
+                                clear_preview_state();
+                            } else {
+                                if (preview_index >= (int)screenshot_items.size())
+                                    preview_index = (int)screenshot_items.size() - 1;
+                                preview_screenshot_path = screenshot_items[preview_index].full_path;
+                                if (preview_texture) {
+                                    if (preview_texture->GetResourceId() != 0)
+                                        preview_texture->Unload();
+                                    preview_texture->Delete();
+                                    preview_texture = nullptr;
+                                }
+                                preview_pixels.clear();
+                                preview_pixels_w = 0;
+                                preview_pixels_h = 0;
+                            }
+                        }
+                        ImGui::SameLine();
+                        if (ImGui::Button("No")) {
+                            preview_delete_pending = false;
+                        }
+                    }
+                }
+
+                ImGui::EndPopup();
+            } else {
+                // BeginPopupModal returned false. Only clear state if the popup is
+                // truly closed (X/Escape), not just covered by another window like a new pin.
+                if (preview_open_active && !ImGui::IsPopupOpen("Screenshot Preview")) {
+                    clear_preview_state();
+                }
+            }
+            // X button on modal title bar → ImGui sets preview_modal_open to false
+            if (!preview_modal_open && preview_open_active) {
+                clear_preview_state();
+            }
+        }
+
+        // -- Delete confirmation modal --
+        if (show_delete_confirmation || delete_confirm_open_active) {
+            if (show_delete_confirmation) {
+                ImGui::OpenPopup("Confirm Delete");
+                delete_confirm_open_active = true;
+                show_delete_confirmation = false; // consumed - the active flag carries the state
+            }
+            if (ImGui::BeginPopupModal("Confirm Delete", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+                if (delete_all_selected) {
+                    ImGui::Text("Delete all selected screenshots?");
+                } else {
+                    ImGui::Text("Delete this screenshot?");
+                }
+                ImGui::Separator();
+                if (ImGui::Button("Yes")) {
+                    if (delete_all_selected) {
+                        // Delete all selected
+                        for (auto& item : screenshot_items) {
+                            if (!item.selected) continue;
+                            local_storage->file_delete(Local_Storage::screenshots_folder, item.filename);
+                            // Also delete the .json metadata if it exists
+                            std::string json_name = item.filename.substr(0, item.filename.size() - 4) + ".json";
+                            local_storage->file_delete(Local_Storage::screenshots_folder, json_name);
+                        }
+                        refresh_screenshots_list();
+                        // Remove pins for files that no longer exist
+                        for (auto it = pinned_screenshots.begin(); it != pinned_screenshots.end(); ) {
+                            bool exists = false;
+                            for (auto& si : screenshot_items) {
+                                if (si.full_path == it->path) { exists = true; break; }
+                            }
+                            if (!exists) {
+                                if (it->texture) {
+                                    if (it->texture->GetResourceId() != 0)
+                                        it->texture->Unload();
+                                    it->texture->Delete();
+                                }
+                                it = pinned_screenshots.erase(it);
+                            } else {
+                                ++it;
+                            }
+                        }
+                    } else if (!single_delete_path.empty()) {
+                        // Find filename from path
+                        std::string path = local_storage->get_path(Local_Storage::screenshots_folder) + PATH_SEPARATOR;
+                        std::string filename;
+                        if (single_delete_path.find(path) == 0) {
+                            filename = single_delete_path.substr(path.size());
+                        } else {
+                            // Try just the basename
+                            auto pos = single_delete_path.find_last_of("/\\");
+                            filename = (pos != std::string::npos) ? single_delete_path.substr(pos + 1) : single_delete_path;
+                        }
+                        if (!filename.empty()) {
+                            local_storage->file_delete(Local_Storage::screenshots_folder, filename);
+                            std::string json_name = filename.substr(0, filename.size() - 4) + ".json";
+                            local_storage->file_delete(Local_Storage::screenshots_folder, json_name);
+                        }
+                        refresh_screenshots_list();
+                        // Remove pin if the deleted file was pinned
+                        for (auto it = pinned_screenshots.begin(); it != pinned_screenshots.end(); ) {
+                            if (it->path == single_delete_path) {
+                                if (it->texture) {
+                                    if (it->texture->GetResourceId() != 0)
+                                        it->texture->Unload();
+                                    it->texture->Delete();
+                                }
+                                it = pinned_screenshots.erase(it);
+                            } else {
+                                ++it;
+                            }
+                        }
+                    }
+                    single_delete_path.clear();
+                    ImGui::CloseCurrentPopup();
+                }
+                ImGui::SameLine();
+                if (ImGui::Button("No")) {
+                    ImGui::CloseCurrentPopup();
+                }
+                ImGui::EndPopup();
+            } else {
+                if (delete_confirm_open_active) {
+                    // User closed it (Yes or No handled inside the modal). Clear state.
+                    show_delete_confirmation = false;
+                    single_delete_path.clear();
+                    delete_all_selected = false;
+                    delete_confirm_open_active = false;
+                }
+            }
+        }
+    }
+    ImGui::End();
+
+    if (style_color_stack) ImGui::PopStyleColor(style_color_stack);
+    ImGui::PopFont();
+}
+
+// -- Pin helpers --
+void Steam_Overlay::unpin_screenshot(uint64_t id)
+{
+    for (auto it = pinned_screenshots.begin(); it != pinned_screenshots.end(); ++it) {
+        if (it->id == id) {
+            if (it->texture) {
+                if (it->texture->GetResourceId() != 0)
+                    it->texture->Unload();
+                it->texture->Delete();
+            }
+            pinned_screenshots.erase(it);
+            return;
+        }
+    }
+}
+
+void Steam_Overlay::unpin_all_screenshots()
+{
+    for (auto& pin : pinned_screenshots) {
+        if (pin.texture) {
+            if (pin.texture->GetResourceId() != 0)
+                pin.texture->Unload();
+            pin.texture->Delete();
+        }
+    }
+    pinned_screenshots.clear();
+}
+
+// -- Floating pinned screenshots --
+void Steam_Overlay::render_pinned_screenshot()
+{
+    if (pinned_screenshots.empty())
+        return;
+
+    ImGui::PushFont(font_default);
+
+    // Track overlay state transitions once — applies to all pin windows.
+    static bool prev_overlay_state = false;
+    bool overlay_opened = show_overlay && !prev_overlay_state;
+    bool overlay_closed = !show_overlay && prev_overlay_state;
+    prev_overlay_state = show_overlay;
+
+    // Window-decoration overhead (needed for stable sizing)
+    const float pad_x = 2.0f * ImGui::GetStyle().WindowPadding.x;
+    const float pad_y = 2.0f * ImGui::GetStyle().WindowPadding.y;
+    const float title_bar_h = show_overlay ? ImGui::GetFrameHeight() : 0;
+    // Controls (separator + opacity slider) — accurately measured so no gap shows
+    const float controls_h = ImGui::GetFrameHeightWithSpacing()        // slider + its trailing spacing
+        + ImGui::GetStyle().ItemSpacing.y;                              // spacing above separator
+
+    ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
+    if (!show_overlay) {
+        flags |= ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoMove
+               | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar
+               | ImGuiWindowFlags_NoScrollbar
+               | ImGuiWindowFlags_NoBringToFrontOnFocus
+               | ImGuiWindowFlags_NoFocusOnAppearing
+               | ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_NoNavInputs;
+    } else {
+        flags |= ImGuiWindowFlags_NoScrollbar;
+    }
+
+    // Phase 1: render each pin in its own window
+    for (auto& pin : pinned_screenshots) {
+        if (!pin.texture || pin.texture->GetResourceId() == 0)
+            continue;
+
+        char wnd_id[64];
+        snprintf(wnd_id, sizeof(wnd_id), "Pinned Screenshot###pinned_ss_%llu",
+                 (unsigned long long)pin.id);
+
+        // Position (deferred until first manual move)
+        bool first_frame = !pin.pos_set;
+
+        // Always snap window to image display size when not actively resizing
+        // (lets user resize while mouse is held, trims excess on release)
+        bool mouse_down = ImGui::IsMouseDown(0);
+        if (!mouse_down || first_frame) {
+            ImVec2 img = pin.image_disp;
+            bool valid = img.x >= 50.0f && img.y >= 30.0f;
+            if (!valid && pin.pixels_w > 0 && pin.pixels_h > 0 && pin.size.x > 0 && pin.size.y > 0) {
+                // Fallback: derive from pin.size via aspect ratio
+                float s = std::min(pin.size.x / (float)pin.pixels_w,
+                                   pin.size.y / (float)pin.pixels_h);
+                img = ImVec2((float)pin.pixels_w * s, (float)pin.pixels_h * s);
+                valid = img.x >= 50.0f && img.y >= 30.0f;
+            }
+            if (!valid) {
+                img = ImVec2(std::max(pin.size.x, 50.0f), std::max(pin.size.y, 30.0f));
+            }
+
+            // New outer window size after snap
+            ImVec2 new_size = show_overlay
+                ? ImVec2(img.x + pad_x, img.y + controls_h + pad_y + title_bar_h)
+                : ImVec2(img.x + pad_x, img.y + pad_y);
+
+            // Re-center window on the image so both left and right edges
+            // adjust toward the image when the resize grip is released.
+            // pin.size is the content area from the previous frame; the
+            // previous outer size adds the same overhead we just applied.
+            if (pin.size.x > 0 && pin.size.y > 0) {
+                pin.pos.x += (pin.size.x - img.x) * 0.5f;
+                pin.pos.y += (pin.size.y - img.y) * 0.5f;
+            }
+
+            ImGui::SetNextWindowPos(pin.pos, ImGuiCond_Always);
+            ImGui::SetNextWindowSize(new_size, ImGuiCond_Always);
+        } else {
+            ImGui::SetNextWindowPos(pin.pos, first_frame
+                ? ImGuiCond_Always : ImGuiCond_FirstUseEver);
+        }
+        pin.pos_set = true;
+
+        ImGui::SetNextWindowSizeConstraints(ImVec2(100, 60), ImVec2(8192, 8192));
+        ImGui::SetNextWindowBgAlpha(pin.opacity);
+
+        if (ImGui::Begin(wnd_id, &pin.open, flags)) {
+            // Bring pin to front when requested (new pin, overlay opens)
+            if (overlay_opened || pin.focus_requested) {
+                ImGui::SetWindowFocus(wnd_id);
+                pin.focus_requested = false;
+            }
+
+            ImVec2 avail = ImGui::GetContentRegionAvail();
+            float image_avail_y = show_overlay ? avail.y - controls_h : avail.y;
+
+            // Draw image at correct aspect ratio within available space
+            if (pin.pixels_w > 0 && pin.pixels_h > 0 && avail.x > 0 && image_avail_y > 0) {
+                float scale = std::min(avail.x / (float)pin.pixels_w,
+                                       image_avail_y / (float)pin.pixels_h);
+                float disp_w = (float)pin.pixels_w * scale;
+                float disp_h = (float)pin.pixels_h * scale;
+
+                float off_x = (avail.x - disp_w) * 0.5f;
+                if (off_x > 0) ImGui::SetCursorPosX(ImGui::GetCursorPosX() + off_x);
+
+                ImDrawList* dl = ImGui::GetWindowDrawList();
+                ImVec2 p0 = ImGui::GetCursorScreenPos();
+                dl->AddImage(pin.texture->GetResourceId(), p0,
+                    ImVec2(p0.x + disp_w, p0.y + disp_h),
+                    ImVec2(0, 0), ImVec2(1, 1),
+                    IM_COL32(255, 255, 255, (int)(pin.opacity * 255.0f)));
+                ImGui::Dummy(ImVec2(disp_w, disp_h));
+
+                // Track actual image display size for closed-state shrink-wrapping
+                pin.image_disp = ImVec2(disp_w, disp_h);
+            }
+
+            if (show_overlay) {
+                ImGui::Separator();
+                ImGui::SliderFloat("Opacity", &pin.opacity, 0.1f, 1.0f, "%.2f");
+
+                pin.pos = ImGui::GetWindowPos();
+                // Derive image size from outer window size stripping overhead
+                ImVec2 outer = ImGui::GetWindowSize();
+                pin.size = ImVec2(outer.x - pad_x,
+                                  outer.y - controls_h - pad_y - title_bar_h);
+                if (pin.size.x < 50.0f) pin.size.x = 50.0f;
+                if (pin.size.y < 30.0f) pin.size.y = 30.0f;
+            }
+        }
+        ImGui::End();
+    }
+
+    // Phase 2: remove any pins whose X button was clicked
+    for (auto it = pinned_screenshots.begin(); it != pinned_screenshots.end(); ) {
+        if (!it->open) {
+            if (it->texture) {
+                if (it->texture->GetResourceId() != 0)
+                    it->texture->Unload();
+                it->texture->Delete();
+            }
+            it = pinned_screenshots.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    ImGui::PopFont();
 }
 
 

--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -764,7 +764,6 @@ bool Steam_Overlay::submit_notification(
         case notification_type::achievement:
         case notification_type::auto_accept_invite:
         case notification_type::message:
-        case notification_type::game_update:
         case notification_type::screenshot:
             // nothing
         break;
@@ -988,9 +987,6 @@ std::chrono::milliseconds Steam_Overlay::get_notification_duration(notification_
 
     case notification_type::auto_accept_invite:
         return Notification::default_show_time;
-
-    case notification_type::game_update:
-        return std::chrono::hours(24); // stay until user clicks a button
 
     case notification_type::screenshot:
         return std::chrono::milliseconds(settings->overlay_appearance.notification_duration_screenshot);
@@ -1240,7 +1236,6 @@ void Steam_Overlay::build_notifications(float width, float height)
             break;
 
             case notification_type::invite:
-            case notification_type::game_update:
             case notification_type::screenshot:
                 // nothing (needs input for buttons)
             break;
@@ -1351,7 +1346,6 @@ void Steam_Overlay::build_notifications(float width, float height)
                 case notification_type::achievement:
                 case notification_type::auto_accept_invite:
                 case notification_type::message:
-                case notification_type::game_update:
                 case notification_type::screenshot:
                     // nothing
                 break;
@@ -1888,7 +1882,6 @@ void Steam_Overlay::render_main_window()
                             case notification_type::achievement: type_label = "Achievement"; break;
                             case notification_type::achievement_progress: type_label = "Progress"; break;
                             case notification_type::auto_accept_invite: type_label = "Auto-Invite"; break;
-                            case notification_type::game_update: type_label = "Update"; break;
                             case notification_type::screenshot: type_label = "Screenshot"; break;
                         }
 

--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -1554,69 +1554,70 @@ void Steam_Overlay::overlay_render_proc()
     if (_renderer && settings->enable_screenshot && !screenshot_keys.empty()) {
 #ifdef __WINDOWS__
         // Only respond when the game window is focused
+        bool screenshot_focused = true;
         {
             HWND fg = GetForegroundWindow();
             if (fg) {
                 DWORD fg_pid = 0;
                 GetWindowThreadProcessId(fg, &fg_pid);
                 if (fg_pid != GetCurrentProcessId())
-                    goto skip_screenshot_hotkey_win;
+                    screenshot_focused = false;
             }
         }
 
-        // Map ToggleKey to Windows VK codes and check state
-        auto toggleKeyToVK = [](InGameOverlay::ToggleKey key) -> int {
-            switch (key) {
-                case InGameOverlay::ToggleKey::SHIFT: return VK_SHIFT;
-                case InGameOverlay::ToggleKey::CTRL:  return VK_CONTROL;
-                case InGameOverlay::ToggleKey::ALT:   return VK_MENU;
-                case InGameOverlay::ToggleKey::TAB:   return VK_TAB;
-                case InGameOverlay::ToggleKey::F1:    return VK_F1;
-                case InGameOverlay::ToggleKey::F2:    return VK_F2;
-                case InGameOverlay::ToggleKey::F3:    return VK_F3;
-                case InGameOverlay::ToggleKey::F4:    return VK_F4;
-                case InGameOverlay::ToggleKey::F5:    return VK_F5;
-                case InGameOverlay::ToggleKey::F6:    return VK_F6;
-                case InGameOverlay::ToggleKey::F7:    return VK_F7;
-                case InGameOverlay::ToggleKey::F8:    return VK_F8;
-                case InGameOverlay::ToggleKey::F9:    return VK_F9;
-                case InGameOverlay::ToggleKey::F10:   return VK_F10;
-                case InGameOverlay::ToggleKey::F11:   return VK_F11;
-                case InGameOverlay::ToggleKey::F12:   return VK_F12;
-                default: return 0;
+        if (screenshot_focused) {
+            // Map ToggleKey to Windows VK codes and check state
+            auto toggleKeyToVK = [](InGameOverlay::ToggleKey key) -> int {
+                switch (key) {
+                    case InGameOverlay::ToggleKey::SHIFT: return VK_SHIFT;
+                    case InGameOverlay::ToggleKey::CTRL:  return VK_CONTROL;
+                    case InGameOverlay::ToggleKey::ALT:   return VK_MENU;
+                    case InGameOverlay::ToggleKey::TAB:   return VK_TAB;
+                    case InGameOverlay::ToggleKey::F1:    return VK_F1;
+                    case InGameOverlay::ToggleKey::F2:    return VK_F2;
+                    case InGameOverlay::ToggleKey::F3:    return VK_F3;
+                    case InGameOverlay::ToggleKey::F4:    return VK_F4;
+                    case InGameOverlay::ToggleKey::F5:    return VK_F5;
+                    case InGameOverlay::ToggleKey::F6:    return VK_F6;
+                    case InGameOverlay::ToggleKey::F7:    return VK_F7;
+                    case InGameOverlay::ToggleKey::F8:    return VK_F8;
+                    case InGameOverlay::ToggleKey::F9:    return VK_F9;
+                    case InGameOverlay::ToggleKey::F10:   return VK_F10;
+                    case InGameOverlay::ToggleKey::F11:   return VK_F11;
+                    case InGameOverlay::ToggleKey::F12:   return VK_F12;
+                    default: return 0;
+                }
+            };
+
+            bool all_pressed = true;
+            for (auto k : screenshot_keys) {
+                int vk = toggleKeyToVK(k);
+                if (!vk || !(GetAsyncKeyState(vk) & 0x8000)) {
+                    all_pressed = false;
+                    break;
+                }
             }
-        };
 
-        bool all_pressed = true;
-        for (auto k : screenshot_keys) {
-            int vk = toggleKeyToVK(k);
-            if (!vk || !(GetAsyncKeyState(vk) & 0x8000)) {
-                all_pressed = false;
-                break;
+            // Rising edge detection + cooldown (1 second).
+            // `prev_initialized` ensures we don't fire a false trigger on the first call when the
+            // user happens to be holding the hotkey when the overlay is first loaded.
+            static bool prev_screenshot_keys = false;
+            static bool prev_initialized = false;
+            static std::chrono::steady_clock::time_point last_screenshot_time_local{};
+            auto now_local = std::chrono::steady_clock::now();
+            bool rising_edge = false;
+            if (prev_initialized) {
+                rising_edge = all_pressed && !prev_screenshot_keys;
+            }
+            prev_screenshot_keys = all_pressed;
+            prev_initialized = true;
+
+            if (rising_edge && (now_local - last_screenshot_time_local) > std::chrono::seconds(1)) {
+                last_screenshot_time_local = now_local;
+                PRINT_DEBUG("Screenshot hotkey triggered");
+                _renderer->TakeScreenshot(InGameOverlay::ScreenshotType_t::BeforeOverlay);
             }
         }
-
-        // Rising edge detection + cooldown (1 second).
-        // `prev_initialized` ensures we don't fire a false trigger on the first call when the
-        // user happens to be holding the hotkey when the overlay is first loaded.
-        static bool prev_screenshot_keys = false;
-        static bool prev_initialized = false;
-        static std::chrono::steady_clock::time_point last_screenshot_time_local{};
-        auto now_local = std::chrono::steady_clock::now();
-        bool rising_edge = false;
-        if (prev_initialized) {
-            rising_edge = all_pressed && !prev_screenshot_keys;
-        }
-        prev_screenshot_keys = all_pressed;
-        prev_initialized = true;
-
-        if (rising_edge && (now_local - last_screenshot_time_local) > std::chrono::seconds(1)) {
-            last_screenshot_time_local = now_local;
-            PRINT_DEBUG("Screenshot hotkey triggered");
-            _renderer->TakeScreenshot(InGameOverlay::ScreenshotType_t::BeforeOverlay);
-        }
-
-        skip_screenshot_hotkey_win:;
 #else
         // Non-Windows: use ToggleKey to ImGui mapping
         auto toggleKeyToImGui = [](InGameOverlay::ToggleKey key) -> ImGuiKey {

--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -2812,9 +2812,10 @@ void Steam_Overlay::refresh_screenshots_list()
         item.filename = f;
         item.full_path = path + PATH_SEPARATOR + f;
         // Read file modification time
-#ifdef _MSC_VER
+#ifdef __WINDOWS__
         struct _stat st;
-        if (_stat(item.full_path.c_str(), &st) == 0)
+        auto wstat_path = common_helpers::to_wstr(item.full_path);
+        if (_wstat(wstat_path.c_str(), &st) == 0)
             item.mtime = st.st_mtime;
 #else
         struct stat st;
@@ -2898,7 +2899,8 @@ void Steam_Overlay::render_gallery_window()
             if (ImGui::SmallButton("Open Folder")) {
                 std::string path = local_storage->get_path(Local_Storage::screenshots_folder);
 #ifdef __WINDOWS__
-                ShellExecuteW(NULL, L"open", std::wstring(path.begin(), path.end()).c_str(), NULL, NULL, SW_SHOWNORMAL);
+                auto wpath = common_helpers::to_wstr(path);
+                ShellExecuteW(NULL, L"open", wpath.c_str(), NULL, NULL, SW_SHOWNORMAL);
 #elif defined(__linux__)
                 std::string cmd = "xdg-open \"" + path + "\"";
                 std::system(cmd.c_str());

--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -15,7 +15,6 @@
 #include <unordered_set>
 #include <unordered_map>
 #include <algorithm>
-#include <shellapi.h>
 #include <sys/stat.h>
 
 #include "InGameOverlay/RendererDetector.h"

--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -1552,6 +1552,17 @@ void Steam_Overlay::overlay_render_proc()
     // -- Screenshot hotkey detection --
     if (_renderer && !screenshot_keys.empty()) {
 #ifdef __WINDOWS__
+        // Only respond when the game window is focused
+        {
+            HWND fg = GetForegroundWindow();
+            if (fg) {
+                DWORD fg_pid = 0;
+                GetWindowThreadProcessId(fg, &fg_pid);
+                if (fg_pid != GetCurrentProcessId())
+                    goto skip_screenshot_hotkey_win;
+            }
+        }
+
         // Map ToggleKey to Windows VK codes and check state
         auto toggleKeyToVK = [](InGameOverlay::ToggleKey key) -> int {
             switch (key) {
@@ -1603,6 +1614,8 @@ void Steam_Overlay::overlay_render_proc()
             PRINT_DEBUG("Screenshot hotkey triggered");
             _renderer->TakeScreenshot(InGameOverlay::ScreenshotType_t::BeforeOverlay);
         }
+
+        skip_screenshot_hotkey_win:;
 #else
         // Non-Windows: use ToggleKey to ImGui mapping
         auto toggleKeyToImGui = [](InGameOverlay::ToggleKey key) -> ImGuiKey {

--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -16,6 +16,11 @@
 #include <unordered_map>
 #include <algorithm>
 #include <sys/stat.h>
+#include <cstdlib>  // std::system
+
+#ifdef __WINDOWS__
+#include <shellapi.h>
+#endif
 
 #include "InGameOverlay/RendererDetector.h"
 
@@ -2763,7 +2768,7 @@ void Steam_Overlay::process_captured_screenshots()
 #else
         localtime_r(&now_time, &local_tm);
 #endif
-        std::strftime(buff, sizeof(buff), "%a_%b_%d_%H_%M_%S_%Y", &local_tm);
+        std::strftime(buff, sizeof(buff), "%Y-%m-%d_%H-%M-%S", &local_tm);
         std::string filename = buff;
         filename += ".png";
 
@@ -2890,8 +2895,17 @@ void Steam_Overlay::render_gallery_window()
         }
 
         if (!screenshot_items.empty()) {
-            if (ImGui::SmallButton("Refresh")) {
-                refresh_screenshots_list();
+            if (ImGui::SmallButton("Open Folder")) {
+                std::string path = local_storage->get_path(Local_Storage::screenshots_folder);
+#ifdef __WINDOWS__
+                ShellExecuteW(NULL, L"open", std::wstring(path.begin(), path.end()).c_str(), NULL, NULL, SW_SHOWNORMAL);
+#elif defined(__linux__)
+                std::string cmd = "xdg-open \"" + path + "\"";
+                std::system(cmd.c_str());
+#elif defined(__APPLE__)
+                std::string cmd = "open \"" + path + "\"";
+                std::system(cmd.c_str());
+#endif
             }
         }
 
@@ -3001,18 +3015,12 @@ void Steam_Overlay::render_gallery_window()
                 ImGui::PopStyleVar();
                 ImGui::SameLine(0, 0);
                 ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + thumb_width);
-                if (item.mtime > 0) {
-                    char date_buf[32];
-                    struct tm local_tm{};
-#ifdef _MSC_VER
-                    localtime_s(&local_tm, &item.mtime);
-#else
-                    localtime_r(&item.mtime, &local_tm);
-#endif
-                    std::strftime(date_buf, sizeof(date_buf), "%Y-%m-%d-%H:%M", &local_tm);
-                    ImGui::TextUnformatted(date_buf);
-                } else {
-                    ImGui::TextUnformatted(item.filename.c_str());
+                // Show filename (without .png extension) below thumbnail
+                {
+                    std::string label = item.filename;
+                    if (label.size() > 4)
+                        label.resize(label.size() - 4);
+                    ImGui::TextUnformatted(label.c_str());
                 }
                 ImGui::PopTextWrapPos();
 

--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -2843,6 +2843,10 @@ void Steam_Overlay::clear_preview_state()
     preview_screenshot_path.clear();
     preview_open_active = false;
     preview_delete_pending = false;
+    preview_crop_mode = false;
+    preview_crop_rect = ImVec4(0, 0, 0, 0);
+    preview_crop_rect_prev = ImVec4(0, 0, 0, 0);
+    preview_crop_drag = CropDragState{};
     preview_index = -1;
     if (preview_texture) {
         if (preview_texture->GetResourceId() != 0)
@@ -3050,6 +3054,9 @@ void Steam_Overlay::render_gallery_window()
             ImVec2 disp_center = ImGui::GetIO().DisplaySize;
             ImGui::SetNextWindowPos(ImVec2(disp_center.x * 0.5f, disp_center.y * 0.5f), ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
             ImGuiWindowFlags preview_flags = ImGuiWindowFlags_NoScrollbar;
+            if (preview_crop_mode) {
+                preview_flags |= ImGuiWindowFlags_NoMove;
+            }
             bool preview_modal_open = true;
             if (ImGui::BeginPopupModal("Screenshot Preview", &preview_modal_open, preview_flags)) {
                 // Navigate to a different screenshot
@@ -3058,6 +3065,11 @@ void Steam_Overlay::render_gallery_window()
                     screenshot_items[preview_index].full_path != preview_screenshot_path)
                 {
                     preview_screenshot_path = screenshot_items[preview_index].full_path;
+                    // Reset crop state — old selection no longer applies to new image
+                    preview_crop_mode = false;
+                    preview_crop_rect = ImVec4(0, 0, 0, 0);
+                    preview_crop_rect_prev = ImVec4(0, 0, 0, 0);
+                    preview_crop_drag = CropDragState{};
                     if (preview_texture) {
                         if (preview_texture->GetResourceId() != 0)
                             preview_texture->Unload();
@@ -3091,110 +3103,181 @@ void Steam_Overlay::render_gallery_window()
                 bool preview_texture_ok = preview_texture && preview_texture->GetResourceId() != 0 && preview_pixels_w > 0 && preview_pixels_h > 0;
                 if (preview_texture_ok) {
                     ImVec2 avail = ImGui::GetContentRegionAvail();
-                    // Reserve space for the date + button bar at the bottom
-                    float btn_h = ImGui::GetTextLineHeightWithSpacing() * 3.0f + ImGui::GetStyle().ItemSpacing.y * 4.0f;
-                    avail.y -= btn_h;
+                    // Reserve space for the date + button bar at the bottom (only when not in crop mode)
+                    if (!preview_crop_mode) {
+                        float btn_h = ImGui::GetTextLineHeightWithSpacing() * 3.0f + ImGui::GetStyle().ItemSpacing.y * 4.0f;
+                        avail.y -= btn_h;
+                    }
                     float scale = std::min(avail.x / (float)preview_pixels_w, avail.y / (float)preview_pixels_h);
                     ImVec2 preview_display_size = ImVec2((float)preview_pixels_w * scale, (float)preview_pixels_h * scale);
                     // Center the image horizontally so portrait images don't leave a gap on the right
                     float off_x = (avail.x - preview_display_size.x) * 0.5f;
                     if (off_x > 0) ImGui::SetCursorPosX(ImGui::GetCursorPosX() + off_x);
+                    ImVec2 preview_img_pos = ImGui::GetCursorScreenPos();
                     ImGui::Image(preview_texture->GetResourceId(), preview_display_size);
 
-                    ImGui::Separator();
-
-                    // Screenshot date — only shown when texture is loaded (avoids flash on navigation)
-                    if (!screenshot_items.empty() && preview_index >= 0 && preview_index < (int)screenshot_items.size()) {
-                        auto& src_item = screenshot_items[preview_index];
-                        if (src_item.mtime > 0) {
-                            char time_buf[64];
-                            struct tm local_tm{};
-#ifdef _MSC_VER
-                            localtime_s(&local_tm, &src_item.mtime);
-#else
-                            localtime_r(&src_item.mtime, &local_tm);
-#endif
-                            std::strftime(time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M:%S", &local_tm);
-                            ImGui::TextUnformatted(time_buf);
-                        } else {
-                            ImGui::TextUnformatted(src_item.filename.c_str());
+                    // If in crop mode, draw the crop editor over the image. The
+                    // Confirm action creates a new pin with preview_crop_rect.
+                    // Cancel exits crop mode and restores the previous rect.
+                    if (preview_crop_mode) {
+                        // (0,0,0,0) = no selection — user will click-and-drag.
+                        // Non-zero degenerate rect: clamp to bounds as safety net.
+                        if (preview_crop_rect.z <= preview_crop_rect.x
+                            || preview_crop_rect.w <= preview_crop_rect.y) {
+                            if (preview_crop_rect.x != 0 || preview_crop_rect.y != 0 ||
+                                preview_crop_rect.z != 0 || preview_crop_rect.w != 0) {
+                                preview_crop_rect.x = std::max(0.0f, std::min((float)preview_pixels_w, preview_crop_rect.x));
+                                preview_crop_rect.y = std::max(0.0f, std::min((float)preview_pixels_h, preview_crop_rect.y));
+                                preview_crop_rect.z = std::max(preview_crop_rect.x, std::min((float)preview_pixels_w, preview_crop_rect.z));
+                                preview_crop_rect.w = std::max(preview_crop_rect.y, std::min((float)preview_pixels_h, preview_crop_rect.w));
+                            }
+                            // Zero rect (0,0,0,0) left as-is — means "no selection"
                         }
-                    }
+                        CropAction act = render_crop_editor(preview_crop_rect,
+                            preview_crop_drag,
+                            preview_texture->GetResourceId(),
+                            preview_pixels_w, preview_pixels_h,
+                            preview_img_pos, preview_display_size);
+                        if (act == CropAction::Confirm) {
+                            // Create a new pin with the selected crop region
+                            PinnedScreenshot pin;
+                            pin.id = next_pin_id++;
+                            pin.path = screenshot_items[preview_index].full_path;
+                            if (preview_pixels_w > 0 && preview_pixels_h > 0) {
+                                pin.pixels = preview_pixels;
+                                pin.pixels_w = preview_pixels_w;
+                                pin.pixels_h = preview_pixels_h;
+                            }
+                            // Initial size = the crop region (not the full image)
+                            float crop_w = std::max(1.0f, preview_crop_rect.z - preview_crop_rect.x);
+                            float crop_h = std::max(1.0f, preview_crop_rect.w - preview_crop_rect.y);
+                            pin.size = ImVec2(crop_w, crop_h);
+                            if (pin.size.x > kContextPinMaxDim || pin.size.y > kContextPinMaxDim) {
+                                float ss = std::min(kContextPinMaxDim / pin.size.x,
+                                                    kContextPinMaxDim / pin.size.y);
+                                pin.size.x *= ss;
+                                pin.size.y *= ss;
+                            }
+                            if (_renderer) {
+                                pin.texture = _renderer->CreateResource();
+                                if (pin.texture && !pin.pixels.empty())
+                                    pin.texture->AttachResource(pin.pixels.data(),
+                                        pin.pixels_w, pin.pixels_h);
+                            }
+                            pin.crop_rect = preview_crop_rect;
+                            pin.focus_requested = true;
+                            pinned_screenshots.push_back(std::move(pin));
 
-                    // Button bar: < Prev | Pin  Delete | Next >
-                    ImGui::BeginGroup();
+                            // Exit crop mode and close the preview
+                            preview_crop_mode = false;
+                            ImGui::CloseCurrentPopup();
+                            clear_preview_state();
+                        } else if (act == CropAction::Cancel) {
+                            preview_crop_rect = preview_crop_rect_prev;
+                            preview_crop_mode = false;
+                        }
+                    } else {
+                        ImGui::Separator();
 
-                    // Prev — always visible, wraps to last
-                    if (ImGui::Button("< Prev")) {
-                        if (preview_index <= 0)
-                            preview_index = (int)screenshot_items.size() - 1;
-                        else
-                            preview_index--;
-                    }
-                    ImGui::SameLine();
-
-                    ImGui::Text("|");
-                    ImGui::SameLine();
-
-                    if (ImGui::Button("Pin")) {
-                        PinnedScreenshot pin;
-                        pin.id = next_pin_id++;
-                        pin.path = screenshot_items[preview_index].full_path;
-
-                        // Repurpose the already-loaded preview pixels to avoid a second stbi_load
-                        if (preview_pixels_w > 0 && preview_pixels_h > 0) {
-                            pin.pixels = preview_pixels; // copies — small enough for a single frame
-                            pin.pixels_w = preview_pixels_w;
-                            pin.pixels_h = preview_pixels_h;
-                        } else {
-                            int img_w = 0, img_h = 0;
-                            unsigned char* img = stbi_load(pin.path.c_str(), &img_w, &img_h, nullptr, 4);
-                            if (img) {
-                                pin.pixels.assign(img, img + ((size_t)img_w * (size_t)img_h * 4));
-                                pin.pixels_w = (uint32_t)img_w;
-                                pin.pixels_h = (uint32_t)img_h;
-                                stbi_image_free(img);
+                        // Screenshot date — only shown when texture is loaded (avoids flash on navigation)
+                        if (!screenshot_items.empty() && preview_index >= 0 && preview_index < (int)screenshot_items.size()) {
+                            auto& src_item = screenshot_items[preview_index];
+                            if (src_item.mtime > 0) {
+                                char time_buf[64];
+                                struct tm local_tm{};
+#ifdef _MSC_VER
+                                localtime_s(&local_tm, &src_item.mtime);
+#else
+                                localtime_r(&src_item.mtime, &local_tm);
+#endif
+                                std::strftime(time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M:%S", &local_tm);
+                                ImGui::TextUnformatted(time_buf);
+                            } else {
+                                ImGui::TextUnformatted(src_item.filename.c_str());
                             }
                         }
 
-                        // Same initial sizing as context-menu pin (kContextPinMaxDim)
-                        pin.size = ImVec2((float)pin.pixels_w, (float)pin.pixels_h);
-                        if (pin.size.x > kContextPinMaxDim || pin.size.y > kContextPinMaxDim) {
-                            float scale = std::min(kContextPinMaxDim / pin.size.x,
-                                                   kContextPinMaxDim / pin.size.y);
-                            pin.size.x *= scale;
-                            pin.size.y *= scale;
+                        // Button bar: < Prev | Pin  Crop  Delete | Next >
+                        ImGui::BeginGroup();
+
+                        // Prev — always visible, wraps to last
+                        if (ImGui::Button("< Prev")) {
+                            if (preview_index <= 0)
+                                preview_index = (int)screenshot_items.size() - 1;
+                            else
+                                preview_index--;
+                        }
+                        ImGui::SameLine();
+
+                        ImGui::Text("|");
+                        ImGui::SameLine();
+
+                        if (ImGui::Button("Pin")) {
+                            PinnedScreenshot pin;
+                            pin.id = next_pin_id++;
+                            pin.path = screenshot_items[preview_index].full_path;
+
+                            // Repurpose the already-loaded preview pixels to avoid a second stbi_load
+                            if (preview_pixels_w > 0 && preview_pixels_h > 0) {
+                                pin.pixels = preview_pixels; // copies — small enough for a single frame
+                                pin.pixels_w = preview_pixels_w;
+                                pin.pixels_h = preview_pixels_h;
+                            } else {
+                                int img_w = 0, img_h = 0;
+                                unsigned char* img = stbi_load(pin.path.c_str(), &img_w, &img_h, nullptr, 4);
+                                if (img) {
+                                    pin.pixels.assign(img, img + ((size_t)img_w * (size_t)img_h * 4));
+                                    pin.pixels_w = (uint32_t)img_w;
+                                    pin.pixels_h = (uint32_t)img_h;
+                                    stbi_image_free(img);
+                                }
+                            }
+
+                            // Same initial sizing as context-menu pin (kContextPinMaxDim)
+                            pin.size = ImVec2((float)pin.pixels_w, (float)pin.pixels_h);
+                            if (pin.size.x > kContextPinMaxDim || pin.size.y > kContextPinMaxDim) {
+                                float scale = std::min(kContextPinMaxDim / pin.size.x,
+                                                       kContextPinMaxDim / pin.size.y);
+                                pin.size.x *= scale;
+                                pin.size.y *= scale;
+                            }
+
+                            if (_renderer) {
+                                pin.texture = _renderer->CreateResource();
+                                if (pin.texture && !pin.pixels.empty())
+                                    pin.texture->AttachResource(pin.pixels.data(), pin.pixels_w, pin.pixels_h);
+                            }
+                            pin.focus_requested = true;
+                            pinned_screenshots.push_back(std::move(pin));
+
+                            // Leave preview open — pin is immediately visible in its own window
+                        }
+                        ImGui::SameLine();
+
+                        if (ImGui::Button("Crop")) {
+                            preview_crop_rect_prev = preview_crop_rect;
+                            preview_crop_mode = true;
+                        }
+                        ImGui::SameLine();
+
+                        if (!preview_delete_pending && ImGui::Button("Delete")) {
+                            preview_delete_pending = true;
+                        }
+                        ImGui::SameLine();
+
+                        ImGui::Text("|");
+                        ImGui::SameLine();
+
+                        // Next — always visible, wraps to first
+                        if (ImGui::Button("Next >")) {
+                            if (preview_index >= (int)screenshot_items.size() - 1)
+                                preview_index = 0;
+                            else
+                                preview_index++;
                         }
 
-                        if (_renderer) {
-                            pin.texture = _renderer->CreateResource();
-                            if (pin.texture && !pin.pixels.empty())
-                                pin.texture->AttachResource(pin.pixels.data(), pin.pixels_w, pin.pixels_h);
-                        }
-                        pin.focus_requested = true;
-                        pinned_screenshots.push_back(std::move(pin));
-
-                        // Leave preview open — pin is immediately visible in its own window
+                        ImGui::EndGroup();
                     }
-                    ImGui::SameLine();
-
-                    if (!preview_delete_pending && ImGui::Button("Delete")) {
-                        preview_delete_pending = true;
-                    }
-                    ImGui::SameLine();
-
-                    ImGui::Text("|");
-                    ImGui::SameLine();
-
-                    // Next — always visible, wraps to first
-                    if (ImGui::Button("Next >")) {
-                        if (preview_index >= (int)screenshot_items.size() - 1)
-                            preview_index = 0;
-                        else
-                            preview_index++;
-                    }
-
-                    ImGui::EndGroup();
 
                     // Inline delete confirmation (avoids stacking modals which closes the preview)
                     if (preview_delete_pending) {
@@ -3399,6 +3482,294 @@ void Steam_Overlay::unpin_all_screenshots()
 }
 
 // -- Floating pinned screenshots --
+
+// Render the crop-rectangle editor overlay. The caller renders the FULL
+// image with UV (0,0)-(1,1) at img_min/img_size before calling this. This
+// function draws:
+//   1) a dim layer over the whole image,
+//   2) the image AGAIN, clipped to the selection rect, so the selection
+//      region looks "un-dimmed" while everything else is darkened,
+//   3) a bright border and 8 drag handles,
+//   4) a small toolbar with Confirm and Cancel buttons.
+// `tex_id` is the texture's GPU resource ID used for step 2.
+// `rect` is in source-pixel coordinates and is mutated in place. Returns
+// Active until the user clicks Confirm or Cancel.
+Steam_Overlay::CropAction Steam_Overlay::render_crop_editor(
+    ImVec4& rect, CropDragState& st,
+    ImTextureID tex_id,
+    uint32_t src_w, uint32_t src_h,
+    ImVec2 img_min, ImVec2 img_size)
+{
+    constexpr float kMinCropPx = 20.0f;
+    constexpr float kHandlePx = 8.0f;
+    constexpr float kHandleHit = 10.0f;     // generous hit area for handles
+
+    if (src_w == 0 || src_h == 0 || img_size.x <= 0 || img_size.y <= 0)
+        return CropAction::Active;
+
+    // Helper: convert source pixel coords -> screen rect
+    auto src_to_screen = [&](ImVec4 r) -> ImVec4 {
+        float sx = img_size.x / (float)src_w;
+        float sy = img_size.y / (float)src_h;
+        return ImVec4(img_min.x + r.x * sx,
+                      img_min.y + r.y * sy,
+                      img_min.x + r.z * sx,
+                      img_min.y + r.w * sy);
+    };
+    // Helper: convert screen point -> source pixel coords
+    auto screen_to_src = [&](ImVec2 p) -> ImVec2 {
+        float sx = (float)src_w / img_size.x;
+        float sy = (float)src_h / img_size.y;
+        return ImVec2((p.x - img_min.x) * sx,
+                      (p.y - img_min.y) * sy);
+    };
+    // Helper: clamp rect to image bounds
+    auto clamp_rect = [&](ImVec4 r) -> ImVec4 {
+        // When clamping x/y to 0, shift z/w by the same delta so the rect
+        // keeps its original width/height instead of collapsing to the
+        // minimum size.  This prevents a visible "collapse" when the user
+        // body-drags the selection off the left or top edge.
+        if (r.x < 0) {
+            r.z -= r.x;     // r.x is negative, so this adds |r.x| to r.z
+            r.x = 0;
+        }
+        if (r.y < 0) {
+            r.w -= r.y;     // r.y is negative, so this adds |r.y| to r.w
+            r.y = 0;
+        }
+        if (r.z > (float)src_w) r.z = (float)src_w;
+        if (r.w > (float)src_h) r.w = (float)src_h;
+        // Enforce minimum size
+        if (r.z - r.x < kMinCropPx) {
+            float c = (r.x + r.z) * 0.5f;
+            r.x = std::max(0.0f, c - kMinCropPx * 0.5f);
+            r.z = std::min((float)src_w, r.x + kMinCropPx);
+        }
+        if (r.w - r.y < kMinCropPx) {
+            float c = (r.y + r.w) * 0.5f;
+            r.y = std::max(0.0f, c - kMinCropPx * 0.5f);
+            r.w = std::min((float)src_h, r.y + kMinCropPx);
+        }
+        return r;
+    };
+
+    ImDrawList* dl = ImGui::GetWindowDrawList();
+
+    // 1) Dim overlay over the whole image
+    dl->AddRectFilled(img_min,
+                      ImVec2(img_min.x + img_size.x, img_min.y + img_size.y),
+                      IM_COL32(0, 0, 0, 140));
+
+    // 2) Selection rect (clamped, drawn in screen coords)
+    rect = clamp_rect(rect);
+    ImVec4 sel_screen = src_to_screen(rect);
+    ImVec2 s0(sel_screen.x, sel_screen.y);
+    ImVec2 s1(sel_screen.z, sel_screen.w);
+
+    // Redraw the image in the selection area so the dim layer doesn't
+    // cover it. UV is mapped from the source's crop region.
+    if (tex_id) {
+        ImVec2 uv0(rect.x / (float)src_w, rect.y / (float)src_h);
+        ImVec2 uv1(rect.z / (float)src_w, rect.w / (float)src_h);
+        dl->AddImage(tex_id, s0, s1, uv0, uv1,
+                     IM_COL32(255, 255, 255, 255));
+    } else {
+        // Fallback: just a translucent white wash so the user can see the
+        // selection area is "different" from the dim surroundings.
+        dl->AddRectFilled(s0, s1, IM_COL32(255, 255, 255, 30));
+    }
+    // Border
+    dl->AddRect(s0, s1, IM_COL32(255, 255, 255, 255), 0.0f, 0, 2.0f);
+
+    // 3) 8 handles (4 corners + 4 edge midpoints)
+    ImVec2 corners[8] = {
+        ImVec2(s0.x, s0.y),                 // 0: TL
+        ImVec2(s1.x, s0.y),                 // 1: TR
+        ImVec2(s1.x, s1.y),                 // 2: BR
+        ImVec2(s0.x, s1.y),                 // 3: BL
+        ImVec2((s0.x + s1.x) * 0.5f, s0.y), // 4: T
+        ImVec2(s1.x, (s0.y + s1.y) * 0.5f), // 5: R
+        ImVec2((s0.x + s1.x) * 0.5f, s1.y), // 6: B
+        ImVec2(s0.x, (s0.y + s1.y) * 0.5f), // 7: L
+    };
+    for (int i = 0; i < 8; ++i) {
+        dl->AddRectFilled(
+            ImVec2(corners[i].x - kHandlePx * 0.5f, corners[i].y - kHandlePx * 0.5f),
+            ImVec2(corners[i].x + kHandlePx * 0.5f, corners[i].y + kHandlePx * 0.5f),
+            IM_COL32(255, 255, 255, 255));
+        dl->AddRect(
+            ImVec2(corners[i].x - kHandlePx * 0.5f, corners[i].y - kHandlePx * 0.5f),
+            ImVec2(corners[i].x + kHandlePx * 0.5f, corners[i].y + kHandlePx * 0.5f),
+            IM_COL32(0, 0, 0, 255), 0.0f, 0, 1.0f);
+    }
+
+    // 4) Toolbar (Confirm/Cancel) — rendered directly in the parent window
+    //    (no separate child window) to avoid input-routing issues where
+    //    clicks on the image get intercepted by the parent window's title
+    //    bar or the toolbar steals focus.  The background is drawn first
+    //    (via the draw list) so the buttons render on top of it.
+    const float tb_fp_x = 6.0f, tb_fp_y = 4.0f;
+    const float tb_gap = ImGui::GetStyle().ItemSpacing.x;
+    const ImVec2 confirm_sz = ImGui::CalcTextSize("Confirm");
+    const ImVec2 cancel_sz  = ImGui::CalcTextSize("Cancel");
+    const float tb_w = (confirm_sz.x + tb_fp_x * 2) + tb_gap
+                     + (cancel_sz.x  + tb_fp_x * 2);
+    const float tb_h = std::max(confirm_sz.y, cancel_sz.y) + tb_fp_y * 2;
+    const ImVec2 tb_tl = img_min;
+    const ImVec2 tb_br(tb_tl.x + tb_w, tb_tl.y + tb_h);
+
+    // Draw background rounded rect BEFORE buttons so they stack on top
+    dl->AddRectFilled(tb_tl, tb_br, IM_COL32(0, 0, 0, 178), 4.0f);
+
+    // Render buttons into the parent window at the toolbar position
+    ImGui::SetCursorScreenPos(tb_tl);
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(tb_fp_x, tb_fp_y));
+    ImGui::PushStyleColor(ImGuiCol_Button,        ImVec4(0, 0, 0, 0));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1, 1, 1, 0.15f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive,  ImVec4(1, 1, 1, 0.25f));
+    ImGui::PushStyleColor(ImGuiCol_Text,          ImVec4(1, 1, 1, 1));
+
+    CropAction action = CropAction::Active;
+    if (ImGui::Button("Confirm")) {
+        action = CropAction::Confirm;
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Cancel")) {
+        action = CropAction::Cancel;
+    }
+
+    ImGui::PopStyleColor(4);
+    ImGui::PopStyleVar();
+
+    ImVec2 toolbar_min = tb_tl;
+    ImVec2 toolbar_max = tb_br;
+
+    // 5) Mouse input — skip clicks that fall inside the toolbar so the
+    //    Confirm/Cancel buttons aren't treated as crop drags.
+    ImVec2 mouse = ImGui::GetMousePos();
+    bool mouse_in_toolbar = mouse.x >= toolbar_min.x && mouse.x <= toolbar_max.x
+                         && mouse.y >= toolbar_min.y && mouse.y <= toolbar_max.y;
+    bool mouse_in_image = !mouse_in_toolbar
+                       && mouse.x >= img_min.x && mouse.x <= img_min.x + img_size.x
+                       && mouse.y >= img_min.y && mouse.y <= img_min.y + img_size.y;
+    bool mouse_down = ImGui::IsMouseDown(0);
+    bool mouse_clicked = ImGui::IsMouseClicked(0);
+
+    // Determine which handle (if any) the mouse is over
+    int hit_handle = -1;
+    if (mouse_in_image) {
+        for (int i = 0; i < 8; ++i) {
+            if (fabsf(mouse.x - corners[i].x) <= kHandleHit * 0.5f
+             && fabsf(mouse.y - corners[i].y) <= kHandleHit * 0.5f) {
+                hit_handle = i;
+                break;
+            }
+        }
+    }
+    st.handle_hover = hit_handle;
+
+    // Cursor feedback based on what's being hovered
+    if (st.dragging) {
+        if (st.handle == 8) ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
+        else if (st.handle >= 0 && st.handle <= 3) {
+            // Diagonal resize cursors
+            int diag = (st.handle == 0 || st.handle == 2) ? 0 : 1;
+            ImGui::SetMouseCursor(diag == 0 ? ImGuiMouseCursor_ResizeNWSE : ImGuiMouseCursor_ResizeNESW);
+        } else if (st.handle >= 4 && st.handle <= 7) {
+            ImGui::SetMouseCursor((st.handle == 4 || st.handle == 6)
+                ? ImGuiMouseCursor_ResizeNS : ImGuiMouseCursor_ResizeEW);
+        }
+    } else if (hit_handle >= 0) {
+        if (hit_handle <= 3) {
+            int diag = (hit_handle == 0 || hit_handle == 2) ? 0 : 1;
+            ImGui::SetMouseCursor(diag == 0 ? ImGuiMouseCursor_ResizeNWSE : ImGuiMouseCursor_ResizeNESW);
+        } else if (hit_handle >= 4 && hit_handle <= 7) {
+            ImGui::SetMouseCursor((hit_handle == 4 || hit_handle == 6)
+                ? ImGuiMouseCursor_ResizeNS : ImGuiMouseCursor_ResizeEW);
+        }
+    } else if (mouse_in_image && mouse.x >= s0.x && mouse.x <= s1.x
+            && mouse.y >= s0.y && mouse.y <= s1.y) {
+        ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
+    }
+
+    if (!st.dragging) {
+        if (mouse_clicked && mouse_in_image) {
+            if (hit_handle >= 0) {
+                // Start handle drag
+                st.dragging = true;
+                st.handle = hit_handle;
+                st.start = mouse;
+                // Anchor: for corners, opposite corner. For edges, we
+                // preserve the opposite edge automatically by only mutating
+                // the dragged edge in the drag code below, so anchor isn't
+                // needed for edges.
+                if (hit_handle == 0) st.anchor = ImVec2(rect.z, rect.w);
+                else if (hit_handle == 1) st.anchor = ImVec2(rect.x, rect.w);
+                else if (hit_handle == 2) st.anchor = ImVec2(rect.x, rect.y);
+                else if (hit_handle == 3) st.anchor = ImVec2(rect.z, rect.y);
+            } else if (mouse.x >= s0.x && mouse.x <= s1.x
+                    && mouse.y >= s0.y && mouse.y <= s1.y) {
+                // Start body move
+                st.dragging = true;
+                st.handle = 8;
+                ImVec2 src_mouse = screen_to_src(mouse);
+                st.anchor = ImVec2(src_mouse.x - rect.x, src_mouse.y - rect.y);
+            } else {
+                // Click outside selection: start a fresh draw anchored at the
+                // click. The user drags to define the area.
+                ImVec2 src_mouse = screen_to_src(mouse);
+                st.dragging = true;
+                st.handle = 9;  // 9 = initial-draw mode
+                rect = ImVec4(src_mouse.x, src_mouse.y, src_mouse.x, src_mouse.y);
+                st.anchor = src_mouse;
+            }
+        }
+    } else {
+        // In-progress drag
+        if (!mouse_down) {
+            st.dragging = false;
+            st.handle = -1;
+        } else if (st.handle == 8) {
+            // Body move
+            ImVec2 src_mouse = screen_to_src(mouse);
+            float w = rect.z - rect.x;
+            float h = rect.w - rect.y;
+            float nx = src_mouse.x - st.anchor.x;
+            float ny = src_mouse.y - st.anchor.y;
+            rect = ImVec4(nx, ny, nx + w, ny + h);
+        } else if (st.handle == 9) {
+            // Initial draw
+            ImVec2 src_mouse = screen_to_src(mouse);
+            rect = ImVec4(st.anchor.x, st.anchor.y, src_mouse.x, src_mouse.y);
+            // Normalize in case the user drags right-to-left or bottom-to-top
+            if (rect.z < rect.x) std::swap(rect.x, rect.z);
+            if (rect.w < rect.y) std::swap(rect.y, rect.w);
+        } else {
+        // Handle drag. Corners (0-3) use the stored anchor; edges (4-7)
+        // mutate only the dragged edge and preserve the rest of the rect.
+        ImVec2 src_mouse = screen_to_src(mouse);
+        float ax = st.anchor.x, ay = st.anchor.y;
+        float mx = src_mouse.x, my = src_mouse.y;
+        switch (st.handle) {
+            case 0: rect = ImVec4(mx, my, ax, ay); break; // TL drag
+            case 1: rect = ImVec4(ax, my, mx, ay); break; // TR drag
+            case 2: rect = ImVec4(ax, ay, mx, my); break; // BR drag
+            case 3: rect = ImVec4(mx, ay, ax, my); break; // BL drag
+            case 4: rect = ImVec4(rect.x, my, rect.z, rect.w); break; // T
+            case 5: rect = ImVec4(rect.x, rect.y, mx, rect.w); break; // R
+            case 6: rect = ImVec4(rect.x, rect.y, rect.z, my); break; // B
+            case 7: rect = ImVec4(mx, rect.y, rect.z, rect.w); break; // L
+        }
+        // Normalize in case the drag inverted the rect
+        if (rect.z < rect.x) std::swap(rect.x, rect.z);
+        if (rect.w < rect.y) std::swap(rect.y, rect.w);
+        }
+    }
+
+    rect = clamp_rect(rect);
+    return action;
+}
+
 void Steam_Overlay::render_pinned_screenshot()
 {
     if (pinned_screenshots.empty())
@@ -3451,10 +3822,17 @@ void Steam_Overlay::render_pinned_screenshot()
             ImVec2 img = pin.image_disp;
             bool valid = img.x >= 50.0f && img.y >= 30.0f;
             if (!valid && pin.pixels_w > 0 && pin.pixels_h > 0 && pin.size.x > 0 && pin.size.y > 0) {
-                // Fallback: derive from pin.size via aspect ratio
-                float s = std::min(pin.size.x / (float)pin.pixels_w,
-                                   pin.size.y / (float)pin.pixels_h);
-                img = ImVec2((float)pin.pixels_w * s, (float)pin.pixels_h * s);
+                // Fallback: derive from pin.size via aspect ratio.
+                // If no crop rect set, use the full image dimensions.
+                float fw = (float)pin.pixels_w, fh = (float)pin.pixels_h;
+                float crop_w = (pin.crop_rect.z > pin.crop_rect.x)
+                             ? (pin.crop_rect.z - pin.crop_rect.x) : fw;
+                float crop_h = (pin.crop_rect.w > pin.crop_rect.y)
+                             ? (pin.crop_rect.w - pin.crop_rect.y) : fh;
+                crop_w = std::max(1.0f, crop_w);
+                crop_h = std::max(1.0f, crop_h);
+                float s = std::min(pin.size.x / crop_w, pin.size.y / crop_h);
+                img = ImVec2(crop_w * s, crop_h * s);
                 valid = img.x >= 50.0f && img.y >= 30.0f;
             }
             if (!valid) {
@@ -3476,7 +3854,20 @@ void Steam_Overlay::render_pinned_screenshot()
             }
 
             ImGui::SetNextWindowPos(pin.pos, ImGuiCond_Always);
-            ImGui::SetNextWindowSize(new_size, ImGuiCond_Always);
+
+            // Hysteresis: only change window size when the difference is
+            // meaningful (>0.5px).  The snap+rendering feedback loop
+            // (SetNextWindowSize → outer → avail → image_disp → new_size)
+            // can accumulate sub-pixel float error frame by frame,
+            // causing continuous visible shrinking/growing.  Skipping
+            // SetNextWindowSize when the change is negligible locks the
+            // window to its current actual size and breaks the loop.
+            if (first_frame ||
+                pin.last_outer.x == 0.0f || pin.last_outer.y == 0.0f ||
+                fabsf(new_size.x - pin.last_outer.x) > 0.5f ||
+                fabsf(new_size.y - pin.last_outer.y) > 0.5f) {
+                ImGui::SetNextWindowSize(new_size, ImGuiCond_Always);
+            }
         } else {
             ImGui::SetNextWindowPos(pin.pos, first_frame
                 ? ImGuiCond_Always : ImGuiCond_FirstUseEver);
@@ -3486,7 +3877,14 @@ void Steam_Overlay::render_pinned_screenshot()
         ImGui::SetNextWindowSizeConstraints(ImVec2(100, 60), ImVec2(8192, 8192));
         ImGui::SetNextWindowBgAlpha(pin.opacity);
 
-        if (ImGui::Begin(wnd_id, &pin.open, flags)) {
+        // In crop mode, prevent the user from accidentally moving/resizing the
+        // pin window (window movement during drag-to-select is confusing).
+        ImGuiWindowFlags crop_flags = flags;
+        if (pin.crop_mode) {
+            crop_flags |= ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize;
+        }
+
+        if (ImGui::Begin(wnd_id, &pin.open, crop_flags)) {
             // Bring pin to front when requested (new pin, overlay opens)
             if (overlay_opened || pin.focus_requested) {
                 ImGui::SetWindowFocus(wnd_id);
@@ -3496,12 +3894,54 @@ void Steam_Overlay::render_pinned_screenshot()
             ImVec2 avail = ImGui::GetContentRegionAvail();
             float image_avail_y = show_overlay ? avail.y - controls_h : avail.y;
 
+            // Normalize crop_rect: (0,0,0,0) = no crop (show full image).
+            // Non-zero but inverted rects are clamped to image bounds as a safety net.
+            if (pin.crop_rect.z <= pin.crop_rect.x || pin.crop_rect.w <= pin.crop_rect.y) {
+                if (pin.crop_rect.x != 0 || pin.crop_rect.y != 0 ||
+                    pin.crop_rect.z != 0 || pin.crop_rect.w != 0) {
+                    // Non-zero degenerate rect — clamp to bounds
+                    pin.crop_rect.x = std::max(0.0f, std::min((float)pin.pixels_w,  pin.crop_rect.x));
+                    pin.crop_rect.y = std::max(0.0f, std::min((float)pin.pixels_h,  pin.crop_rect.y));
+                    pin.crop_rect.z = std::max(pin.crop_rect.x, std::min((float)pin.pixels_w,  pin.crop_rect.z));
+                    pin.crop_rect.w = std::max(pin.crop_rect.y, std::min((float)pin.pixels_h,  pin.crop_rect.w));
+                }
+                // Zero rect (0,0,0,0) is left as-is — means "no crop"
+            }
+
+            // In crop_mode we render the FULL image so the user can see the source
+            // to crop from; the dim overlay + selection rect is drawn on top.
+            // Otherwise we render only the cropped region via UV mapping.
+            // (0,0,0,0) crop_rect = no crop = show full image.
+            bool has_crop = pin.crop_rect.z > pin.crop_rect.x
+                         && pin.crop_rect.w > pin.crop_rect.y;
+            float src_w = (pin.crop_mode || !has_crop) ? (float)pin.pixels_w
+                                                       : (pin.crop_rect.z - pin.crop_rect.x);
+            float src_h = (pin.crop_mode || !has_crop) ? (float)pin.pixels_h
+                                                       : (pin.crop_rect.w - pin.crop_rect.y);
+            ImVec2 uv0 = (pin.crop_mode || !has_crop) ? ImVec2(0, 0)
+                                                       : ImVec2(pin.crop_rect.x / (float)pin.pixels_w,
+                                                                pin.crop_rect.y / (float)pin.pixels_h);
+            ImVec2 uv1 = (pin.crop_mode || !has_crop) ? ImVec2(1, 1)
+                                                       : ImVec2(pin.crop_rect.z / (float)pin.pixels_w,
+                                                                pin.crop_rect.w / (float)pin.pixels_h);
+
             // Draw image at correct aspect ratio within available space
-            if (pin.pixels_w > 0 && pin.pixels_h > 0 && avail.x > 0 && image_avail_y > 0) {
-                float scale = std::min(avail.x / (float)pin.pixels_w,
-                                       image_avail_y / (float)pin.pixels_h);
-                float disp_w = (float)pin.pixels_w * scale;
-                float disp_h = (float)pin.pixels_h * scale;
+            ImVec2 img_screen_pos = ImVec2(0, 0);
+            ImVec2 img_screen_size = ImVec2(0, 0);
+            if (pin.pixels_w > 0 && pin.pixels_h > 0 && avail.x > 0 && image_avail_y > 0
+                && src_w > 0 && src_h > 0) {
+                float scale = std::min(avail.x / src_w, image_avail_y / src_h);
+                float disp_w = src_w * scale;
+                float disp_h = src_h * scale;
+
+                // Snap the constrained axis to the exact avail dimension to
+                // prevent float-arithmetic drift: src_w * (avail.x / src_w)
+                // may not equal avail.x exactly in IEEE 754, causing a tiny
+                // sub-pixel error every frame that compounds.
+                if (avail.x * src_h <= image_avail_y * src_w)
+                    disp_w = avail.x;   // width-constrained
+                else
+                    disp_h = image_avail_y;  // height-constrained
 
                 float off_x = (avail.x - disp_w) * 0.5f;
                 if (off_x > 0) ImGui::SetCursorPosX(ImGui::GetCursorPosX() + off_x);
@@ -3510,26 +3950,67 @@ void Steam_Overlay::render_pinned_screenshot()
                 ImVec2 p0 = ImGui::GetCursorScreenPos();
                 dl->AddImage(pin.texture->GetResourceId(), p0,
                     ImVec2(p0.x + disp_w, p0.y + disp_h),
-                    ImVec2(0, 0), ImVec2(1, 1),
+                    uv0, uv1,
                     IM_COL32(255, 255, 255, (int)(pin.opacity * 255.0f)));
                 ImGui::Dummy(ImVec2(disp_w, disp_h));
 
                 // Track actual image display size for closed-state shrink-wrapping
                 pin.image_disp = ImVec2(disp_w, disp_h);
+                img_screen_pos = p0;
+                img_screen_size = ImVec2(disp_w, disp_h);
+            }
+
+            if (pin.crop_mode) {
+                if (img_screen_size.x > 0 && img_screen_size.y > 0
+                    && pin.pixels_w > 0 && pin.pixels_h > 0) {
+                    ImTextureID tex = pin.texture ? pin.texture->GetResourceId() : 0;
+                    CropAction act = render_crop_editor(pin.crop_rect, pin.crop_drag,
+                        tex, pin.pixels_w, pin.pixels_h,
+                        img_screen_pos, img_screen_size);
+                    if (act == CropAction::Confirm) {
+                        // Clamp the final rect to source bounds (clamp_rect is
+                        // already called inside render_crop_editor, so this is
+                        // a no-op safety net)
+                        pin.crop_mode = false;
+                        pin.focus_requested = false;
+                        // Reset image_disp so the next frame recalculates the
+                        // window size from the (now smaller) crop_rect instead
+                        // of reusing the last crop-mode full-image size.
+                        pin.image_disp = ImVec2(0, 0);
+                    } else if (act == CropAction::Cancel) {
+                        pin.crop_rect = pin.crop_rect_prev;
+                        pin.crop_mode = false;
+                    }
+                }
+            } else if (show_overlay) {
+                ImGui::Separator();
+                ImGui::SliderFloat("Opacity", &pin.opacity, 0.1f, 1.0f, "%.2f");
+                ImGui::SameLine();
+                if (ImGui::Button("Crop")) {
+                    pin.crop_rect_prev = pin.crop_rect;
+                    pin.crop_mode = true;
+                }
             }
 
             if (show_overlay) {
-                ImGui::Separator();
-                ImGui::SliderFloat("Opacity", &pin.opacity, 0.1f, 1.0f, "%.2f");
-
                 pin.pos = ImGui::GetWindowPos();
-                // Derive image size from outer window size stripping overhead
-                ImVec2 outer = ImGui::GetWindowSize();
-                pin.size = ImVec2(outer.x - pad_x,
-                                  outer.y - controls_h - pad_y - title_bar_h);
+                // Use the actual content region avail (from GetContentRegionAvail)
+                // instead of deriving from outer size minus estimated overhead,
+                // so there is zero mismatch between what the rendering sees
+                // and what the snap uses for sizing and re-centering next frame.
+                pin.size = ImVec2(avail.x, image_avail_y);
                 if (pin.size.x < 50.0f) pin.size.x = 50.0f;
                 if (pin.size.y < 30.0f) pin.size.y = 30.0f;
+            } else {
+                // Track position and size even with overlay closed so the first
+                // overlay-on frame doesn't work with stale values.
+                pin.pos = ImGui::GetWindowPos();
+                pin.size = ImVec2(avail.x, avail.y);
             }
+            // Record the actual window outer size for the next frame's
+            // hysteresis comparison.  Must come after the window has been
+            // fully sized and positioned by ImGui::Begin+SetNextWindowSize.
+            pin.last_outer = ImGui::GetWindowSize();
         }
         ImGui::End();
     }

--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -2791,6 +2791,10 @@ void Steam_Overlay::refresh_screenshots_list()
     }
     screenshot_items.clear();
 
+    if (!local_storage->dir_exists(Local_Storage::screenshots_folder)) {
+        return;
+    }
+
     std::string path = local_storage->get_path(Local_Storage::screenshots_folder);
     auto filenames = Local_Storage::get_filenames_path(path);
 

--- a/post_build/steam_settings.EXAMPLE/configs.overlay.EXAMPLE.ini
+++ b/post_build/steam_settings.EXAMPLE/configs.overlay.EXAMPLE.ini
@@ -62,6 +62,10 @@ overlay_always_show_frametime=0
 # 1=always show playtime in the overlay
 # default=0
 overlay_always_show_playtime=0
+# 1=enable the F12 screenshot feature
+# 0=disable the F12 screenshot hotkey (gallery/pins remain available)
+# default=1
+enable_screenshot=1
 
 [overlay::hotkeys]
 # combination of keys used to show/hide the overlay

--- a/post_build/steam_settings.EXAMPLE/configs.overlay.EXAMPLE.ini
+++ b/post_build/steam_settings.EXAMPLE/configs.overlay.EXAMPLE.ini
@@ -82,6 +82,10 @@ overlay_always_show_playtime=0
 # default=shift + tab
 key_combo=shift + tab
 
+# combination of keys used to take a screenshot (same syntax as key_combo above)
+# default=f12
+screenshot_combo=f12
+
 [overlay::appearance]
 # load custom TrueType font from a path, it could be absolute, or relative
 # relative paths will be looked up inside the local folder "steam_settings/fonts" first,
@@ -136,6 +140,9 @@ Notification_Duration_Achievement=7.0
 Notification_Duration_Invitation=8.0
 # duration of chat message
 Notification_Duration_Chat=4.0
+# duration of screenshot saved notification
+# default=1.0
+Notification_Duration_Screenshot=1.0
 
 # minimum time interval between achievement notifications (in seconds)
 # set to 0 to show all achievements immediately without delay


### PR DESCRIPTION
**1. Screenshot hotkey** — Press F12 to take a screenshot. The game window is captured before the overlay renders, then saved as PNG. The hotkey uses rising-edge detection with a 1-second cooldown to avoid accidental duplicates.

**2. Screenshot gallery** — Browse all screenshots from the overlay main menu. Thumbnails load lazily, sorted by date. Click a thumbnail to open a preview with Prev/Next navigation, Pin, Crop, and Delete buttons. Multi-select works with Shift (range) and Ctrl (toggle). Deleting removes the file and any associated metadata.

**3. Pinned screenshots** — Pin any screenshot to create a floating window. Drag, resize, and adjust opacity while the overlay is open. When the overlay closes, pinned windows become click-through so they don't block your game. Close pins individually with the X button or all at once from the gallery.

**4. Crop tool** — Crop a screenshot before pinning it from the preview, or crop an existing pinned screenshot.

**5. Settings:**
- [overlay::hotkeys] → screenshot_combo — hotkey to take a screenshot (default: f12)
- [overlay::appearance] → Notification_Duration_Screenshot — notification duration in seconds (default: 1.0)