### PR TITLE
Integrating New Texts Added to the Overlay into the Translation File and Translating the New Texts into Turkish

### DIFF
--- a/overlay_experimental/overlay/steam_overlay_translations.h
+++ b/overlay_experimental/overlay/steam_overlay_translations.h
@@ -1075,6 +1075,102 @@ const char translationUserPlaying[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_B
   
 };
 
+const char translationTotalTime[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFER_SIZE] = {
+	// 0 - English
+  u8"Total: %s  Session: %s",
+
+	// 1 - Arabic
+  u8"Total: %s  Session: %s",
+
+	// 2 - Bulgarian
+  u8"Total: %s  Session: %s",
+
+	// 3 - Simplified Chinese
+  u8"Total: %s  Session: %s",
+
+	// 4 - Traditional Chinese
+  u8"Total: %s  Session: %s",
+
+	// 5 - Czech
+  u8"Total: %s  Session: %s",
+
+	// 6 - Danish
+  u8"Total: %s  Session: %s",
+
+	// 7 - Dutch
+  u8"Total: %s  Session: %s",
+
+	// 8 - Finnish
+  u8"Total: %s  Session: %s",
+
+	// 9 - French
+  u8"Total: %s  Session: %s",
+
+	// 10 - German
+  u8"Total: %s  Session: %s",
+
+	// 11 - Greek
+  u8"Total: %s  Session: %s",
+
+	// 12 - Hungarian
+  u8"Total: %s  Session: %s",
+
+	// 13 - Italian
+  u8"Total: %s  Session: %s",
+
+	// 14 - Japanese
+  u8"Total: %s  Session: %s",
+
+	// 15 - Korean
+  u8"Total: %s  Session: %s",
+
+	// 16 - Norwegian
+  u8"Total: %s  Session: %s",
+
+	// 17 - Polish
+  u8"Total: %s  Session: %s",
+
+	// 18 - Portuguese
+  u8"Total: %s  Session: %s",
+
+	// 19 - Brazilian Portuguese
+  u8"Total: %s  Session: %s",
+
+	// 20 - Romanian
+  u8"Total: %s  Session: %s",
+
+	// 21 - Russian
+  u8"Total: %s  Session: %s",
+
+	// 22 - Spanish
+  u8"Total: %s  Session: %s",
+
+	// 23 - Latin American
+  u8"Total: %s  Session: %s",
+
+	// 24 - Swedish
+  u8"Total: %s  Session: %s",
+
+	// 25 - Thai
+  u8"Total: %s  Session: %s",
+
+	// 26 - Turkish
+  u8"Toplam: %s  Oturum: %s",
+
+	// 27 - Ukrainian
+  u8"Total: %s  Session: %s",
+
+	// 28 - Vietnamese
+  u8"Total: %s  Session: %s",
+
+	// 29 - Croatian
+  u8"Total: %s  Session: %s",
+  
+  // 30 - Indonesian
+  u8"Total: %s  Session: %s",
+  
+};
+
 const char translationRenderer[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFER_SIZE] = {
 	// 0 - English
   u8"Renderer: %s",

--- a/overlay_experimental/overlay/steam_overlay_translations.h
+++ b/overlay_experimental/overlay/steam_overlay_translations.h
@@ -1077,6 +1077,102 @@ const char translationUserPlaying[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_B
 
 const char translationTotalTime[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFER_SIZE] = {
 	// 0 - English
+  u8"%uh %um",
+
+	// 1 - Arabic
+  u8"%uh %um",
+
+	// 2 - Bulgarian
+  u8"%uh %um",
+
+	// 3 - Simplified Chinese
+  u8"%uh %um",
+
+	// 4 - Traditional Chinese
+  u8"%uh %um",
+
+	// 5 - Czech
+  u8"%uh %um",
+
+	// 6 - Danish
+  u8"%uh %um",
+
+	// 7 - Dutch
+  u8"%uh %um",
+
+	// 8 - Finnish
+  u8"%uh %um",
+
+	// 9 - French
+  u8"%uh %um",
+
+	// 10 - German
+  u8"%uh %um",
+
+	// 11 - Greek
+  u8"%uh %um",
+
+	// 12 - Hungarian
+  u8"%uh %um",
+
+	// 13 - Italian
+  u8"%uh %um",
+
+	// 14 - Japanese
+  u8"%uh %um",
+
+	// 15 - Korean
+  u8"%uh %um",
+
+	// 16 - Norwegian
+  u8"%uh %um",
+
+	// 17 - Polish
+  u8"%uh %um",
+
+	// 18 - Portuguese
+  u8"%uh %um",
+
+	// 19 - Brazilian Portuguese
+  u8"%uh %um",
+
+	// 20 - Romanian
+  u8"%uh %um",
+
+	// 21 - Russian
+  u8"%uh %um",
+
+	// 22 - Spanish
+  u8"%uh %um",
+
+	// 23 - Latin American
+  u8"%uh %um",
+
+	// 24 - Swedish
+  u8"%uh %um",
+
+	// 25 - Thai
+  u8"%uh %um",
+
+	// 26 - Turkish
+  u8"%us %ud",
+
+	// 27 - Ukrainian
+  u8"%uh %um",
+
+	// 28 - Vietnamese
+  u8"%uh %um",
+
+	// 29 - Croatian
+  u8"%uh %um",
+  
+  // 30 - Indonesian
+  u8"%uh %um",
+  
+};
+
+const char translationTotalTimeText[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFER_SIZE] = {
+	// 0 - English
   u8"Total: %s  Session: %s",
 
 	// 1 - Arabic

--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -323,6 +323,7 @@ void Steam_Overlay::create_fonts()
         font_builder.AddText(translationRefuse[i]);
         font_builder.AddText(translationSend[i]);
         font_builder.AddText(translationUserPlaying[i]);
+        font_builder.AddText(translationTotalTime[i]);
         font_builder.AddText(translationRenderer[i]);
         font_builder.AddText(translationShowAchievements[i]);
         font_builder.AddText(translationSettings[i]);
@@ -1598,7 +1599,7 @@ void Steam_Overlay::render_main_window()
                 snprintf(total_buf, sizeof(total_buf), "%uh %um", total_h, total_m);
                 snprintf(session_buf, sizeof(session_buf), "%02u:%02u:%02u", hh, mm, ss);
 
-                ImGui::LabelText("##playtime", "Total: %s  Session: %s", total_buf, session_buf);
+                ImGui::LabelText("##playtime", translationTotalTime[current_language], total_buf, session_buf);
             }
         }
 

--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -324,6 +324,7 @@ void Steam_Overlay::create_fonts()
         font_builder.AddText(translationSend[i]);
         font_builder.AddText(translationUserPlaying[i]);
         font_builder.AddText(translationTotalTime[i]);
+        font_builder.AddText(translationTotalTimeText[i]);
         font_builder.AddText(translationRenderer[i]);
         font_builder.AddText(translationShowAchievements[i]);
         font_builder.AddText(translationSettings[i]);
@@ -1596,10 +1597,10 @@ void Steam_Overlay::render_main_window()
 
                 char total_buf[32]{};
                 char session_buf[32]{};
-                snprintf(total_buf, sizeof(total_buf), "%uh %um", total_h, total_m);
+                snprintf(total_buf, sizeof(total_buf), translationTotalTime[current_language], total_h, total_m);
                 snprintf(session_buf, sizeof(session_buf), "%02u:%02u:%02u", hh, mm, ss);
 
-                ImGui::LabelText("##playtime", translationTotalTime[current_language], total_buf, session_buf);
+                ImGui::LabelText("##playtime", translationTotalTimeText[current_language], total_buf, session_buf);
             }
         }
 


### PR DESCRIPTION
I linked the new texts to steam_overlay_translations.h and added the missing Turkish translations.