### PR TITLE
Fix `GetRelayNetworkStatus()` and `GetLaunchCommandLine()` and Revert `run SteamAPI_ManualDispatch_Init() only once`

### DIFF
--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -1313,14 +1313,10 @@ static void cb_add_queue_client(std::vector<char> result, int callback)
 /// you use any of the other manual dispatch functions below.
 STEAMAPI_API void S_CALLTYPE SteamAPI_ManualDispatch_Init()
 {
-    static std::atomic_bool manual_dispatch_called = false;
-    bool not_yet = false;
-    if (manual_dispatch_called.compare_exchange_weak(not_yet, true)) {
-        PRINT_DEBUG_ENTRY();
-        Steam_Client *steam_client = get_steam_client();
-        steam_client->callback_results_server->setCbAll(&cb_add_queue_server);
-        steam_client->callback_results_client->setCbAll(&cb_add_queue_client);
-    }
+    PRINT_DEBUG_ENTRY();
+    Steam_Client *steam_client = get_steam_client();
+    steam_client->callback_results_server->setCbAll(&cb_add_queue_server);
+    steam_client->callback_results_client->setCbAll(&cb_add_queue_client);
 }
 
 /// Perform certain periodic actions that need to be performed.

--- a/dll/steam_apps.cpp
+++ b/dll/steam_apps.cpp
@@ -541,7 +541,10 @@ int Steam_Apps::GetLaunchCommandLine( char *pszCommandLine, int cubCommandLine )
 {
     PRINT_DEBUG_TODO();
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
-    return 0;
+    if (cubCommandLine > 0 && pszCommandLine) {
+        memset(pszCommandLine, 0, cubCommandLine);
+    }
+    return 1;
 }
 
 // Check if user borrowed this game via Family Sharing, If true, call GetAppOwner() to get the lender SteamID

--- a/dll/steam_networking_utils.cpp
+++ b/dll/steam_networking_utils.cpp
@@ -132,17 +132,19 @@ ESteamNetworkingAvailability Steam_Networking_Utils::GetRelayNetworkStatus( Stea
     PRINT_DEBUG("TODO %p", pDetails);
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
 
+    ESteamNetworkingAvailability ret = k_ESteamNetworkingAvailability_Unknown;
     //TODO: check if this is how real steam returns it
     SteamRelayNetworkStatus_t data = {};
     if (relay_initialized) {
         data = get_network_status();
+        ret = k_ESteamNetworkingAvailability_Current;
     }
 
     if (pDetails) {
         *pDetails = data;
     }
 
-    return k_ESteamNetworkingAvailability_Current;
+    return ret;
 }
 
 float Steam_Networking_Utils::GetLocalPingLocation( SteamNetworkPingLocation_t &result )


### PR DESCRIPTION
Some weird games call `ISteamApps::GetLaunchCommandLine()`, and fail if it directly returns 0. According to my simple test, I modified how this function behaves in order to make it more accurate.

BTW, I also tweaked `ISteamNetworkingUtils::GetRelayNetworkStatus()` since I believe previous return value was not accurate if `relay_initialized` is false.

Revert `run SteamAPI_ManualDispatch_Init() only once` introduced in commit 325631e, which causes bugs in appid 
4380490.

Try to fix #574.