### PR TITLE
Fix Steam Input not updating when the game calls Init(false)

### DIFF
--- a/dll/steam_controller.cpp
+++ b/dll/steam_controller.cpp
@@ -1174,7 +1174,7 @@ void Steam_Controller::SetDualSenseTriggerEffect( InputHandle_t inputHandle, con
 
 void Steam_Controller::RunCallbacks()
 {
-    if (explicitly_call_run_frame) {
+    if (!explicitly_call_run_frame) {
         RunFrame();
     }
 }


### PR DESCRIPTION
### Problem

`Steam_Controller::RunCallbacks()` only calls `RunFrame()` when `explicitly_call_run_frame`
is true. That is backwards from the documented ISteamInput contract, quoted from
`sdk/steam/isteaminput.h` in this repo:

> if bExplicitlyCallRunFrame is called then you will need to manually call RunFrame
> each frame, otherwise Steam Input will updated when SteamAPI_RunCallbacks() is called

- `Init(true)`  -> the game calls `RunFrame()` itself, emulator should not
- `Init(false)` -> emulator must refresh input from `SteamAPI_RunCallbacks()`

Because the condition is inverted, every game that passes `false` never reaches
`GamepadUpdate()` after init. Action sets load, handles resolve, `GetConnectedControllers()`
reports the pad — but input state is never refreshed, so all buttons read as unpressed
permanently.

### Fix

Negate the condition. Games passing `true` keep driving `RunFrame()` themselves; games
passing `false` get the documented automatic update. Calling `RunFrame()` unconditionally
would also work, since `GamepadUpdate()` is idempotent, if that is preferred.

### Verification

Repro title: MGS2 Master Collection (appid 2131640), which calls `Init(false)`.

Emulator debug log before the fix, single session:

| call | count |
| --- | --- |
| `Steam_Client::RunCallbacks` | 19406 |
| `Steam_Controller::RunFrame` | 0 |

Meanwhile `GetConnectedControllers()` returned 1, `GetActionSetHandle("CommonSet")` returned 1,
and all 16 digital + 4 analog action handles resolved non-zero the whole time. Only the state
refresh was missing.

Calling `ISteamInput::RunFrame()` externally via the exported flat API
(`SteamAPI_ISteamInput_RunFrame`) on a timer, with no other changes, took
`Steam_Controller::RunFrame` from 0 to 3843 and made the controller fully functional,
including rumble.

Tested on Linux (Wine/Proton) against release build 2026_07_19. I have not built from source
locally — verified behaviorally through the flat API rather than a patched build.

Trying to fix #404.