### PR TITLE
steam_overlay_translations.h: Add French translation

### DIFF
--- a/overlay_experimental/overlay/steam_overlay_translations.h
+++ b/overlay_experimental/overlay/steam_overlay_translations.h
@@ -132,7 +132,7 @@ const char translationCopyId[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFER
   u8"Copy ID",
 
 	// 9 - French
-  u8"Copy ID",
+  u8"Copier l'ID",
 
 	// 10 - German
   u8"Copy ID",
@@ -228,7 +228,7 @@ const char translationTestAchievement[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATI
   u8"Test achievement",
 
 	// 9 - French
-  u8"Test achievement",
+  u8"Tester le succès",
 
 	// 10 - German
   u8"Test achievement",
@@ -422,7 +422,7 @@ const char translationInviteAll[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUF
   u8"Invite all",
 
 	// 9 - French
-  u8"Invite all",
+  u8"Inviter tout le monde",
 
 	// 10 - German
   u8"Invite all",
@@ -1008,7 +1008,7 @@ const char translationUserPlaying[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_B
   u8"Username: %s (%llu) playing %u",
 
 	// 9 - French
-  u8"Username: %s (%llu) playing %u",
+  u8"Nom d'utilisateur : %s (%llu) joue à %u",
 
 	// 10 - German
   u8"Username: %s (%llu) playing %u",
@@ -1200,7 +1200,7 @@ const char translationTotalTimeText[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION
   u8"Total: %s  Session: %s",
 
 	// 9 - French
-  u8"Total: %s  Session: %s",
+  u8"Total : %s  Session : %s",
 
 	// 10 - German
   u8"Total: %s  Session: %s",
@@ -1296,7 +1296,7 @@ const char translationRenderer[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFF
   u8"Renderer: %s",
 
 	// 9 - French
-  u8"Renderer: %s",
+  u8"Moteur de rendu : %s",
 
 	// 10 - German
   u8"Renderer: %s",
@@ -1392,7 +1392,7 @@ const char translationToggleUserInfo[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATIO
   u8"Toggle User Info",
 
 	// 9 - French
-  u8"Toggle User Info",
+  u8"Afficher/masquer les infos utilisateur",
 
 	// 10 - German
   u8"Toggle User Info",
@@ -1488,7 +1488,7 @@ const char translationShowAchievements[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLAT
   u8"Show Achievements",
 
 	// 9 - French
-  u8"Show Achievements",
+  u8"Afficher les succès",
 
 	// 10 - German
   u8"Show Achievements",
@@ -1682,7 +1682,7 @@ const char translationHistory[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFE
   u8"History",
 
 	// 9 - French
-  u8"History",
+  u8"Historique",
 
 	// 10 - German
   u8"History",
@@ -1778,7 +1778,7 @@ const char translationScreenshots[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_B
   u8"Screenshots",
 
 	// 9 - French
-  u8"Screenshots",
+  u8"Captures d'écran",
 
 	// 10 - German
   u8"Screenshots",
@@ -1972,7 +1972,7 @@ const char translationNoNotification[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATIO
   u8"No notifications yet",
 
 	// 9 - French
-  u8"No notifications yet",
+  u8"Aucune notification pour le moment",
 
 	// 10 - German
   u8"No notifications yet",
@@ -2068,7 +2068,7 @@ const char translationClearAll[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFF
   u8"Clear All",
 
 	// 9 - French
-  u8"Clear All",
+  u8"Tout effacer",
 
 	// 10 - German
   u8"Clear All",
@@ -2260,7 +2260,7 @@ const char translationHistoryInvite[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION
   u8"Invite",
 
 	// 9 - French
-  u8"Invite",
+  u8"Inviter",
 
 	// 10 - German
   u8"Invite",
@@ -2356,7 +2356,7 @@ const char translationHistoryAchievement[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSL
   u8"Achievement",
 
 	// 9 - French
-  u8"Achievement",
+  u8"Succès",
 
 	// 10 - German
   u8"Achievement",
@@ -2452,7 +2452,7 @@ const char translationHistoryProgress[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATI
   u8"Progress",
 
 	// 9 - French
-  u8"Progress",
+  u8"Progression",
 
 	// 10 - German
   u8"Progress",
@@ -2548,7 +2548,7 @@ const char translationHistoryAutoInvite[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLA
   u8"Auto-Invite",
 
 	// 9 - French
-  u8"Auto-Invite",
+  u8"Invitation automatique",
 
 	// 10 - German
   u8"Auto-Invite",
@@ -2644,7 +2644,7 @@ const char translationHistoryScreenshot[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLA
   u8"Screenshot",
 
 	// 9 - French
-  u8"Screenshot",
+  u8"Capture d'écran",
 
 	// 10 - German
   u8"Screenshot",
@@ -2740,7 +2740,7 @@ const char translationShow[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFER_S
   u8"Show",
 
 	// 9 - French
-  u8"Show",
+  u8"Afficher",
 
 	// 10 - German
   u8"Show",
@@ -2836,7 +2836,7 @@ const char translationUnlocked[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFF
   u8"Unlocked",
 
 	// 9 - French
-  u8"Unlocked",
+  u8"Déverrouillé",
 
 	// 10 - German
   u8"Unlocked",
@@ -2932,7 +2932,7 @@ const char translationNoUnlockedAchievements[TRANSLATION_NUMBER_OF_LANGUAGES][TR
   u8"No achievements unlocked yet",
 
 	// 9 - French
-  u8"No achievements unlocked yet",
+  u8"Aucun succès n'a encore été débloqué",
 
 	// 10 - German
   u8"No achievements unlocked yet",
@@ -3028,7 +3028,7 @@ const char translationLocked[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFER
   u8"Locked",
 
 	// 9 - French
-  u8"Locked",
+  u8"Verrouillé",
 
 	// 10 - German
   u8"Locked",
@@ -3124,7 +3124,7 @@ const char translationAllAchievementsUnlocked[TRANSLATION_NUMBER_OF_LANGUAGES][T
   u8"All achievements unlocked!",
 
 	// 9 - French
-  u8"All achievements unlocked!",
+  u8"Tous les succès ont été débloqués !",
 
 	// 10 - German
   u8"All achievements unlocked!",
@@ -3220,7 +3220,7 @@ const char translationAchievementWindow[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLA
   u8"Achievement Window",
 
 	// 9 - French
-  u8"Achievement Window",
+  u8"Fenêtre des succès",
 
 	// 10 - German
   u8"Achievement Window",
@@ -3316,7 +3316,7 @@ const char translationListOfAchievements[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSL
   u8"List of achievements",
 
 	// 9 - French
-  u8"List of achievements",
+  u8"Liste des succès",
 
 	// 10 - German
   u8"List of achievements",
@@ -3412,7 +3412,7 @@ const char translationAchievements[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_
   u8"Achievements",
 
 	// 9 - French
-  u8"Achievements",
+  u8"Succès",
 
 	// 10 - German
   u8"Achievements",
@@ -3508,7 +3508,7 @@ const char translationHiddenAchievement[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLA
   u8"hidden achievement",
 
 	// 9 - French
-  u8"hidden achievement",
+  u8"Succès caché",
 
 	// 10 - German
   u8"hidden achievement",
@@ -3604,7 +3604,7 @@ const char translationAchievedOn[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BU
   u8"achieved on %s",
 
 	// 9 - French
-  u8"achieved on %s",
+  u8"obtenu le %s",
 
 	// 10 - German
   u8"achieved on %s",
@@ -3700,7 +3700,7 @@ const char translationNotAchieved[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_B
   u8"not achieved",
 
 	// 9 - French
-  u8"not achieved",
+  u8"non obtenu",
 
 	// 10 - German
   u8"not achieved",
@@ -3796,7 +3796,7 @@ const char translationGlobalSettingsWindow[TRANSLATION_NUMBER_OF_LANGUAGES][TRAN
   u8"Global Settings Window",
 
 	// 9 - French
-  u8"Global Settings Window",
+  u8"Fenêtre des paramètres globaux",
 
 	// 10 - German
   u8"Global Settings Window",
@@ -3892,7 +3892,7 @@ const char translationGlobalSettingsWindowDescription[TRANSLATION_NUMBER_OF_LANG
   u8"These are global emulator settings and will apply to all games.",
 
 	// 9 - French
-  u8"These are global emulator settings and will apply to all games.",
+  u8"Ce sont des paramètres globaux de l'émulateur qui s'appliqueront à tous les jeux.",
 
 	// 10 - German
   u8"These are global emulator settings and will apply to all games.",
@@ -3988,7 +3988,7 @@ const char translationUsername[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFF
   u8"Username:",
 
 	// 9 - French
-  u8"Username:",
+  u8"Nom d'utilisateur :",
 
 	// 10 - German
   u8"Username:",
@@ -4084,7 +4084,7 @@ const char translationLanguage[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFF
   u8"Language:",
 
 	// 9 - French
-  u8"Language:",
+  u8"Langue :",
 
 	// 10 - German
   u8"Language:",
@@ -4180,7 +4180,7 @@ const char translationSelectedLanguage[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLAT
   u8"Selected Language: %s",
 
 	// 9 - French
-  u8"Selected Language: %s",
+  u8"Langue sélectionnée : %s",
 
 	// 10 - German
   u8"Selected Language: %s",
@@ -4276,7 +4276,7 @@ const char translationRestartTheGameToApply[TRANSLATION_NUMBER_OF_LANGUAGES][TRA
   u8"You may have to restart the game for these to apply.",
 
 	// 9 - French
-  u8"You may have to restart the game for these to apply.",
+  u8"Vous devrez peut-être redémarrer le jeu pour que les modifications prennent effet.",
 
 	// 10 - German
   u8"You may have to restart the game for these to apply.",
@@ -4372,7 +4372,7 @@ const char translationSave[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFER_S
   u8"Save",
 
 	// 9 - French
-  u8"Save",
+  u8"Enregistrer",
 
 	// 10 - German
   u8"Save",
@@ -4468,7 +4468,7 @@ const char translationWarning[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFE
   u8"WARNING",
 
 	// 9 - French
-  u8"WARNING",
+  u8"AVERTISSEMENT",
 
 	// 10 - German
   u8"WARNING",
@@ -4564,7 +4564,7 @@ const char translationWarningDescription_badAppid[TRANSLATION_NUMBER_OF_LANGUAGE
   u8"AppID is 0, please create a steam_appid.txt with the right appid and restart the game.",
 
 	// 9 - French
-  u8"AppID is 0, please create a steam_appid.txt with the right appid and restart the game.",
+  u8"AppID est 0, veuillez créer steam_appid.txt contenant le bon AppID et redémarrer le jeu.",
 
 	// 10 - German
   u8"AppID is 0, please create a steam_appid.txt with the right appid and restart the game.",
@@ -4660,7 +4660,7 @@ const char translationWarningDescription_localSave[TRANSLATION_NUMBER_OF_LANGUAG
   u8"local_save_path detected, the emu is saving locally to the game folder. Please delete it if you don't want this.",
 
 	// 9 - French
-  u8"local_save_path detected, the emu is saving locally to the game folder. Please delete it if you don't want this.",
+  u8"local_save_path détecté, l’émulateur enregistre localement dans le dossier du jeu. Veuillez le supprimer si vous ne le souhaitez pas.",
 
 	// 10 - German
   u8"local_save_path detected, the emu is saving locally to the game folder. Please delete it if you don't want this.",
@@ -4756,7 +4756,7 @@ const char translationSteamOverlayURL[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATI
   u8"The game tried to get the steam overlay to open this url:",
 
 	// 9 - French
-  u8"The game tried to get the steam overlay to open this url:",
+  u8"Le jeu a voulu ouvrir cette URL par l’overlay Steam :",
 
 	// 10 - German
   u8"The game tried to get the steam overlay to open this url:",
@@ -4950,7 +4950,7 @@ const char translationPlaying[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFE
   u8"playing",
 
 	// 9 - French
-  u8"playing",
+  u8"joue à",
 
 	// 10 - German
   u8"playing",
@@ -5046,7 +5046,7 @@ const char translationScreenshotSaved[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATI
   u8"Screenshot saved: ",
 
 	// 9 - French
-  u8"Screenshot saved: ",
+  u8"Capture d'écran enregistrée : ",
 
 	// 10 - German
   u8"Screenshot saved: ",
@@ -5142,7 +5142,7 @@ const char translationUnpinAll[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFF
   u8"Unpin all",
 
 	// 9 - French
-  u8"Unpin all",
+  u8"Désépingler tout",
 
 	// 10 - German
   u8"Unpin all",
@@ -5238,7 +5238,7 @@ const char translationDeleteSelected[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATIO
   u8"Delete selected",
 
 	// 9 - French
-  u8"Delete selected",
+  u8"Supprimer la sélection",
 
 	// 10 - German
   u8"Delete selected",
@@ -5334,7 +5334,7 @@ const char translationOpenFolder[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BU
   u8"Open Folder",
 
 	// 9 - French
-  u8"Open Folder",
+  u8"Ouvrir le dossier",
 
 	// 10 - German
   u8"Open Folder",
@@ -5430,7 +5430,7 @@ const char translationNoScreenshotsYet[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLAT
   u8"No screenshots yet",
 
 	// 9 - French
-  u8"No screenshots yet",
+  u8"Aucune capture d’écran pour le moment",
 
 	// 10 - German
   u8"No screenshots yet",
@@ -5526,7 +5526,7 @@ const char translationDelete[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFER
   u8"Delete",
 
 	// 9 - French
-  u8"Delete",
+  u8"Supprimer",
 
 	// 10 - German
   u8"Delete",
@@ -5622,7 +5622,7 @@ const char translationScreenshotPreview[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLA
   u8"Screenshot Preview",
 
 	// 9 - French
-  u8"Screenshot Preview",
+  u8"Aperçu de la capture d'écran",
 
 	// 10 - German
   u8"Screenshot Preview",
@@ -5718,7 +5718,7 @@ const char translationPrev[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFER_S
   u8"< Prev",
 
 	// 9 - French
-  u8"< Prev",
+  u8"< Préc.",
 
 	// 10 - German
   u8"< Prev",
@@ -5814,7 +5814,7 @@ const char translationPin[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFER_SI
   u8"Pin",
 
 	// 9 - French
-  u8"Pin",
+  u8"Épingler",
 
 	// 10 - German
   u8"Pin",
@@ -5910,7 +5910,7 @@ const char translationCrop[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFER_S
   u8"Crop",
 
 	// 9 - French
-  u8"Crop",
+  u8"Recadrer",
 
 	// 10 - German
   u8"Crop",
@@ -6006,7 +6006,7 @@ const char translationNext[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFER_S
   u8"Next >",
 
 	// 9 - French
-  u8"Next >",
+  u8"Suiv. >",
 
 	// 10 - German
   u8"Next >",
@@ -6102,7 +6102,7 @@ const char translationDeleteThisScreenshot[TRANSLATION_NUMBER_OF_LANGUAGES][TRAN
   u8"Delete this screenshot?",
 
 	// 9 - French
-  u8"Delete this screenshot?",
+  u8"Supprimer cette capture d'écran ?",
 
 	// 10 - German
   u8"Delete this screenshot?",
@@ -6198,7 +6198,7 @@ const char translationDeleteAllScelectedScreenshots[TRANSLATION_NUMBER_OF_LANGUA
   u8"Delete all selected screenshots?",
 
 	// 9 - French
-  u8"Delete all selected screenshots?",
+  u8"Supprimer toutes les captures d'écran sélectionnées ?",
 
 	// 10 - German
   u8"Delete all selected screenshots?",
@@ -6294,7 +6294,7 @@ const char translationYes[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFER_SI
   u8"Yes",
 
 	// 9 - French
-  u8"Yes",
+  u8"Oui",
 
 	// 10 - German
   u8"Yes",
@@ -6390,7 +6390,7 @@ const char translationNo[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFER_SIZ
   u8"No",
 
 	// 9 - French
-  u8"No",
+  u8"Non",
 
 	// 10 - German
   u8"No",
@@ -6486,7 +6486,7 @@ const char translationConfirmDelete[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION
   u8"Confirm Delete",
 
 	// 9 - French
-  u8"Confirm Delete",
+  u8"Confirmer la suppression",
 
 	// 10 - German
   u8"Confirm Delete",
@@ -6582,7 +6582,7 @@ const char translationConfirm[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFE
   u8"Confirm",
 
 	// 9 - French
-  u8"Confirm",
+  u8"Confirmer",
 
 	// 10 - German
   u8"Confirm",
@@ -6678,7 +6678,7 @@ const char translationCancel[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFER
   u8"Cancel",
 
 	// 9 - French
-  u8"Cancel",
+  u8"Annuler",
 
 	// 10 - German
   u8"Cancel",
@@ -6774,7 +6774,7 @@ const char translationPinnedScreenshots[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLA
   u8"Pinned Screenshot###pinned_ss_%llu",
 
 	// 9 - French
-  u8"Pinned Screenshot###pinned_ss_%llu",
+  u8"Capture d'écran épinglée###pinned_ss_%llu",
 
 	// 10 - German
   u8"Pinned Screenshot###pinned_ss_%llu",
@@ -6870,7 +6870,7 @@ const char translationOpacity[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATION_BUFFE
   u8"Opacity",
 
 	// 9 - French
-  u8"Opacity",
+  u8"Opacité",
 
 	// 10 - German
   u8"Opacity",
@@ -6966,7 +6966,7 @@ const char translationAutoAcceptFriendInvite[TRANSLATION_NUMBER_OF_LANGUAGES][TR
   u8"Invitations are controlled by auto_accept_invite.txt!",
 
 	// 9 - French
-  u8"Invitations are controlled by auto_accept_invite.txt!",
+  u8"Les invitations sont gérées par auto_accept_invite.txt !",
 
 	// 10 - German
   u8"Invitations are controlled by auto_accept_invite.txt!",
@@ -7542,7 +7542,7 @@ const char translationPlaytimeCheckbox[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLAT
   u8"Playtime",
 
 	// 9 - French
-  u8"Playtime",
+  u8"Temps de jeu",
 
 	// 10 - German
   u8"Playtime",
@@ -7638,7 +7638,7 @@ const char translationPlaytimeDisplay[TRANSLATION_NUMBER_OF_LANGUAGES][TRANSLATI
   u8"PLT: ",
 
 	// 9 - French
-  u8"PLT: ",
+  u8"TdJ: ",
 
 	// 10 - German
   u8"PLT: ",


### PR DESCRIPTION
Don't mistake the space in `word :` for mistakenly inserted, that's how French added colon after the word.

Also I translated it carefully and faithfully.