### PR TITLE
Selecting the Overlay Language

### DIFF
--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -221,6 +221,7 @@ private:
     CGameID game_id{};
     std::string name{};
     std::string language{}; // default "english"
+    std::string overlay_language{}; // for overlay language
     CSteamID lobby_id = k_steamIDNil;
 
     bool offline = false;
@@ -438,6 +439,9 @@ public:
 
     const char *get_language();
     void set_language(const char *language);
+
+    const char *get_overlay_language();
+    void set_overlay_language(const char *language);
 
     void set_supported_languages(const std::set<std::string> &langs);
     const std::set<std::string>& get_supported_languages_set() const;

--- a/dll/settings.cpp
+++ b/dll/settings.cpp
@@ -85,6 +85,7 @@ Settings::Settings(CSteamID steam_id, CGameID game_id, const std::string &name, 
     std::transform(lang.begin(), lang.end(), lang.begin(), ::tolower);
     lang.erase(std::remove(lang.begin(), lang.end(), ' '), lang.end());
     this->language = lang;
+    this->overlay_language = lang;
 
     this->offline = offline;
 }
@@ -126,6 +127,16 @@ const char *Settings::get_local_name()
 const char *Settings::get_language()
 {
     return language.c_str();
+}
+
+const char *Settings::get_overlay_language()
+{
+    return overlay_language.c_str();
+}
+
+void Settings::set_overlay_language(const char *language)
+{
+    this->overlay_language = language;
 }
 
 void Settings::set_local_name(const char *name)

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -2080,8 +2080,10 @@ uint32 create_localstorage_settings(Settings **settings_client_out, Settings **s
     uint32 alt_steamid_count = parse_alt_steamid_count(local_storage);
 
     // Language
-    std::string language(parse_current_language(local_storage));
-    // Supported languages, this will change the current language if needed
+    std::string requested_language(parse_current_language(local_storage));
+    std::string language = requested_language; // creating a copy for the game language
+    
+    // Supported languages
     std::set<std::string> supported_languages(parse_supported_languages(local_storage, language));
 
     bool steam_offline_mode = ini.GetBoolValue("main::connectivity", "offline", false);
@@ -2099,6 +2101,9 @@ uint32 create_localstorage_settings(Settings **settings_client_out, Settings **s
     // listen port
     settings_client->set_port(port);
     settings_server->set_port(port);
+    // provide the original 'requested_language' value, which is not affected by the txt file, as the overlay language
+    settings_client->set_overlay_language(requested_language.c_str());
+    settings_server->set_overlay_language(requested_language.c_str());
     // broadcasts list
     settings_client->custom_broadcasts = custom_broadcasts;
     settings_server->custom_broadcasts = custom_broadcasts;

--- a/overlay_experimental/steam_overlay.cpp
+++ b/overlay_experimental/steam_overlay.cpp
@@ -252,7 +252,7 @@ Steam_Overlay::Steam_Overlay(Settings* settings, Local_Storage *local_storage, S
         !settings->disable_overlay_warning_any && !settings->disable_overlay_warning_bad_appid && settings->get_local_game_id().AppID() == 0;
 
     current_language = 0;
-    const char *language = settings->get_language();
+    const char *language = settings->get_overlay_language();
 
     show_user_info = settings->overlay_always_show_user_info;
     show_notification_history = settings->overlay_appearance.show_notification_history;


### PR DESCRIPTION
Hello. I noticed something while using the emulator. If a game doesn't support the `language` parameter in `configs.user.ini` (if the selected language isn't listed in `supported_language.txt`), overlay language automatically defaults to English. I made some changes to fix this.